### PR TITLE
feat: Add `named-grid-areas-alignment` rule

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -114,6 +114,9 @@ Here are `stylelint-stylistic` rules, grouped by the _thing_ they apply to (just
 - [`at-rule-semicolon-newline-after`](../../lib/rules/at-rule-semicolon-newline-after/README.md): Require a newline after the semicolon of at-rules (Autofixable).
 - [`at-rule-semicolon-space-before`](../../lib/rules/at-rule-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of at-rules.
 
+## Named grid areas
+- [`named-grid-areas-alignment`](../../lib/rules/named-grid-areas-alignment/README.md): Require cell tokens (and optionally ending quotes) within `grid-template-areas` to be aligned (Autofixable).
+
 ## General / Sheet
 
 - [`indentation`](../../lib/rules/indentation/README.md): Specify indentation (Autofixable).

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -141,6 +141,9 @@ const rules = {
 	get 'media-query-list-comma-space-before' () {
 		return import(`./media-query-list-comma-space-before/index.js`).then((m) => m.default)
 	},
+	get 'named-grid-areas-alignment' () {
+		return import(`./named-grid-areas-alignment/index.js`).then((m) => m.default)
+	},
 	get 'no-empty-first-line' () {
 		return import(`./no-empty-first-line/index.js`).then((m) => m.default)
 	},

--- a/lib/rules/named-grid-areas-alignment/README.md
+++ b/lib/rules/named-grid-areas-alignment/README.md
@@ -1,0 +1,123 @@
+# named-grid-areas-alignment
+
+Require cell tokens (and optionally ending quotes) within `grid-template-areas` to be aligned.
+
+```css
+div {
+  grid-template-areas: 'column a-long-one bar'
+                       'cell   .          bar'
+/**                                ↑
+ *                      This "table" alignment 
+ */
+}
+```
+
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+
+## Options
+
+### `true`
+
+The following patterns are considered problems:
+
+```css
+/* ❌ Not aligned cell tokens */
+
+div {
+  grid-template-areas: 
+    'a a a'
+    'bb bb bb';
+}
+```
+
+```css
+/* ❌ Inconsistent spacing between cell tokens */
+
+div {
+  grid-template-areas: 'a a    a  a';
+}
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+/* ✅ Aligned cell tokens */
+
+div {
+  grid-template-areas: 
+    'a  a  a'
+    'bb bb bb'
+}
+```
+
+```css
+/* ✅ Consistent spacing between cell tokens */
+
+div {
+  grid-template-areas: 'a a a a'
+}
+```
+
+## Optional secondary options
+
+### `gap: number`
+
+Specifies the number of spaces between cell tokens (default is `1`).
+
+**Given rule configuration: `named-grid-areas-alignment: [true, { gap: 2 }]`**
+
+The following patterns are considered problems:
+
+```css
+/* ❌ Single space between cell tokens */
+
+div {
+  grid-template-areas: 
+    'a  a  a'
+    'bb bb bb'
+}
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+/* ✅ Two spaces between cell tokens */
+
+div {
+  grid-template-areas: 
+    'a   a   a'
+    'bb  bb  bb'
+}
+```
+
+### `alignQuotes: boolean`
+
+Whether to align an ending quotes (default is `false`).
+
+**Given rule configuration: `named-grid-areas-alignment: [true, { alignQuotes: true }]`**
+
+The following patterns are considered problems:
+
+```css
+/* ❌ Ending quotes are not aligned */
+
+div {
+  grid-template-areas: 
+    'a        a'
+    'foo      foo'
+    'long-one long-one'
+}
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+/* ✅ Ending quotes are properly aligned */
+
+div {
+  grid-template-areas: 
+    'a        a       '
+    'foo      foo     '
+    'long-one long-one'
+}
+```

--- a/lib/rules/named-grid-areas-alignment/index.js
+++ b/lib/rules/named-grid-areas-alignment/index.js
@@ -1,0 +1,142 @@
+import stylelint from "stylelint"
+import valueParser from "postcss-value-parser"
+
+import declarationValueIndex from "../../utils/declarationValueIndex.js"
+import getDeclarationValue from "../../utils/getDeclarationValue.js"
+import setDeclarationValue from "../../utils/setDeclarationValue.js"
+import { addNamespace } from "../../utils/addNamespace.js"
+import { getRuleDocUrl } from "../../utils/getRuleDocUrl.js"
+import { isBoolean, isNumber } from "../../utils/validateTypes.js"
+
+const { utils: { report, ruleMessages, validateOptions } } = stylelint
+
+const shortName = `named-grid-areas-alignment`
+
+export const ruleName = addNamespace(shortName)
+
+export const messages = ruleMessages(ruleName, {
+	expected: () => `Expected \`grid-template-areas\` value to be aligned`,
+})
+
+export const meta = {
+	url: getRuleDocUrl(shortName),
+	fixable: true,
+}
+
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions = {}, context) => (root, result) => {
+	const validOptions = validateOptions(
+		result,
+		ruleName,
+		{ actual: primary },
+		{
+			actual: secondaryOptions,
+			possible: {
+				gap: [isNumber, (value) => value > 1],
+				alignQuotes: [isBoolean],
+			},
+			optional: true,
+		},
+	)
+
+	if (!validOptions) { return }
+
+	const gap = secondaryOptions.gap ?? 1
+	const alignQuotes = secondaryOptions.alignQuotes ?? false
+
+	const referenceGap = ` `.repeat(gap)
+
+	root.walkDecls(`grid-template-areas`, (declaration) => {
+		const parsedValue = valueParser(getDeclarationValue(declaration))
+		const gridRows = parsedValue.nodes.filter((node) => node.type === `string`)
+
+		// To compare with the formatted value to determine if there is an error
+		const originalRows = gridRows.map(({ value }) => value).filter(Boolean)
+		// The ones to operate with
+		const rows = gridRows
+			.map(({ value }) => value.trim().replaceAll(/\s+/g, ` `))
+			.filter(Boolean)
+
+		let maxCellsCount = 0
+		const table = rows.reduce((acc, row) => {
+			const cells = row.split(` `)
+			maxCellsCount = Math.max(maxCellsCount, cells.length)
+			acc.push(row.split(` `))
+			return acc
+		}, [])
+
+		const maxLengths = new Array(maxCellsCount).fill(``).reduce((acc, part, index) => {
+			const parts = table.map((row) => row[index]?.length ?? 0)
+			acc.push(Math.max(part.length, ...parts))
+			return acc
+		}, [])
+
+		let maxRowLength = 0
+		let formatted = table.map((row) => {
+			const formattedRow = row
+				.map((cell, index) => cell.padEnd(maxLengths[index], ` `))
+				.join(referenceGap)
+			maxRowLength = Math.max(maxRowLength, formattedRow.length)
+			return alignQuotes ? formattedRow : formattedRow.trimEnd()
+		})
+
+		if (alignQuotes) {
+			formatted = formatted.map((row) => {
+				if (row.length === maxRowLength) { return row }
+				const cleanRowValue = row.trimEnd()
+				return `${cleanRowValue}${` `.repeat(maxRowLength - cleanRowValue.length)}`
+			})
+		}
+
+		const isValid = originalRows.every((row, index) => row === formatted[index])
+		if (isValid) { return }
+
+		if (context.fix) {
+			const formattedValue = parsedValue.nodes.reduce((acc, node) => {
+				if (node.type === `string`) {
+					acc.push(`${node.quote}${formatted.shift()}${node.quote}`)
+					return acc
+				}
+				if (node.type === `comment`) {
+					acc.push(`/*${node.value}*/`)
+					return acc
+				}
+
+				acc.push(`${node.before ?? ``}${node.value}${node.after ?? ``}`)
+				return acc
+			}, []).join(``)
+
+			setDeclarationValue(declaration, formattedValue)
+			return
+		}
+
+		const extraStartLines = declaration.raws.between.match(/[\r\n?|\n]*/g)
+			?.reduce((acc, newLineBlock) => acc + newLineBlock.length, 0)
+
+		/* eslint-disable operator-linebreak */
+		const extraStartColumns = extraStartLines === 0
+			? declarationValueIndex(declaration) + declaration.source.start.column
+			: declaration.raws.between.match(/[^\r\n?|\n]+$/)?.[0].length + 1 ?? 0
+		/* eslint-enable operator-linebreak */
+
+		report({
+			message: messages.expected(),
+			node: declaration,
+			start: {
+				line: extraStartLines + declaration.source.start.line,
+				column: extraStartColumns,
+			},
+			end: {
+				line: declaration.source.end.line,
+				column: declaration.source.end.column,
+			},
+			result,
+			ruleName,
+		})
+	})
+}
+
+rule.ruleName = ruleName
+rule.messages = messages
+rule.meta = meta
+export default rule

--- a/lib/rules/named-grid-areas-alignment/index.test.js
+++ b/lib/rules/named-grid-areas-alignment/index.test.js
@@ -1,0 +1,649 @@
+import { testRule } from "stylelint-test-rule-node"
+import plugins from "../../index.js"
+import { ruleName, messages } from "./index.js"
+import { stripIndent } from "common-tags"
+
+/**
+ * Default options
+ */
+testRule({
+	plugins,
+	ruleName,
+	config: [true],
+	fix: true,
+
+	accept: [
+		{
+			description: `No value yet`,
+			code: `a { grid-template-areas: }`,
+		},
+		{
+			description: `Weirdly formatted property name`,
+			code: `a { GrId-TeMpLaTe-ArEaS: }`,
+		},
+		{
+			description: `With literal value`,
+			code: `a { grid-template-areas: none; }`,
+		},
+		{
+			description: `With literal value and comment`,
+			code: `a { grid-template-areas: /* "comment" */none; }`,
+		},
+		{
+			description: `Empty value`,
+			code: `a { grid-template-areas: ''; }`,
+		},
+		{
+			description: `Minimal example`,
+			code: `a { grid-template-areas: 'a a a'; }`,
+		},
+		{
+			description: `Basic example`,
+			code: `a { grid-template-areas: 'a a a' 'b b b'; }`,
+		},
+		{
+			description: `Basic example with different cell lengths`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a aa aaa aaaa'
+						'b b  b   b';
+				}
+			`),
+		},
+		{
+			description: `Invalid but properly aligned value (1)`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a aa aaa b'
+						'b b  b   b';
+				}
+			`),
+		},
+		{
+			description: `Invalid but properly aligned value (2)`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'aaa aaa'
+					                     'b   b   b b'
+															 'c';
+				}
+			`),
+		},
+		{
+			description: `With weird linebreaks and tabs`,
+			code: stripIndent(`
+				a
+
+				{ grid-template-areas:
+							'a aa aaa aaaa'
+							'b b  b   b'
+
+							'c cc ccc c'
+				}
+			`),
+		},
+		{
+			description: `With linebreaks and comments`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+
+						'a aa aaa aaaa'
+						/* example comment with "double", 'single' brackets or \`backticks\` */
+						'b b  b   b'
+						'c cc ccc c' }
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `Not aligned columns`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'   a a a'
+						'bb bb bb'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a  a  a'
+						'bb bb bb'
+				}
+			`),
+			message: messages.expected(),
+			line: 3, column: 3,
+			endLine: 4, endColumn: 12,
+		},
+		{
+			description: `Not aligned columns using different cell lengths, whitespaces, quotes and comments`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a a'
+						/* comment */
+						'bb bbbb bb'
+								/*"another" comment*/
+						"cccc ccc cc"
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a    a    a'
+						/* comment */
+						'bb   bbbb bb'
+								/*"another" comment*/
+						"cccc ccc  cc"
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 7, endColumn: 15,
+			message: messages.expected(),
+		},
+		{
+			description: `Not aligned columns with missed cells`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a'
+						'bb bbbb bb'
+						'cccc ccc'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a'
+						'bb   bbbb bb'
+						'cccc ccc'
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 5, endColumn: 12,
+			message: messages.expected(),
+		},
+		{
+			description: `With SASS-style comment`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a  a            a' // inline SASS-style comment
+						// some comment
+						'b     b b'
+						  /* and a CSS one with extra spaces */
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a a' // inline SASS-style comment
+						// some comment
+						'b b b'
+						  /* and a CSS one with extra spaces */
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 5, endColumn: 13,
+			message: messages.expected(),
+		},
+	],
+})
+
+/**
+ * Report ranges using various (sometimes even weird) formatting
+ */
+testRule({
+	plugins,
+	ruleName,
+	config: [true],
+
+	reject: [
+		{
+			description: `Single-line formatting`,
+			code: `a { grid-template-areas: 'a  a  a' }`,
+			message: messages.expected(),
+			line: 1, column: 26,
+			endLine: 1, endColumn: 34,
+		},
+		{
+			description: `Single-line formatting with extra linebreaks and mixed tab and space characters`,
+			code: stripIndent(`
+				a {
+
+
+					grid-template-areas:
+
+									   'a  a  a'
+				}
+			`),
+			message: messages.expected(),
+			line: 6, column: 9,
+			endLine: 6, endColumn: 17,
+		},
+		{
+			description: `Multi-line formatting starting on the same line`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a  a  a'
+					                     'bb  bb  bb'
+					                     'ccc  ccc  ccc'
+				}
+			`),
+			message: messages.expected(),
+			line: 2, column: 23,
+			endLine: 4, endColumn: 37,
+		},
+		{
+			description: `Multi-line formatting starting on the same line with no alignment`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a  a  a'
+					   'bb  bb  bb'
+					        'ccc  ccc  ccc'
+				}
+			`),
+			message: messages.expected(),
+			line: 2, column: 23,
+			endLine: 4, endColumn: 24,
+		},
+		{
+			description: `Multi-line formatting starting on different lines`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a  a  a'
+						'bb  bb  bb'
+						'ccc  ccc  ccc'
+				}
+			`),
+			message: messages.expected(),
+			line: 3, column: 3,
+			endLine: 5, endColumn: 17,
+		},
+		{
+			description: `Multi-line formatting starting on different lines using extra linebreaks, comments and mixed tabs/spaces`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+
+						  'a  a  a' /* comment */
+						'bb  bb  bb'
+						/* comment */
+						'ccc  ccc  ccc     '
+				}
+			`),
+			message: messages.expected(),
+			line: 4, column: 5,
+			endLine: 7, endColumn: 22,
+		},
+		{
+			description: `Declaration within at-rule`,
+			code: stripIndent(`
+				@media (width >= 320px) {
+					a {
+						grid-template-areas:
+							'a  a  a'
+							'bb  bb  bb'
+							'ccc  ccc  ccc'
+					}
+				}
+			`),
+			message: messages.expected(),
+			line: 4, column: 4,
+			endLine: 6, endColumn: 18,
+		},
+		{
+			description: `Nested declaration within at-rule with extra indentation`,
+			code: stripIndent(`
+				@media (width >= 320px) {
+					a {
+								a {
+									grid-template-areas:
+										'a  a  a'
+										'bb  bb  bb'
+										'ccc  ccc  ccc'
+								}
+					}
+				}
+			`),
+			message: messages.expected(),
+			line: 5, column: 7,
+			endLine: 7, endColumn: 21,
+		},
+	],
+})
+
+/**
+ * Custom `gap`
+ */
+testRule({
+	plugins,
+	ruleName,
+	config: [true, { gap: 2 }],
+	fix: true,
+
+	accept: [
+		{
+			description: `Minimal example using custom 'gap'`,
+			code: `a { grid-template-areas: 'a  a  a'; }`,
+		},
+		{
+			description: `Basic example using custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+					'a  a  a'
+					'b  b  b';
+				}
+			`),
+		},
+		{
+			description: `Basic example using custom 'gap' with different cell lengths`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a  aa  aaa  aaaa'
+						'b  b   b    b';
+				}
+			`),
+		},
+		{
+			description: `With linebreaks, tabs and three rows using custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+					'a  aa  aaa  aaaa'
+						'b  b   b    b'
+					'c  cc  ccc  c'
+				}
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `Wrong number of spaces`,
+			code: `a { grid-template-areas: 'a a a' }`,
+			fixed: `a { grid-template-areas: 'a  a  a' }`,
+			message: messages.expected(),
+			line: 1, column: 26,
+			endLine: 1, endColumn: 32,
+		},
+		{
+			description: `Not aligned columns using custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a a'
+						'bb bb bb'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a   a   a'
+						'bb  bb  bb'
+				}
+			`),
+			message: messages.expected(),
+			line: 3, column: 3,
+			endLine: 4, endColumn: 12,
+		},
+		{
+			description: `Not aligned columns using different cell lengths, whitespaces, quotes and comments with custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a a'
+						'bb bbbb bb'
+							/* comment */
+						"cccc ccc cc"  }
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a     a     a'
+						'bb    bbbb  bb'
+							/* comment */
+						"cccc  ccc   cc"  }
+			`),
+			message: messages.expected(),
+			line: 3, column: 3,
+			endLine: 6, endColumn: 15,
+		},
+		{
+			description: `Not aligned columns with missed cells`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+					'a'
+					'bb bbbb bb'
+					'cccc ccc'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+					'a'
+					'bb    bbbb  bb'
+					'cccc  ccc'
+				}
+			`),
+			message: messages.expected(),
+			line: 3, column: 2,
+			endLine: 5, endColumn: 11,
+		},
+	],
+})
+
+/**
+ * `alignQuotes` set to `true`
+ */
+testRule({
+	plugins,
+	ruleName,
+	config: [true, { alignQuotes: true }],
+	fix: true,
+
+	accept: [
+		{
+			description: `Basic example using 'alignQuotes' with different cell lengths`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a aa aaa aaaa'
+						'b b  b   b   ';
+				}
+			`),
+		},
+		{
+			description: `With linebreaks/tabs, three rows and 'alignQuotes'`,
+			code: stripIndent(`
+				a {
+				grid-template-areas:
+
+						'a aa aaa aaaa'
+						 'b b  b   b   '
+						'c cc ccc c   '
+				}
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `Not aligned ending quotes using 'alignQuotes: true'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a   a   a'
+						'bbb bbb bbb'
+					}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a   a   a  '
+						'bbb bbb bbb'
+					}
+			`),
+			line: 3, column: 3,
+			endLine: 4, endColumn: 15,
+			message: messages.expected(),
+		},
+		{
+			description: `Not aligned columns using different cell lengths, whitespaces, quotes and comments with 'alignQuotes'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a    a    a'
+						'bb   bbbb bbbb'
+						/* comment */
+						"cccc ccc  cc"/* ending comment */
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a    a    a   '
+						'bb   bbbb bbbb'
+						/* comment */
+						"cccc ccc  cc  "/* ending comment */
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 6, endColumn: 16,
+			message: messages.expected(),
+		},
+		{
+			description: `Not aligned columns with missed cells using 'alignQuotes'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a'
+						'bb   bbbb bb'
+						'cccc ccc'
+					}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a           '
+						'bb   bbbb bb'
+						'cccc ccc    '
+					}
+			`),
+			line: 3, column: 3,
+			endLine: 5, endColumn: 12,
+			message: messages.expected(),
+		},
+	],
+})
+
+/**
+ * `alignQuotes` set to `true` and custom `gap`
+ */
+testRule({
+	plugins,
+	ruleName,
+	config: [true, { gap: 3, alignQuotes: true }],
+	fix: true,
+
+	accept: [
+		{
+			description: `Basic example using custom settings with different cell lengths`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a   aa   aaa   aaaa'
+						'b   b    b     b   ';
+					}
+			`),
+		},
+		{
+			description: `With linebreaks/tabs, three rows using custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a   aa   aaa   aaaa'
+						'b   b    b     b   '
+
+						'c   cc   ccc   c   '}
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `Not aligned columns using 'alignQuotes' and custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a aaaa'
+						'bb bb bb'
+					}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a    a    aaaa'
+						'bb   bb   bb  '
+					}
+			`),
+			line: 3, column: 3,
+			endLine: 4, endColumn: 12,
+			message: messages.expected(),
+		},
+		{
+			description: `Not aligned columns using different cell lengths, whitespaces, quotes and comments with 'alignQuotes' and custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a a a'
+						'bb bbbb bb'
+						/* comment */
+						"cccc ccc cc";
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a      a      a '
+						'bb     bbbb   bb'
+						/* comment */
+						"cccc   ccc    cc";
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 6, endColumn: 16,
+			message: messages.expected(),
+		},
+		{
+			description: `Not aligned columns with missed cells using 'alignQuotes' and custom 'gap'`,
+			code: stripIndent(`
+				a {
+					grid-template-areas:
+						'a'
+						'bb bbbb bb'
+						'cccc ccc';
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas:
+						'a               '
+						'bb     bbbb   bb'
+						'cccc   ccc      ';
+				}
+			`),
+			line: 3, column: 3,
+			endLine: 5, endColumn: 13,
+			message: messages.expected(),
+		},
+	],
+})


### PR DESCRIPTION
Good day, @firefoxic 

There is a new rule `named-grid-template-areas` implementation, that resolves #15 
