### PR TITLE
fix(named-grid-areas-alignment): Handle single-line input separately

### DIFF
--- a/lib/rules/named-grid-areas-alignment/index.js
+++ b/lib/rules/named-grid-areas-alignment/index.js
@@ -47,7 +47,10 @@ const rule = (primary, secondaryOptions = {}, context) => (root, result) => {
 	const referenceGap = ` `.repeat(gap)
 
 	root.walkDecls(`grid-template-areas`, (declaration) => {
-		const parsedValue = valueParser(getDeclarationValue(declaration))
+		const declarationValue = getDeclarationValue(declaration)
+		const parsedValue = valueParser(declarationValue)
+		const isMultilineDeclaration = declarationValue.includes(`\n`)
+
 		const gridRows = parsedValue.nodes.filter((node) => node.type === `string`)
 
 		// To compare with the formatted value to determine if there is an error
@@ -74,13 +77,13 @@ const rule = (primary, secondaryOptions = {}, context) => (root, result) => {
 		let maxRowLength = 0
 		let formatted = table.map((row) => {
 			const formattedRow = row
-				.map((cell, index) => cell.padEnd(maxLengths[index], ` `))
+				.map((cell, index) => isMultilineDeclaration ? cell.padEnd(maxLengths[index], ` `) : cell)
 				.join(referenceGap)
 			maxRowLength = Math.max(maxRowLength, formattedRow.length)
 			return alignQuotes ? formattedRow : formattedRow.trimEnd()
 		})
 
-		if (alignQuotes) {
+		if (alignQuotes && isMultilineDeclaration) {
 			formatted = formatted.map((row) => {
 				if (row.length === maxRowLength) { return row }
 				const cleanRowValue = row.trimEnd()

--- a/lib/rules/named-grid-areas-alignment/index.test.js
+++ b/lib/rules/named-grid-areas-alignment/index.test.js
@@ -146,6 +146,38 @@ testRule({
 			message: messages.expected(),
 		},
 		{
+			description: `Inconsistent spacing between cell tokens using single-line input`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a  a  a' 'bb bb bb';
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas: 'a a a' 'bb bb bb';
+				}
+			`),
+			message: messages.expected(),
+			line: 2, column: 23,
+			endLine: 2, endColumn: 43,
+		},
+		{
+			description: `Consistent spacing but aligned quotes using single-line input`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a a a   ' 'bb bb bb';
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas: 'a a a' 'bb bb bb';
+				}
+			`),
+			message: messages.expected(),
+			line: 2, column: 23,
+			endLine: 2, endColumn: 44,
+		},
+		{
 			description: `Not aligned columns with missed cells`,
 			code: stripIndent(`
 				a {
@@ -333,6 +365,10 @@ testRule({
 			code: `a { grid-template-areas: 'a  a  a'; }`,
 		},
 		{
+			description: `Single-line example using custom 'gap'`,
+			code: `a { grid-template-areas: 'a  a  a' 'bb  bb  bb'; }`,
+		},
+		{
 			description: `Basic example using custom 'gap'`,
 			code: stripIndent(`
 				a {
@@ -373,6 +409,14 @@ testRule({
 			message: messages.expected(),
 			line: 1, column: 26,
 			endLine: 1, endColumn: 32,
+		},
+		{
+			description: `Wrong number of spaces using single-line input`,
+			code: `a { grid-template-areas: 'a a a'   'bb bb bb' }`,
+			fixed: `a { grid-template-areas: 'a  a  a'   'bb  bb  bb' }`,
+			message: messages.expected(),
+			line: 1, column: 26,
+			endLine: 1, endColumn: 45,
 		},
 		{
 			description: `Not aligned columns using custom 'gap'`,
@@ -473,6 +517,12 @@ testRule({
 				}
 			`),
 		},
+		{
+			description: `Option 'alignQuotes' does not apply to single-line input`,
+			code: stripIndent(`
+				a { grid-template-areas: 'a a a' 'bb bb bb' }
+			`),
+		},
 	],
 
 	reject: [
@@ -542,6 +592,22 @@ testRule({
 			endLine: 5, endColumn: 12,
 			message: messages.expected(),
 		},
+		{
+			description: `Option 'alignQuotes' does not apply to single-line input`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a a a   ' 'bb bb bb';
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas: 'a a a' 'bb bb bb';
+				}
+			`),
+			line: 2, column: 23,
+			endLine: 2, endColumn: 44,
+			message: messages.expected(),
+		},
 	],
 })
 
@@ -562,6 +628,14 @@ testRule({
 					grid-template-areas:
 						'a   aa   aaa   aaaa'
 						'b   b    b     b   ';
+					}
+			`),
+		},
+		{
+			description: `Option 'gap' is applied to single-line input, option 'alignQuotes' is not`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a   a   a'  'bb   bb   bb';
 					}
 			`),
 		},
@@ -643,6 +717,38 @@ testRule({
 			`),
 			line: 3, column: 3,
 			endLine: 5, endColumn: 13,
+			message: messages.expected(),
+		},
+		{
+			description: `Not consistent spacing between cell tokens using single-line input`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a            a  a' 'bb bb bb'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas: 'a   a   a' 'bb   bb   bb'
+				}
+			`),
+			line: 2, column: 23,
+			endLine: 2, endColumn: 52,
+			message: messages.expected(),
+		},
+		{
+			description: `Aligned quotes using single-line input`,
+			code: stripIndent(`
+				a {
+					grid-template-areas: 'a   a   a   ' 'bb   bb   bb'
+				}
+			`),
+			fixed: stripIndent(`
+				a {
+					grid-template-areas: 'a   a   a' 'bb   bb   bb'
+				}
+			`),
+			line: 2, column: 23,
+			endLine: 2, endColumn: 51,
 			message: messages.expected(),
 		},
 	],


### PR DESCRIPTION
Hello,

One of my co-workers found the unwanted behavior with a single-line input using `alignQuotes` option:

**Real scenario:**
```css
.block {
  grid-template-areas: 'header' 'main' 'footer';
}

// This autofixes to 

.block {
  grid-template-areas: 'header' 'main  ' 'footer';
}
```

---

I've also noticed that using single line input it doesn't make sense to add extra spaces for "table alignment":

**Given input:**
```scss
// I don't like this kind of entry, but it's possible and should be a separate scenario
.block {
  grid-template-areas: 'a a a' 'bb bb bb';
}
```

**Current autofix behavior:**
```scss
.block {
  grid-template-areas: 'a  a  a ' 'bb bb bb';
}
```

**After merging this PR:**
```scss
.block {
  grid-template-areas: 'a a a' 'bb bb bb';
}
```

Single line input will only care about the spacing between individual cell tokens without considering the rest of the "rows", the "alignQuotes" option is also ignored.