### PR TITLE
Fix `block-closing-brace-empty-line-before` with `except: ["after-closing-brace"]` false negatives for CSS Nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- `block-closing-brace-empty-line-before` with except: ["after-closing-brace"] false negatives for CSS Nesting ([#22](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/22)) ([@firefoxic](https://github.com/firefoxic)).
 - `named-grid-areas-alignment` for single-line input ([#21](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/21)) ([@MorevM](https://github.com/MorevM)).
 
 ## [2.1.0] — 2024–02–18

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -79,7 +79,7 @@ const rule = (primary, secondaryOptions, context) => (root, result) => {
 
 			// Reverse the primary options if `after-closing-brace` is set
 			if (
-				optionsMatches(secondaryOptions, `except`, `after-closing-brace`) && statement.type === `atrule` && !childNodeTypes.includes(`decl`)
+				optionsMatches(secondaryOptions, `except`, `after-closing-brace`) && !childNodeTypes.includes(`decl`)
 			) {
 				return primary === `never`
 			}

--- a/lib/rules/block-closing-brace-empty-line-before/index.test.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.test.js
@@ -278,6 +278,12 @@ testRule({
 			code: `@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n}`,
 		},
 		{
+			code: `a {\n\n\tb {\n\t\tcolor: aquamarine;\n\t}\n\n}`,
+		},
+		{
+			code: `a {\n\n\t@media print {\n\t\tcolor: aquamarine;\n\t}\n\n}`,
+		},
+		{
 			code: `@font-face {\n\tfont-family: "MyFont";\n\tsrc: url("myfont.woff2") format("woff2");\n}`,
 		},
 		{


### PR DESCRIPTION
Resolves #20