### PR TITLE
Fix autofixing of `@charset` name by `string-quotes` rule

### DIFF
--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -189,9 +189,10 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			if (isAtRule(node) && node.name === `charset`) {
-				// allow @charset rules to have double quotes, in spite of the configuration
-				// TODO: @charset should always use double-quotes, see https://github.com/stylelint/stylelint/issues/2788
-				return
+				const hasValidQuotes = node.params.startsWith(`"`) && node.params.endsWith(`"`)
+
+				// pass through to the fixer only if the primary option is "double"
+				if (hasValidQuotes || correctQuote === `'`) { return }
 			}
 
 			valueParser(value).walk((valueNode) => {

--- a/lib/rules/string-quotes/index.test.js
+++ b/lib/rules/string-quotes/index.test.js
@@ -99,6 +99,13 @@ testRule({
 			line: 1,
 			column: 9,
 		},
+		{
+			code: `@charset 'utf-8'`,
+			fixed: `@charset "utf-8"`,
+			description: `should be covered by a new at-charset-rule-no-invalid rule
+			see stylelint/stylelint#7492`,
+			skip: true,
+		},
 	],
 })
 
@@ -186,6 +193,13 @@ testRule({
 			message: messages.expected(`double`),
 			line: 1,
 			column: 9,
+		},
+		{
+			code: `@charset 'utf-8'`,
+			fixed: `@charset "utf-8"`,
+			message: messages.expected(`double`),
+			line: 1,
+			column: 10,
 		},
 	],
 })


### PR DESCRIPTION
fixes #13

I chose not to fix `@charset 'utf-8';` if `"string-quotes": "single"` because that would be unexpected and not on scope with the rule.
see https://github.com/stylelint-stylistic/stylelint-stylistic/pull/26/files#diff-0d86982fe84f31cbb25c04fb29c4accaaf6060ade33eda47bf6636349cb4d514R105-R106