### PR TITLE
Fix `indentation` rule for `postcss-styled-syntax` custom syntax 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
-- Calculation of indentation using `postcss-styled-syntax` custom syntax
+- Calculation of indentation using `postcss-styled-syntax` custom syntax ([#41](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/41)) ([@MorevM](https://github.com/MorevM)).
 
 ## [3.0.1] — 2024–08–18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 - The `messageArgs` to 16 rules for custom message arguments. See [stylelint documentation](https://stylelint.io/user-guide/configure/#message) for details.
 
+### Fixed
+
+- Calculation of indentation using `postcss-styled-syntax` custom syntax
+
 ## [3.0.1] — 2024–08–18
 
 ### Fixed

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -5,6 +5,7 @@ import { addNamespace } from "../../utils/addNamespace.js"
 import beforeBlockString from "../../utils/beforeBlockString.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl.js"
 import hasBlock from "../../utils/hasBlock.js"
+import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode.js"
 import optionsMatches from "../../utils/optionsMatches.js"
 import { assertString, isBoolean, isNumber, isString } from "../../utils/validateTypes.js"
 import { isAtRule, isDeclaration, isRoot, isRule } from "../../utils/typeGuards.js"
@@ -79,6 +80,7 @@ function rule (primary, secondaryOptions = {}) {
 			}
 
 			let nodeLevel = indentationLevel(node)
+			let styledDeclarationLevel = isStyledSyntaxNode(node) ? getStyledDeclarationLevel(node) : 0
 
 			// Cut out any * and _ hacks from `before`
 			let before = (node.raws.before || ``).replace(/[*_]$/, ``)
@@ -104,7 +106,7 @@ function rule (primary, secondaryOptions = {}) {
 			if ((lastIndexOfNewline !== -1 || (isFirstChild && (!getDocument(parent) || (parent.raws.codeBefore && parent.raws.codeBefore.endsWith(`\n`))))) && before.slice(lastIndexOfNewline + 1) !== expectedOpeningBraceIndentation) {
 				report({
 					message: messages.expected,
-					messageArgs: [legibleExpectation(nodeLevel)],
+					messageArgs: [legibleExpectation(nodeLevel - styledDeclarationLevel)],
 					node,
 					result,
 					ruleName,
@@ -128,7 +130,7 @@ function rule (primary, secondaryOptions = {}) {
 			if ((isRule(node) || isAtRule(node)) && hasBlock(node) && after && after.includes(`\n`) && after.slice(after.lastIndexOf(`\n`) + 1) !== expectedClosingBraceIndentation) {
 				report({
 					message: messages.expected,
-					messageArgs: [legibleExpectation(closingBraceLevel)],
+					messageArgs: [legibleExpectation(closingBraceLevel - styledDeclarationLevel)],
 					node,
 					index: node.toString().length - 1,
 					result,
@@ -156,12 +158,35 @@ function rule (primary, secondaryOptions = {}) {
 		})
 
 		/**
+		 * Roughly calculates the indentation level of the line where styled expression starts.
+		 * Required to format the error text relative to this level, not the beginning of a line.
+		 *
+		 * @param {import('postcss').Node} node
+		 */
+		function getStyledDeclarationLevel (node) {
+			// Content of the line where styled expressions starts
+			const expressionStartLine = node.parent.parent.source.input.css.split(`\n`)[node.parent.source.start.line - 1]
+			// Indent characters (spaces/tabs) before the content of the line where the styled expressions starts
+			const indentCharacters = expressionStartLine.match(/^[ \t]*/g)?.[0] ?? ``
+
+			return Math.ceil(indentCharacters.length / indentChar.length)
+		}
+
+		/**
 		 * @param {import('postcss').Node} node
 		 * @param {number} level
 		 * @returns {number}
 		 */
 		function indentationLevel (node, level = 0) {
 			if (!node.parent) { throw new Error(`A parent node must be present`) }
+
+			if (isStyledSyntaxNode(node)) {
+				const isMultilineDeclaration = !!node.parent.source?.input.css.includes(`\n`)
+
+				if (isMultilineDeclaration) level++
+
+				level += getStyledDeclarationLevel(node)
+			}
 
 			if (isRoot(node.parent)) {
 				return level + getRootBaseIndentLevel(node.parent, baseIndentLevel, primary)

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -271,7 +271,7 @@ function rule (primary, secondaryOptions = {}) {
 
 					let expectedIndentLevel = newlineIndentLevel
 
-					// Modififications for parenthetical content
+					// Modifications for parenthetical content
 					if (!ignoreInsideParans && match.insideParens) {
 						// If the first match in is within parentheses, reduce the parenthesis penalty
 						if (matchCount === 1) { parentheticalDepth -= 1 }

--- a/lib/rules/indentation/styled-syntax.test.js
+++ b/lib/rules/indentation/styled-syntax.test.js
@@ -1,0 +1,468 @@
+/* eslint-disable */
+import { stripIndent } from "common-tags"
+import { testRule } from "stylelint-test-rule-node"
+
+import plugins from "../../index.js"
+import { messages, ruleName } from "./index.js"
+
+testRule({
+	customSyntax: `postcss-styled-syntax`,
+	plugins,
+	ruleName,
+	config: [2],
+	fix: true,
+
+	accept: [
+		{
+			description: `Single-line no value`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`\`
+			`),
+		},
+		{
+			description: `Multi-line no value`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+				\`
+			`),
+		},
+		{
+			description: `The basic scenario using spaces`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+				  background: white;
+				\`
+			`),
+		},
+		{
+			description: `Single-line scenario (no extra spaces)`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`background: white;\`
+			`),
+		},
+		{
+			description: `Keyframes scenario using spaces`,
+			code: stripIndent(`
+				const rotate = css\`
+				  from {
+				    transform: rotate(0deg);
+				  }
+
+				  to {
+				    transform: rotate(360deg);
+				  }
+				\`;
+			`),
+		},
+		{
+			description: `Custom CSS using spaces`,
+			code: stripIndent(`
+				const styles = css\`
+				  color: blue;
+
+				  @media screen {
+				    color: red;
+				  }
+				\`
+			`),
+		},
+		{
+			description: `Conditional CSS using spaces`,
+			code: stripIndent(`
+				const Component = styled.p\`
+				  \${(props) =>
+				    props.isPrimary
+				      ? css\`
+				        background: green;
+				        \`
+				      : css\`
+				        border: 1px solid blue;
+				        \`
+				  }
+				\`;
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `The basic scenario using wrong count of spaces`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+				background: white;
+				\`
+			`),
+			fixed: stripIndent(`
+				const StyledDiv = styled.div\`
+				  background: white;
+				\`
+			`),
+			message: messages.expected(`2 spaces`),
+			line: 2,
+			column: 1,
+		},
+		{
+			description: `Single-line scenario (should be no extra spaces)`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`  background: white;\`
+			`),
+			fixed: stripIndent(`
+				const StyledDiv = styled.div\`background: white;\`
+			`),
+			message: messages.expected(`0 spaces`),
+			line: 1,
+			column: 32,
+		},
+		{
+			description: `Keyframes scenario using wrong count of spaces`,
+			code: stripIndent(`
+				const rotate = css\`
+					from {
+				      transform: rotate(0deg);
+				  }
+
+				    to {
+				              transform: rotate(360deg);
+				  }
+				\`;
+			`),
+			fixed: stripIndent(`
+				const rotate = css\`
+				  from {
+				    transform: rotate(0deg);
+				  }
+
+				  to {
+				    transform: rotate(360deg);
+				  }
+				\`;
+			`),
+			warnings: [
+				{
+					line: 2,
+					column: 2,
+					message: messages.expected(`2 spaces`),
+				},
+				{
+					line: 3,
+					column: 7,
+					message: messages.expected(`4 spaces`),
+				},
+				{
+					line: 6,
+					column: 5,
+					message: messages.expected(`2 spaces`),
+				},
+				{
+					line: 7,
+					column: 15,
+					message: messages.expected(`4 spaces`),
+				},
+			]
+		},
+		{
+			description: `Custom CSS using wrong count of spaces/tabs`,
+			code: stripIndent(`
+				const styles = css\`
+					color: blue;
+
+				  @media screen {
+				      color: red;
+				  }
+				\`
+			`),
+			fixed: stripIndent(`
+				const styles = css\`
+				  color: blue;
+
+				  @media screen {
+				    color: red;
+				  }
+				\`
+			`),
+			warnings: [
+				{
+					line: 2,
+					column: 2, // because tab is 1
+					message: messages.expected(`2 spaces`),
+				},
+				{
+					line: 5,
+					column: 7, // next char after 6 spaces
+					message: messages.expected(`4 spaces`),
+				},
+			]
+		},
+		{
+			description: `Conditional CSS using spaces`,
+			code: stripIndent(`
+				const Component = styled.p\`
+				  \${(props) =>
+				    props.isPrimary
+				      ? css\`
+				          background: green;
+				        \`
+				      : css\`
+				border: 1px solid blue;
+				        \`
+				  }
+				\`;
+			`),
+			fixed: stripIndent(`
+				const Component = styled.p\`
+				  \${(props) =>
+				    props.isPrimary
+				      ? css\`
+				        background: green;
+				        \`
+				      : css\`
+				        border: 1px solid blue;
+				        \`
+				  }
+				\`;
+			`),
+			warnings: [
+				{
+					line: 5,
+					column: 11,
+					message: messages.expected(`2 spaces`),
+				},
+				{
+					line: 8,
+					column: 1,
+					message: messages.expected(`2 spaces`),
+				},
+			]
+		},
+	],
+})
+
+testRule({
+	customSyntax: `postcss-styled-syntax`,
+	plugins,
+	ruleName,
+	config: [`tab`],
+	fix: true,
+
+	accept: [
+		{
+			description: `The basic scenario using tabs`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+					background: white;
+				\`
+			`),
+		},
+		{
+			description: `Single-line scenario (no extra tabs)`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`background: white;\`
+			`),
+		},
+		{
+			description: `Keyframes scenario using tabs`,
+			code: stripIndent(`
+				const rotate = css\`
+					from {
+						transform: rotate(0deg);
+					}
+
+					to {
+						transform: rotate(360deg);
+					}
+				\`;
+			`),
+		},
+		{
+			description: `Custom CSS using tabs`,
+			code: stripIndent(`
+				const styles = css\`
+					color: blue;
+
+					@media screen {
+						color: red;
+					}
+				\`
+			`),
+		},
+		{
+			description: `Conditional CSS using tabs`,
+			code: stripIndent(`
+				const Component = styled.p\`
+					\${(props) =>
+						props.isPrimary
+							? css\`
+								background: green;
+								\`
+							: css\`
+								border: 1px solid blue;
+								\`
+					}
+				\`;
+			`),
+		},
+	],
+
+	reject: [
+		{
+			description: `The basic scenario using wrong count of tabs`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+				background: white;
+				\`
+			`),
+			fixed: stripIndent(`
+				const StyledDiv = styled.div\`
+					background: white;
+				\`
+			`),
+			message: messages.expected(`1 tab`),
+			line: 2,
+			column: 1,
+		},
+		{
+			description: `The basic scenario using wrong spaces`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`
+				  background: white;
+				\`
+			`),
+			fixed: stripIndent(`
+				const StyledDiv = styled.div\`
+					background: white;
+				\`
+			`),
+			message: messages.expected(`1 tab`),
+			line: 2,
+			column: 3,
+		},
+		{
+			description: `Single-line scenario (should be no extra tabs or spaces)`,
+			code: stripIndent(`
+				const StyledDiv = styled.div\`  background: white;\`
+			`),
+			fixed: stripIndent(`
+				const StyledDiv = styled.div\`background: white;\`
+			`),
+			message: messages.expected(`0 tabs`),
+			line: 1,
+			column: 32,
+		},
+		{
+			description: `Keyframes scenario using wrong spaces`,
+			code: stripIndent(`
+				const rotate = css\`
+					from {
+				      transform: rotate(0deg);
+					}
+
+				    to {
+				              transform: rotate(360deg);
+					}
+				\`;
+			`),
+			fixed: stripIndent(`
+				const rotate = css\`
+					from {
+						transform: rotate(0deg);
+					}
+
+					to {
+						transform: rotate(360deg);
+					}
+				\`;
+			`),
+			warnings: [
+				{
+					line: 3,
+					column: 7,
+					message: messages.expected(`2 tabs`),
+				},
+				{
+					line: 6,
+					column: 5,
+					message: messages.expected(`1 tab`),
+				},
+				{
+					line: 7,
+					column: 15,
+					message: messages.expected(`2 tabs`),
+				},
+			]
+		},
+		{
+			description: `Custom CSS using wrong count of spaces/tabs`,
+			code: stripIndent(`
+				const styles = css\`
+				  color: blue;
+
+					@media screen {
+							color: red;
+					}
+				\`
+			`),
+			fixed: stripIndent(`
+				const styles = css\`
+					color: blue;
+
+					@media screen {
+						color: red;
+					}
+				\`
+			`),
+			warnings: [
+				{
+					line: 2,
+					column: 3,
+					message: messages.expected(`1 tab`),
+				},
+				{
+					line: 5,
+					column: 4,
+					message: messages.expected(`2 tabs`),
+				},
+			]
+		},
+		{
+			description: `Conditional CSS using tabs`,
+			code: stripIndent(`
+				const Component = styled.p\`
+					\${(props) =>
+						props.isPrimary
+							? css\`
+				          background: green;
+								\`
+							: css\`
+				border: 1px solid blue;
+								\`
+					}
+				\`;
+			`),
+			fixed: stripIndent(`
+				const Component = styled.p\`
+					\${(props) =>
+						props.isPrimary
+							? css\`
+								background: green;
+								\`
+							: css\`
+								border: 1px solid blue;
+								\`
+					}
+				\`;
+			`),
+			warnings: [
+				{
+					line: 5,
+					column: 11,
+					message: messages.expected(`1 tab`),
+				},
+				{
+					line: 8,
+					column: 1,
+					message: messages.expected(`1 tab`),
+				},
+			]
+		},
+	],
+})

--- a/lib/utils/isStyledSyntaxNode.js
+++ b/lib/utils/isStyledSyntaxNode.js
@@ -1,0 +1,9 @@
+/**
+ * Check whether the Node is processed by `postcss-styled-syntax`.
+ *
+ * @param {import('postcss').Node} node
+ * @returns {boolean}
+ */
+export function isStyledSyntaxNode (node) {
+	return node.parent?.raws.styledSyntaxRangeStart !== undefined
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"postcss-html": "^1.7.0",
 		"postcss-less": "^6.0.0",
 		"postcss-scss": "^4.0.9",
+		"postcss-styled-syntax": "^0.6.4",
 		"stylelint-test-rule-node": "^0.3.0"
 	},
 	"keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 0.1.0
       stylelint:
         specifier: ^16.8.2
-        version: 16.8.2
+        version: 16.8.2(typescript@5.6.2)
     devDependencies:
       '@firefoxic/eslint-config':
         specifier: ^3.0.1
@@ -60,9 +60,12 @@ importers:
       postcss-scss:
         specifier: ^4.0.9
         version: 4.0.9(postcss@8.4.41)
+      postcss-styled-syntax:
+        specifier: ^0.6.4
+        version: 0.6.4(postcss@8.4.41)
       stylelint-test-rule-node:
         specifier: ^0.3.0
-        version: 0.3.0(stylelint@16.8.2)
+        version: 0.3.0(stylelint@16.8.2(typescript@5.6.2))
 
 packages:
 
@@ -700,6 +703,12 @@ packages:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
 
+  postcss-styled-syntax@0.6.4:
+    resolution: {integrity: sha512-uWiLn+9rKgIghUYmTHvXMR6MnyPULMe9Gv3bV537Fg4FH6CA6cn21WMjKss2Qb98LUhT847tKfnRGG3FhSOgUQ==}
+    engines: {node: '>=14.17'}
+    peerDependencies:
+      postcss: ^8.4.21
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -824,6 +833,11 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1049,12 +1063,14 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  cosmiconfig@9.0.0:
+  cosmiconfig@9.0.0(typescript@5.6.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.6.2
 
   cross-spawn@7.0.3:
     dependencies:
@@ -1443,6 +1459,11 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-styled-syntax@0.6.4(postcss@8.4.41):
+    dependencies:
+      postcss: 8.4.41
+      typescript: 5.6.2
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.41:
@@ -1507,11 +1528,11 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  stylelint-test-rule-node@0.3.0(stylelint@16.8.2):
+  stylelint-test-rule-node@0.3.0(stylelint@16.8.2(typescript@5.6.2)):
     dependencies:
-      stylelint: 16.8.2
+      stylelint: 16.8.2(typescript@5.6.2)
 
-  stylelint@16.8.2:
+  stylelint@16.8.2(typescript@5.6.2):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.1(@csstools/css-tokenizer@3.0.1)
       '@csstools/css-tokenizer': 3.0.1
@@ -1520,7 +1541,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.1.0
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0
+      cosmiconfig: 9.0.0(typescript@5.6.2)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
       debug: 4.3.6
@@ -1588,6 +1609,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript@5.6.2: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
Resolves #39 

Take a look at the tests to make sure I've accounted for everything, please.

Notes:
* I created a global utility `isStyledSyntaxNode` as I expect more changes for this syntax in the future.
* The tests for [`keywords`](https://styled-components.com/docs/basics#animations) is not fair - they utilize `css` function, not `keyframes`, as `postcss-styled-syntax` only support this and `createGlobalStyle`. \
To make it work with `keyframes`, the change should be done on the `postcss-styled-syntax` side (most probably [here](https://github.com/hudochenkov/postcss-styled-syntax/blob/9455a3b9a4f100b83288408a3ff28418500d6416/lib/isStyledComponent.js#L44))