### PR TITLE
Disable indentation checking for property values that use dynamic expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
-- Disable indentation checking for property values that use dynamic expressions when `postcss-styled-syntax` is used.
+- Disable indentation checking for property values that use dynamic expressions when `postcss-styled-syntax` is used ([#44](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/44)) ([@MorevM](https://github.com/MorevM)).
 
 ## [3.1.0] — 2024–09–23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
-- Disable indentation checking for property values that use dynamic expressions when `postcss-styled-syntax` is used ([#44](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/44)) ([@MorevM](https://github.com/MorevM)).
+- Indentation checking for property values that use dynamic expressions when using `postcss-styled-syntax` is now disabled ([#44](https://github.com/stylelint-stylistic/stylelint-stylistic/pull/44)) ([@MorevM](https://github.com/MorevM)).
 
 ## [3.1.0] — 2024–09–23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable indentation checking for property values that use dynamic expressions when `postcss-styled-syntax` is used.
+
 ## [3.1.0] — 2024–09–23
 
 ### Added

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -5,6 +5,7 @@ import { addNamespace } from "../../utils/addNamespace.js"
 import beforeBlockString from "../../utils/beforeBlockString.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl.js"
 import hasBlock from "../../utils/hasBlock.js"
+import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration.js"
 import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode.js"
 import optionsMatches from "../../utils/optionsMatches.js"
 import { assertString, isBoolean, isNumber, isString } from "../../utils/validateTypes.js"
@@ -215,6 +216,10 @@ function rule (primary, secondaryOptions = {}) {
 		 */
 		function checkValue (decl, declLevel) {
 			if (!decl.value.includes(`\n`)) {
+				return
+			}
+
+			if (isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`)) {
 				return
 			}
 

--- a/lib/rules/indentation/styled-syntax.test.js
+++ b/lib/rules/indentation/styled-syntax.test.js
@@ -82,6 +82,28 @@ testRule({
 				\`;
 			`),
 		},
+		{
+			description: `Ignores indentation of property values containing dynamic expressions using spaces`,
+			code: stripIndent(`
+				const Option = styled.div\`
+				  &:hover {
+				    background-color: \${({ colours, isOptionSelected }) => (
+				      isOptionSelected
+				        ? colours.backgroundColour
+				        : colours.backgroundColourOnHover
+				    )};
+				    gap: 8px \${({ isWide }) => (
+				      isWide
+				        ? '40px'
+				        : '24px'
+				    )};
+				    grid-template-areas:
+				      'foo  foo  foo'
+				      'bar  bar  bar'
+				  }
+				\`;
+			`),
+		},
 	],
 
 	reject: [
@@ -234,6 +256,54 @@ testRule({
 				},
 			]
 		},
+		{
+			description: `Ignores only property values containing dynamic expressions using spaces (JS expressions are broken intentionally)`,
+			code: stripIndent(`
+				const Option = styled.div\`
+				  &:hover {
+				    background-color: \${({ colours, isOptionSelected }) => (
+				    	isOptionSelected
+				                          ? colours.backgroundColour
+				      : colours.backgroundColourOnHover
+				    )};
+				    gap: 8px \${({ isWide }) => (
+				      isWide
+				         ? '40px'
+				       : '24px'
+				    )};
+				    grid-template-areas:
+				      'foo  foo  foo'
+				       'bar  bar  bar'
+				  }
+				\`;
+			`),
+			fixed: stripIndent(`
+				const Option = styled.div\`
+				  &:hover {
+				    background-color: \${({ colours, isOptionSelected }) => (
+				    	isOptionSelected
+				                          ? colours.backgroundColour
+				      : colours.backgroundColourOnHover
+				    )};
+				    gap: 8px \${({ isWide }) => (
+				      isWide
+				         ? '40px'
+				       : '24px'
+				    )};
+				    grid-template-areas:
+				      'foo  foo  foo'
+				      'bar  bar  bar'
+				  }
+				\`;
+			`),
+			warnings: [
+				{
+					line: 15,
+					column: 8,
+					message: messages.expected(`6 spaces`),
+				},
+			]
+		},
 	],
 })
 
@@ -297,6 +367,28 @@ testRule({
 							: css\`
 								border: 1px solid blue;
 								\`
+					}
+				\`;
+			`),
+		},
+		{
+			description: `Ignores indentation of property values containing dynamic expressions using tabs`,
+			code: stripIndent(`
+				const Option = styled.div\`
+					&:hover {
+						background-color: \${({ colours, isOptionSelected }) => (
+							isOptionSelected
+								? colours.backgroundColour
+								: colours.backgroundColourOnHover
+						)};
+						gap: 8px \${({ isWide }) => (
+							isWide
+								? '40px'
+								: '24px'
+						)};
+						grid-template-areas:
+							'foo  foo  foo'
+							'bar  bar  bar'
 					}
 				\`;
 			`),
@@ -461,6 +553,59 @@ testRule({
 					line: 8,
 					column: 1,
 					message: messages.expected(`1 tab`),
+				},
+			]
+		},
+		{
+			description: `Ignores only property values containing dynamic expressions using tabs (JS expressions are broken intentionally)`,
+			code: stripIndent(`
+				const Option = styled.div\`
+					&:hover {
+						background-color: \${({ colours, isOptionSelected }) => (
+							isOptionSelected
+											     ? colours.backgroundColour
+							: colours.backgroundColourOnHover
+						)};
+							gap: 8px \${({ isWide }) => (
+							isWide
+								? '40px'
+							: '24px'
+						)};
+						grid-template-areas:
+							 'foo  foo  foo'
+							'bar  bar  bar'
+					}
+				\`;
+			`),
+			fixed: stripIndent(`
+				const Option = styled.div\`
+					&:hover {
+						background-color: \${({ colours, isOptionSelected }) => (
+							isOptionSelected
+											     ? colours.backgroundColour
+							: colours.backgroundColourOnHover
+						)};
+						gap: 8px \${({ isWide }) => (
+							isWide
+								? '40px'
+							: '24px'
+						)};
+						grid-template-areas:
+							'foo  foo  foo'
+							'bar  bar  bar'
+					}
+				\`;
+			`),
+			warnings: [
+				{
+					line: 8,
+					column: 4,
+					message: messages.expected(`2 tabs`),
+				},
+				{
+					line: 14,
+					column: 5,
+					message: messages.expected(`3 tabs`),
 				},
 			]
 		},

--- a/lib/rules/indentation/styled-syntax.test.js
+++ b/lib/rules/indentation/styled-syntax.test.js
@@ -260,6 +260,18 @@ testRule({
 			description: `Ignores only property values containing dynamic expressions using spaces (JS expressions are broken intentionally)`,
 			code: stripIndent(`
 				const Option = styled.div\`
+				  width: \${({ isLarge }) => (
+				    isLarge
+				      ? '40px'
+				      : '8px'
+				  )};
+
+				  gap: 8px \${({ isLarge }) => (
+				    isLarge
+				      ? '16px'
+				      : '8px'
+				  )};
+
 				  &:hover {
 				    background-color: \${({ colours, isOptionSelected }) => (
 				    	isOptionSelected
@@ -279,6 +291,18 @@ testRule({
 			`),
 			fixed: stripIndent(`
 				const Option = styled.div\`
+				  width: \${({ isLarge }) => (
+				    isLarge
+				      ? '40px'
+				      : '8px'
+				  )};
+
+				  gap: 8px \${({ isLarge }) => (
+				    isLarge
+				      ? '16px'
+				      : '8px'
+				  )};
+
 				  &:hover {
 				    background-color: \${({ colours, isOptionSelected }) => (
 				    	isOptionSelected
@@ -298,7 +322,7 @@ testRule({
 			`),
 			warnings: [
 				{
-					line: 15,
+					line: 27,
 					column: 8,
 					message: messages.expected(`6 spaces`),
 				},
@@ -560,6 +584,18 @@ testRule({
 			description: `Ignores only property values containing dynamic expressions using tabs (JS expressions are broken intentionally)`,
 			code: stripIndent(`
 				const Option = styled.div\`
+					width: \${({ isLarge }) => (
+						isLarge
+							? '40px'
+							: '24px'
+					)};
+
+					gap: 8px \${({ isLarge }) => (
+						isLarge
+							? '40px'
+							: '24px'
+					)};
+
 					&:hover {
 						background-color: \${({ colours, isOptionSelected }) => (
 							isOptionSelected
@@ -579,6 +615,18 @@ testRule({
 			`),
 			fixed: stripIndent(`
 				const Option = styled.div\`
+					width: \${({ isLarge }) => (
+						isLarge
+							? '40px'
+							: '24px'
+					)};
+
+					gap: 8px \${({ isLarge }) => (
+						isLarge
+							? '40px'
+							: '24px'
+					)};
+
 					&:hover {
 						background-color: \${({ colours, isOptionSelected }) => (
 							isOptionSelected
@@ -598,12 +646,12 @@ testRule({
 			`),
 			warnings: [
 				{
-					line: 8,
+					line: 20,
 					column: 4,
 					message: messages.expected(`2 tabs`),
 				},
 				{
-					line: 14,
+					line: 26,
 					column: 5,
 					message: messages.expected(`3 tabs`),
 				},

--- a/lib/utils/isStyledSyntaxDeclaration.js
+++ b/lib/utils/isStyledSyntaxDeclaration.js
@@ -1,0 +1,9 @@
+/**
+ * Check whether the declaration is processed by `postcss-styled-syntax`.
+ *
+ * @param {import('postcss').Declaration} declaration
+ * @returns {boolean}
+ */
+export function isStyledSyntaxDeclaration (declaration) {
+	return declaration.parent?.parent?.raws.styledSyntaxRangeStart !== undefined
+}

--- a/lib/utils/isStyledSyntaxDeclaration.js
+++ b/lib/utils/isStyledSyntaxDeclaration.js
@@ -5,5 +5,14 @@
  * @returns {boolean}
  */
 export function isStyledSyntaxDeclaration (declaration) {
-	return declaration.parent?.parent?.raws.styledSyntaxRangeStart !== undefined
+	let parent = declaration.parent
+
+	while (parent) {
+		if (parent.raws.styledSyntaxRangeStart !== undefined) {
+			return true
+		}
+		parent = parent.parent
+	}
+
+	return false
 }


### PR DESCRIPTION
Resolves #39 again

[Demo](https://stylelint.io/demo/#N4Igxg9gJgpiBc4IDsDOAXABAZXQTwBsYoBhFdAQwEtkYAnTAXkw0OIDooqA3AAwB1kmTACMKYANYBzOhACuyKPEwBiAGYbNAbkG8dyQZDRYA8gAd0VFExb4iUTjwFDMAMngALCN3qZgg4WExSRl5RQBaSAIIOmUAEmAACmBMKPk6VAAaTCpUc0sUbBgiMHRiTABfAEomAD5MRIDA4Vz8q2QikrKoJubhAH5UiGi5DPZg6VkFUmH03r7lNNHUcfFJsJmRuhNkAAlvenmqiv15gHoAKkwASSwqKWQYmFRMdA8YTBQCPEwzWTN6PhMNwKAQ5M8hshKDQaFJMDAAB5-Z6odovC5nc5XbAQV4eXLwuiyBgYKgEAiYOgwMwxbrsTAY+aYKQUMzKAAcZgRpxcwncXh8DH8vMCLLZmE53KZzNZHK5mASyRyqAAMhQ6FIPtU6g1pS1VerNXrAoMAOQAFgADFzTcbhMpTQAmc026XHeYVJqe5B6QSGFAYTAAMQguOYrHsjj4TTFcoRCqSKVyao1WpqjHqjRFycNMGlZqtrpF9swTpdCNtLndPpAmRAajJMAAchQALZwRCIttmIjsABWqFrSGQDakCBAwuE-HAcgwEFb2DwUIoCOnymnNIwYFQqHCEeIe6XlFXtaaG7BUhoqDXmAA2vNpwABCO5SxgM77gg0dDhHtyS8GCATQALqZGeIB0HIRDXggfgPiAz52K+VDvjQsDLgUgHKI6XqCN6Q5GKOIZ0K2FDoOOA4oEOsBmIOiCToET4vqS76ft+v4XjQN7Th46DoLR8BnGckCwNEFAOJebxyCI7CQK2H52MU7HMW+ClsF+UJ7khLFnJQdDsFIABeZxUmoqBnO84nmQ2CJnFAS5tih4SIsiO5olpbBQIey4nmBIobhAW47h59jece3EgAQZHPOg05+c005sVCEVRWUGDTnhIAVEAA) for this PR.

I've decided to completely disable indentation checking for properties if they contain dynamic expressions.
This covers the scenario from the issue, and also cases like this:

```js
const Foo = styled.div`
  gap: 8px ${({ isLarge }) => (
    isLarge
      ? '40px'
      : '24px'
  )}
`
```