### PR TITLE
Add an exception related to an empty custom property value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
-- An exception for an empty custom property value has been added to the `declaration-block-semicolon-newline-before` rule: the `--custom-prop: ;` and `--custom-prop:;` variants are now considered valid (see [#50](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50)).
+- An exception for an empty custom property value has been added to the `declaration-block-semicolon-newline-before` and `declaration-colon-space-after` rules: the `--custom-prop: ;` and `--custom-prop:;` variants are now considered valid (see [#50](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50)).
 
 ## [5.1.0] — 2026–03–28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ## [Unreleased]
 
+### Fixed
+
+- An exception for an empty custom property value has been added to the `declaration-block-semicolon-newline-before` rule: the `--custom-prop: ;` and `--custom-prop:;` variants are now considered valid (see [#50](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50)).
+
 ## [5.1.0] — 2026–03–28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ## [Unreleased]
 
+### Added
+
+- The `declaration-block-semicolon-newline-before` rule is now autofixable.
+
 ### Fixed
 
 - An exception for an empty custom property value has been added to the `declaration-block-semicolon-newline-before` rule: the `--custom-prop: ;` and `--custom-prop:;` variants are now considered valid (see [#50](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50)).

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -53,7 +53,7 @@ Here are `stylelint-stylistic` rules, grouped by the _thing_ they apply to (just
 ## Declaration block
 
 - [`declaration-block-semicolon-newline-after`](../../lib/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks (Autofixable).
-- [`declaration-block-semicolon-newline-before`](../../lib/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks.
+- [`declaration-block-semicolon-newline-before`](../../lib/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks (Autofixable).
 - [`declaration-block-semicolon-space-after`](../../lib/rules/declaration-block-semicolon-space-after/README.md): Require a single space or disallow whitespace after the semicolons of declaration blocks (Autofixable).
 - [`declaration-block-semicolon-space-before`](../../lib/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks (Autofixable).
 - [`declaration-block-trailing-semicolon`](../../lib/rules/declaration-block-trailing-semicolon/README.md): Require or disallow a trailing semicolon within declaration blocks (Autofixable).

--- a/lib/rules/declaration-block-semicolon-newline-before/README.md
+++ b/lib/rules/declaration-block-semicolon-newline-before/README.md
@@ -13,6 +13,8 @@ Require a newline or disallow whitespace before the semicolons of declaration bl
 
 This rule ignores semicolons that are preceded by Less mixins.
 
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -2,6 +2,7 @@ import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { blockString } from "../../utils/blockString/index.js"
+import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
@@ -44,7 +45,13 @@ function rule (primary) {
 
 			if (!isAtRule(parentRule) && !isRule(parentRule)) return
 
+			// Ignore last declaration if there's no trailing semicolon
 			if (!parentRule.raws.semicolon && parentRule.last === decl) return
+
+			let value = getDeclarationValue(decl)
+
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50
+			if (primary.startsWith(`never`) && value === ` `) return
 
 			const declString = decl.toString()
 			const problemIndex = decl.toString().length - 1
@@ -53,9 +60,9 @@ function rule (primary) {
 				source: declString,
 				index: declString.length,
 				lineCheckStr: blockString(parentRule),
-				err: (m) => {
+				err: (message) => {
 					report({
-						message: m,
+						message,
 						node: decl,
 						index: problemIndex,
 						endIndex: problemIndex,

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -4,6 +4,7 @@ import { addNamespace } from "../../utils/addNamespace/index.js"
 import { blockString } from "../../utils/blockString/index.js"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { isCustomProperty } from "../../utils/isCustomProperty/index.js"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
 
@@ -21,13 +22,14 @@ export let messages = ruleMessages(ruleName, {
 
 export let meta = {
 	url: getRuleDocUrl(shortName),
+	fixable: true,
 }
 
 /**
  * Requires a newline or disallows whitespace before the semicolons of declaration blocks.
  * @type {import('stylelint').Rule}
  */
-function rule (primary) {
+function rule (primary, _secondaryOptions, context) {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -49,6 +51,7 @@ function rule (primary) {
 			if (!parentRule.raws.semicolon && parentRule.last === decl) return
 
 			let value = getDeclarationValue(decl)
+			let isCustomPropertyWithOnlyHorizontalSpaces = isCustomProperty(decl.prop) && (/^[ \t]+$/).test(value)
 
 			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50
 			if (primary.startsWith(`never`) && value === ` `) return
@@ -68,6 +71,35 @@ function rule (primary) {
 						endIndex: problemIndex,
 						result,
 						ruleName,
+						fix: () => {
+							if (primary.startsWith(`always`)) {
+								if (decl.raws.important) {
+									decl.raws.important = decl.raws.important.replace(/\s*$/, context.newline)
+								}
+								else {
+									value = value.replace(/\s*$/, context.newline)
+
+									if (decl.raws.value) decl.raws.value.raw = value
+									else decl.value = value
+								}
+
+								return
+							}
+
+							if (primary === `never-multi-line`) {
+								if (decl.raws.important) {
+									decl.raws.important = decl.raws.important.replace(/\s*$/, ``)
+								}
+								else {
+									let newValue = isCustomPropertyWithOnlyHorizontalSpaces
+										? ` `
+										: value.replace(/\s*$/, ``)
+
+									if (decl.raws.value) decl.raws.value.raw = newValue
+									else decl.value = newValue
+								}
+							}
+						},
 					})
 				},
 			})

--- a/lib/rules/declaration-block-semicolon-newline-before/index.test.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.test.js
@@ -48,28 +48,69 @@ testRule({
 
 	reject: [
 		{
+			code: `a {--a:;}`,
+			fixed: `a {--a:\n;}`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: `a {\n\t--a:;\n}`,
+			fixed: `a {\n\t--a:\n;\n}`,
+			message: messages.expectedBefore(),
+			line: 2,
+			column: 5,
+		},
+		{
 			code: `a { color: pink;top: 0 }`,
+			fixed: `a { color: pink\n;top: 0 }`,
 			message: messages.expectedBefore(),
 			line: 1,
 			column: 15,
 		},
 		{
 			code: `a { color: pink ;top: 0 }`,
+			fixed: `a { color: pink\n;top: 0 }`,
 			message: messages.expectedBefore(),
 			line: 1,
 			column: 16,
 		},
 		{
 			code: `a { color: pink  ;top: 0 }`,
+			fixed: `a { color: pink\n;top: 0 }`,
 			message: messages.expectedBefore(),
 			line: 1,
 			column: 17,
 		},
 		{
 			code: `a { color: pink\t;top: 0 }`,
+			fixed: `a { color: pink\n;top: 0 }`,
 			message: messages.expectedBefore(),
 			line: 1,
 			column: 16,
+		},
+		{
+			code: `a { color: pink\t ;top: 0 }`,
+			fixed: `a { color: pink\n;top: 0 }`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 17,
+		},
+		{
+			code: `a { color: pink/*comment*/;top: 0 }`,
+			fixed: `a { color: pink/*comment*/\n;top: 0 }`,
+			description: `comment`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 26,
+		},
+		{
+			code: `a { color: pink/*comment*/ ;top: 0 }`,
+			fixed: `a { color: pink/*comment*/\n;top: 0 }`,
+			description: `comment`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 27,
 		},
 	],
 })
@@ -121,19 +162,29 @@ testRule({
 
 	reject: [
 		{
+			code: `a {\n\t--a:;\n}`,
+			fixed: `a {\n\t--a:\n;\n}`,
+			message: messages.expectedBeforeMultiLine(),
+			line: 2,
+			column: 5,
+		},
+		{
 			code: `a {\ncolor: pink;top: 0\n}`,
+			fixed: `a {\ncolor: pink\n;top: 0\n}`,
 			message: messages.expectedBeforeMultiLine(),
 			line: 2,
 			column: 11,
 		},
 		{
 			code: `a {\ncolor: pink ;top: 0\n}`,
+			fixed: `a {\ncolor: pink\n;top: 0\n}`,
 			message: messages.expectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
 		},
 		{
 			code: `a {\ncolor: pink  ;top: 0\n}`,
+			fixed: `a {\ncolor: pink\n;top: 0\n}`,
 			message: messages.expectedBeforeMultiLine(),
 			line: 2,
 			column: 13,
@@ -141,15 +192,25 @@ testRule({
 		{
 			code: `a {\r\ncolor: pink  ;top: 0\r\n}`,
 			description: `CRLF`,
+			fixed: `a {\r\ncolor: pink\r\n;top: 0\r\n}`,
 			message: messages.expectedBeforeMultiLine(),
 			line: 2,
 			column: 13,
 		},
 		{
 			code: `a {\ncolor: pink\t;top: 0\n}`,
+			fixed: `a {\ncolor: pink\n;top: 0\n}`,
 			message: messages.expectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
+		},
+		{
+			code: `a {\ncolor: pink/*comment*/;top: 0\n}`,
+			fixed: `a {\ncolor: pink/*comment*/\n;top: 0\n}`,
+			description: `comment`,
+			message: messages.expectedBeforeMultiLine(),
+			line: 2,
+			column: 22,
 		},
 	],
 })
@@ -200,13 +261,22 @@ testRule({
 
 	reject: [
 		{
+			code: `a {\n\t--a:\n;\n}`,
+			fixed: `a {\n\t--a:;\n}`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 2,
+			column: 6,
+		},
+		{
 			code: `a {\ncolor: pink\n;top: 0\n}`,
+			fixed: `a {\ncolor: pink;top: 0\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
 		},
 		{
 			code: `a {\ncolor: pink ;top: 0\n}`,
+			fixed: `a {\ncolor: pink;top: 0\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
@@ -214,18 +284,21 @@ testRule({
 		{
 			code: `a {\r\ncolor: pink ;top: 0\r\n}`,
 			description: `CRLF`,
+			fixed: `a {\r\ncolor: pink;top: 0\r\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
 		},
 		{
 			code: `a {\ncolor: pink  ;top: 0\n}`,
+			fixed: `a {\ncolor: pink;top: 0\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 13,
 		},
 		{
 			code: `a {\ncolor: pink\t;top: 0\n}`,
+			fixed: `a {\ncolor: pink;top: 0\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
@@ -233,9 +306,26 @@ testRule({
 		{
 			code: `a {\r\ncolor: pink\t;top: 0\r\n}`,
 			description: `CRLF`,
+			fixed: `a {\r\ncolor: pink;top: 0\r\n}`,
 			message: messages.rejectedBeforeMultiLine(),
 			line: 2,
 			column: 12,
+		},
+		{
+			code: `a {\ncolor: pink/*comment*/\n;top: 0\n}`,
+			fixed: `a {\ncolor: pink/*comment*/;top: 0\n}`,
+			description: `comment`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 2,
+			column: 23,
+		},
+		{
+			code: `a {\ncolor: pink/*comment*/ ;top: 0\n}`,
+			fixed: `a {\ncolor: pink/*comment*/;top: 0\n}`,
+			description: `comment`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 2,
+			column: 23,
 		},
 	],
 })

--- a/lib/rules/declaration-block-semicolon-newline-before/index.test.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.test.js
@@ -8,6 +8,12 @@ testRule({
 
 	accept: [
 		{
+			code: `a {--a:\n;}`,
+		},
+		{
+			code: `a {\n\t--a:\n;\n}`,
+		},
+		{
 			code: `color: pink\n;`,
 			description: `declaration on root`,
 		},
@@ -73,6 +79,9 @@ testRule({
 	config: [`always-multi-line`],
 
 	accept: [
+		{
+			code: `a {\n\t--a:\n;\n}`,
+		},
 		{
 			code: `color: pink\n;`,
 			description: `declaration on root`,
@@ -153,6 +162,12 @@ testRule({
 		{
 			code: `color: pink;`,
 			description: `declaration on root`,
+		},
+		{
+			code: `a {\n\t--a:;\n}`,
+		},
+		{
+			code: `a {\n\t--a: ;\n}`,
 		},
 		{
 			code: `a {\ncolor: pink;\n}`,

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -3,7 +3,10 @@ import stylelint from "stylelint"
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { declarationColonSpaceChecker } from "../../utils/declarationColonSpaceChecker/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
+import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { isCustomProperty } from "../../utils/isCustomProperty/index.js"
+import { setDeclarationValue } from "../../utils/setDeclarationValue/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -52,11 +55,21 @@ function rule (primary) {
 				if (primary.startsWith(`always`)) {
 					decl.raws.between = between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, `: `)
 
+					// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50
+					if (isCustomProperty(decl.prop) && (/^\s*$/).test(getDeclarationValue(decl))) {
+						setDeclarationValue(decl, ``)
+					}
+
 					return true
 				}
 
 				if (primary === `never`) {
 					decl.raws.between = between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, `:`)
+
+					// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50
+					if (isCustomProperty(decl.prop) && (/^\s*$/).test(getDeclarationValue(decl))) {
+						setDeclarationValue(decl, ``)
+					}
 
 					return true
 				}

--- a/lib/rules/declaration-colon-space-after/index.test.js
+++ b/lib/rules/declaration-colon-space-after/index.test.js
@@ -8,6 +8,14 @@ testRule({
 
 	accept: [
 		{
+			code: `a { --a: ; }`,
+			description: `space only empty custom property value after`,
+		},
+		{
+			code: `a { --a: ; color: red; }`,
+			description: `space only empty custom property value after with other declarations`,
+		},
+		{
 			code: `a { color: pink }`,
 			description: `space only after`,
 		},
@@ -38,6 +46,46 @@ testRule({
 	],
 
 	reject: [
+		{
+			code: `a { --a:; }`,
+			fixed: `a { --a: ; }`,
+			description: `no space empty custom property value after`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 9,
+		},
+		{
+			code: `a { --a:  ; }`,
+			fixed: `a { --a: ; }`,
+			description: `two spaces empty custom property value after`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 9,
+		},
+		{
+			code: `a {\n\t--a:;\n}`,
+			fixed: `a {\n\t--a: ;\n}`,
+			description: `no space empty custom property value after`,
+			message: messages.expectedAfter(),
+			line: 2,
+			column: 6,
+		},
+		{
+			code: `a {\n\t--a:  ;\n}`,
+			fixed: `a {\n\t--a: ;\n}`,
+			description: `two spaces empty custom property value after`,
+			message: messages.expectedAfter(),
+			line: 2,
+			column: 6,
+		},
+		{
+			code: `a {\n\t--a:\n\t;\n}`,
+			fixed: `a {\n\t--a: ;\n}`,
+			description: `multi-line empty custom property value after`,
+			message: messages.expectedAfter(),
+			line: 2,
+			column: 6,
+		},
 		{
 			code: `a { color :pink; }`,
 			fixed: `a { color : pink; }`,
@@ -103,6 +151,10 @@ testRule({
 
 	accept: [
 		{
+			code: `a { --a:; color:red; }`,
+			description: `no space empty custom property value after`,
+		},
+		{
 			code: `a { color:pink }`,
 			description: `no space before and after`,
 		},
@@ -125,6 +177,14 @@ testRule({
 	],
 
 	reject: [
+		{
+			code: `a { --a: ; color:red; }`,
+			fixed: `a { --a:; color:red; }`,
+			description: `spaced empty custom property value after`,
+			message: messages.rejectedAfter(),
+			line: 1,
+			column: 9,
+		},
 		{
 			code: `a { color : pink; }`,
 			fixed: `a { color :pink; }`,
@@ -182,6 +242,14 @@ testRule({
 
 	accept: [
 		{
+			code: `a { --a: ; color: red; }`,
+			description: `space only empty custom property value after single-line with other declarations`,
+		},
+		{
+			code: `a { --a: ; }`,
+			description: `space only empty custom property value after single-line`,
+		},
+		{
 			code: `a { color: pink }`,
 			description: `space only after single-line`,
 		},
@@ -204,6 +272,30 @@ testRule({
 	],
 
 	reject: [
+		{
+			code: `a { --a:; }`,
+			fixed: `a { --a: ; }`,
+			description: `no space empty custom property value after single-line`,
+			message: messages.expectedAfterSingleLine(),
+			line: 1,
+			column: 9,
+		},
+		{
+			code: `a { --a:  ; }`,
+			fixed: `a { --a: ; }`,
+			description: `two spaces empty custom property value after single-line`,
+			message: messages.expectedAfterSingleLine(),
+			line: 1,
+			column: 9,
+		},
+		{
+			code: `a { --a:  ; color: red; }`,
+			fixed: `a { --a: ; color: red; }`,
+			description: `two spaces empty custom property value after single-line with other declarations`,
+			message: messages.expectedAfterSingleLine(),
+			line: 1,
+			column: 9,
+		},
 		{
 			code: `a { color :pink; }`,
 			fixed: `a { color : pink; }`,

--- a/lib/rules/declaration-colon-space-after/integration.test.js
+++ b/lib/rules/declaration-colon-space-after/integration.test.js
@@ -1,0 +1,121 @@
+import { messages as declarationBlockSemicolonNewlineBeforeMessages } from "../declaration-block-semicolon-newline-before/index.js"
+import { messages as declarationBlockSemicolonSpaceBeforeMessages } from "../declaration-block-semicolon-space-before/index.js"
+
+import { messages, ruleName } from "./index.js"
+
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
+
+testRule({
+	ruleName,
+	config: [`always-single-line`],
+	extraRules: {
+		"@stylistic/declaration-block-semicolon-newline-before": `never-multi-line`,
+		"@stylistic/declaration-block-semicolon-space-before": `never`,
+	},
+
+	accept: [
+		{
+			code: `
+				a {
+					gap:
+						0
+						2em;
+					--foo: ;
+					color: red;
+					--bar: ;
+				}`,
+		},
+	],
+
+	reject: [
+		{
+			code: `
+				a {
+					color:red ;
+					gap:
+						0
+						2em
+					;
+					--foo: ;
+					--bar:;
+					--baz:          ;
+				}`,
+
+			fixed: `
+				a {
+					color: red;
+					gap:
+						0
+						2em;
+					--foo: ;
+					--bar: ;
+					--baz: ;
+				}`,
+			warnings: [
+				{
+					line: 2,
+					column: 8,
+					endLine: 2,
+					endColumn: 9,
+					message: messages.expectedAfterSingleLine(),
+				},
+				{
+					line: 8,
+					column: 8,
+					endLine: 8,
+					endColumn: 9,
+					message: messages.expectedAfterSingleLine(),
+				},
+				{
+					line: 9,
+					column: 8,
+					endLine: 9,
+					endColumn: 9,
+					message: messages.expectedAfterSingleLine(),
+				},
+				{
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 12,
+					message: declarationBlockSemicolonNewlineBeforeMessages.rejectedBeforeMultiLine(),
+				},
+				{
+					line: 6,
+					column: 1,
+					endLine: 6,
+					endColumn: 2,
+					message: declarationBlockSemicolonNewlineBeforeMessages.rejectedBeforeMultiLine(),
+				},
+				{
+					line: 9,
+					column: 17,
+					endLine: 9,
+					endColumn: 18,
+					message: declarationBlockSemicolonNewlineBeforeMessages.rejectedBeforeMultiLine(),
+				},
+				{
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 12,
+					message: declarationBlockSemicolonSpaceBeforeMessages.rejectedBefore(),
+				},
+				{
+					line: 6,
+					column: 1,
+					endLine: 6,
+					endColumn: 2,
+					message: declarationBlockSemicolonSpaceBeforeMessages.rejectedBefore(),
+				},
+				{
+					line: 9,
+					column: 17,
+					endLine: 9,
+					endColumn: 18,
+					message: declarationBlockSemicolonSpaceBeforeMessages.rejectedBefore(),
+				},
+			],
+		},
+	],
+})

--- a/lib/utils/declarationColonSpaceChecker/index.js
+++ b/lib/utils/declarationColonSpaceChecker/index.js
@@ -1,6 +1,7 @@
 import stylelint from "stylelint"
 
 import { declarationValueIndex } from "../declarationValueIndex/index.js"
+import { isCustomProperty } from "../isCustomProperty/index.js"
 import { isStandardSyntaxDeclaration } from "../isStandardSyntaxDeclaration/index.js"
 
 let { utils: { report } } = stylelint
@@ -27,9 +28,15 @@ export function declarationColonSpaceChecker (opts) {
 		// Get the raw prop, and only the prop
 		let endOfPropIndex = declarationValueIndex(decl) + (decl.raws.between || ``).length - 1
 
-		// The extra characters tacked onto the end ensure that there is a character to check
-		// after the colon. Otherwise, with `background:pink` the character after the
+		// The extra characters tacked onto the end ensure that there is a character to check after the colon.
+		// Otherwise, with `background:pink` the character after the colon would not exist, making it impossible for the location checker to validate the whitespace.
 		let propPlusColon = `${decl.toString().slice(0, endOfPropIndex)}xxx`
+
+		// For custom properties with whitespace-only values, PostCSS puts the whitespace in `decl.value` instead of `decl.raws.between`.
+		// We need to preserve the whitespace after the colon so the checker can validate it correctly.
+		if (isCustomProperty(decl.prop) && decl.value !== `` && (/^\s+$/).test(decl.value)) {
+			propPlusColon = `${decl.toString().slice(0, endOfPropIndex)}${decl.value}x`
+		}
 
 		for (let i = 0, l = propPlusColon.length; i < l; i += 1) {
 			if (propPlusColon[i] !== `:`) continue


### PR DESCRIPTION
Fixes #50

In addition to the existing exception in the `declaration-block-semicolon-space-before` rule, similar exceptions have been added to the `declaration-block-semicolon-newline-before` and `declaration-block-semicolon-space-before` rules.

Live [demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcICGACYAdAdugLpANhAE7xExQoDcWuA5kgA7w064AMLuATDALYvVsOALTCAZhAjwqLUQCMkJQbnlIAXtJRbt2wQF8QAGhBiAlvhgA5JLziIYADxsMLAOjABnD0fARMZ2gQQDCF0EBcAV1pTTA8w6QBtMIABDxwAT3xTNNMwAHo0zJgszBFI6OwQAF1DThAiCIs4hDROVhBUjKyc-NgwfEUkHFM-YTlCMABrYQ8+XIhCTGFMGAB3EpgxmAkyeJQwlYA3GCJhXkbh4Q2w2tD2zszs4d6YfsHh0fGIKZm5glGPAwkGBNnJtsQYHsDjBjkQbm0UoVus88n0BkQhiMlv8loDgZskGIcCcoch8KskOkPDMYrQLFcYpCQCw9FhWZgfJB-KZaAAxYi8IZBVxI4oxHBEMCuABWHj8PlgDG8iBCOkRXSeuQKXTFpWE5RipIAFjgcEr4Hk8pBYIQkFBXNEcEaInJ3BBeNqiiUREjNflRd6ZhqenkcIoHWo8mQxB48kaYHbY2YHHk+AwMsIwBE0u79UQIAwThl4Zg1SAA+LSQNiWkwmyQHogA)… but this is just a duplicate of the integration test.