### PR TITLE
Fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/stylelint-stylistic/stylelint-stylistic.git"
+		"url": "git+https://github.com/stylelint-stylistic/stylelint-stylistic.git"
 	},
 	"type": "module",
 	"exports": "./lib/index.js",


### PR DESCRIPTION
## Summary

- update the package repository URL from the deprecated `git://` protocol to the npm-friendly `git+https` form
- keep the existing homepage and bugs metadata unchanged

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/stylelint-stylistic/stylelint-stylistic.git') process.exit(1); console.log(p.repository.url)"`
- `git diff --check`

I also tried `npm --cache /private/tmp/codex-npm-cache pack --dry-run --ignore-scripts --json`, but this environment is on Node `v25.5.0` and the repo's `devEngines.runtime.version` requires `>=26.2`, so npm stopped before packing with `EBADDEVENGINES`.
