### PR TITLE
Add the `ignoreFunctions` option to the `function-comma-newline-after` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ## [Unreleased]
 
+### Added
+
+- The `ignoreFunctions` secondary option for the `function-comma-newline-after` rule (see [#78](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/78)).
+
 ## [5.2.1] — 2026–07–01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Added
 
-- The `ignoreFunctions` secondary option for the `function-comma-newline-after` rule (see [#78](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/78)).
+- The `function-comma-newline-after` rule now has an additional `ignoreFunctions` option (see [#78](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/78)).
 
 ## [5.2.1] — 2026–07–01
 

--- a/lib/rules/function-comma-newline-after/README.md
+++ b/lib/rules/function-comma-newline-after/README.md
@@ -105,7 +105,7 @@ a {
 
 Ignore the commas of specified functions, including the commas of any function nested within them.
 
-Function names are matched as written, so use a case-insensitive regex (e.g. `"/^translate$/i"`) to also match other letter cases.
+Function names are matched case-sensitively as written. Use a case-insensitive regex (e.g. `"/^translate$/i"`) to match other letter cases. This is important for custom functions like `--my-function()`, whose names are case-sensitive.
 
 For example, with `"always"`.
 

--- a/lib/rules/function-comma-newline-after/README.md
+++ b/lib/rules/function-comma-newline-after/README.md
@@ -98,3 +98,43 @@ a {
     ,1)
 }
 ```
+
+## Optional secondary options
+
+### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+
+Ignore the commas of specified functions, including the commas of any function nested within them.
+
+Function names are matched as written, so use a case-insensitive regex (e.g. `"/^translate$/i"`) to also match other letter cases.
+
+For example, with `"always"`.
+
+Given:
+
+```json
+["translate", "/^rgba?$/"]
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+a { transform: translate(1,1) }
+```
+
+```css
+a { color: rgba(0,0,0,0.5) }
+```
+
+```css
+a { transform: translate(min(1px,2px),1) }
+```
+
+The following patterns are still considered problems:
+
+```css
+a { transform: scale(1,1) }
+```
+
+```css
+a { background: linear-gradient(45deg,rgba(0,0,0,0.5)) }
+```

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -4,6 +4,7 @@ import { addNamespace } from "../../utils/addNamespace/index.js"
 import { functionCommaSpaceChecker } from "../../utils/functionCommaSpaceChecker/index.js"
 import { functionCommaSpaceFix } from "../../utils/functionCommaSpaceFix/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { isRegExp, isString } from "../../utils/validateTypes/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -27,14 +28,25 @@ export let meta = {
  * Requires a newline or disallows whitespace after the commas of functions.
  * @type {import('stylelint').Rule}
  */
-function rule (primary, _secondaryOptions, context) {
+function rule (primary, secondaryOptions, context) {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
-		let validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [`always`, `always-multi-line`, `never-multi-line`],
-		})
+		let validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [`always`, `always-multi-line`, `never-multi-line`],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignoreFunctions: [isString, isRegExp],
+				},
+				optional: true,
+			},
+		)
 
 		if (!validOptions) return
 
@@ -43,6 +55,7 @@ function rule (primary, _secondaryOptions, context) {
 			result,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
+			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,
 				index,

--- a/lib/rules/function-comma-newline-after/index.test.js
+++ b/lib/rules/function-comma-newline-after/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -450,23 +450,39 @@ testRule({
 			description: `function nested inside an ignored function`,
 		},
 		{
-			code: `a { transform: scale(1,\n1); }`,
+			code: `
+				a {
+					transform: scale(1,
+					1);
+				}
+			`,
 			description: `not ignored function without problems`,
 		},
 	],
 
 	reject: [
 		{
-			code: `a { transform: scale(1,1); }`,
-			fixed: `a { transform: scale(1,\n1); }`,
+			code: `
+				a { transform: scale(1,1); }
+			`,
+			fixed: `
+				a { transform: scale(1,
+				1); }
+			`,
 			description: `not ignored function`,
 			message: messages.expectedAfter(),
 			line: 1,
 			column: 23,
 		},
 		{
-			code: `a { background: linear-gradient(45deg,red,blue); }`,
-			fixed: `a { background: linear-gradient(45deg,\nred,\nblue); }`,
+			code: `
+				a { background: linear-gradient(45deg,red,blue); }
+			`,
+			fixed: `
+				a { background: linear-gradient(45deg,
+				red,
+				blue); }
+			`,
 			description: `not ignored function with two problems`,
 			warnings: [
 				{
@@ -482,8 +498,13 @@ testRule({
 			],
 		},
 		{
-			code: `a { background: linear-gradient(45deg,rgba(0,0,0,1)); }`,
-			fixed: `a { background: linear-gradient(45deg,\nrgba(0,0,0,1)); }`,
+			code: `
+				a { background: linear-gradient(45deg,rgba(0,0,0,1)); }
+			`,
+			fixed: `
+				a { background: linear-gradient(45deg,
+				rgba(0,0,0,1)); }
+			`,
 			description: `ignored function nested inside a not ignored one`,
 			message: messages.expectedAfter(),
 			line: 1,
@@ -498,19 +519,34 @@ testRule({
 
 	accept: [
 		{
-			code: `a { transform: translate(1\n, 1); }`,
+			code: `
+				a {
+					transform: translate(1
+					, 1);
+				}
+			`,
 			description: `ignored function`,
 		},
 	],
 
 	reject: [
 		{
-			code: `a { transform: scale(1\n, 1); }`,
-			fixed: `a { transform: scale(1\n,1); }`,
+			code: `
+				a {
+					transform: scale(1
+					, 1);
+				}
+			`,
+			fixed: `
+				a {
+					transform: scale(1
+					,1);
+				}
+			`,
 			description: `not ignored function`,
 			message: messages.rejectedAfterMultiLine(),
-			line: 2,
-			column: 1,
+			line: 3,
+			column: 2,
 		},
 	],
 })

--- a/lib/rules/function-comma-newline-after/index.test.js
+++ b/lib/rules/function-comma-newline-after/index.test.js
@@ -423,3 +423,94 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`, { ignoreFunctions: [`translate`, `/^rgba?$/`, /^hsl$/u] }],
+
+	accept: [
+		{
+			code: `a { transform: translate(1,1); }`,
+			description: `ignored function given as a string`,
+		},
+		{
+			code: `a { color: rgb(0,0,0); }`,
+			description: `ignored function given as a regex string`,
+		},
+		{
+			code: `a { color: rgba(0,0,0,1); }`,
+			description: `ignored function given as a regex string`,
+		},
+		{
+			code: `a { color: hsl(0,0%,0%); }`,
+			description: `ignored function given as a regex`,
+		},
+		{
+			code: `a { transform: translate(min(1px,2px),1); }`,
+			description: `function nested inside an ignored function`,
+		},
+		{
+			code: `a { transform: scale(1,\n1); }`,
+			description: `not ignored function without problems`,
+		},
+	],
+
+	reject: [
+		{
+			code: `a { transform: scale(1,1); }`,
+			fixed: `a { transform: scale(1,\n1); }`,
+			description: `not ignored function`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 23,
+		},
+		{
+			code: `a { background: linear-gradient(45deg,red,blue); }`,
+			fixed: `a { background: linear-gradient(45deg,\nred,\nblue); }`,
+			description: `not ignored function with two problems`,
+			warnings: [
+				{
+					message: messages.expectedAfter(),
+					line: 1,
+					column: 38,
+				},
+				{
+					message: messages.expectedAfter(),
+					line: 1,
+					column: 42,
+				},
+			],
+		},
+		{
+			code: `a { background: linear-gradient(45deg,rgba(0,0,0,1)); }`,
+			fixed: `a { background: linear-gradient(45deg,\nrgba(0,0,0,1)); }`,
+			description: `ignored function nested inside a not ignored one`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 38,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never-multi-line`, { ignoreFunctions: [`translate`] }],
+
+	accept: [
+		{
+			code: `a { transform: translate(1\n, 1); }`,
+			description: `ignored function`,
+		},
+	],
+
+	reject: [
+		{
+			code: `a { transform: scale(1\n, 1); }`,
+			fixed: `a { transform: scale(1\n,1); }`,
+			description: `not ignored function`,
+			message: messages.rejectedAfterMultiLine(),
+			line: 2,
+			column: 1,
+		},
+	],
+})

--- a/lib/utils/functionCommaSpaceChecker/index.js
+++ b/lib/utils/functionCommaSpaceChecker/index.js
@@ -4,6 +4,7 @@ import stylelint from "stylelint"
 import { declarationValueIndex } from "../declarationValueIndex/index.js"
 import { getDeclarationValue } from "../getDeclarationValue/index.js"
 import { isStandardSyntaxFunction } from "../isStandardSyntaxFunction/index.js"
+import { optionsMatches } from "../optionsMatches/index.js"
 import { setDeclarationValue } from "../setDeclarationValue/index.js"
 
 const COMMENT_PATTERN = / *\/(?:\*.*?\*\/(?!\S)|\/.*)/u
@@ -25,6 +26,7 @@ let { utils: { report } } = stylelint
  *   fix: ((node: ValueParserDivNode, index: number, nodes: ValueParserNode[]) => boolean),
  *   result: import('stylelint').PostcssResult,
  *   checkedRuleName: string,
+ *   ignoreFunctions?: string | RegExp | Array<string | RegExp>,
  * }} opts - The options object
  */
 export function functionCommaSpaceChecker (opts) {
@@ -41,6 +43,9 @@ export function functionCommaSpaceChecker (opts) {
 
 			// Ignore `url()` arguments, which may contain data URIs or other funky stuff
 			if (valueNode.value.toLowerCase() === `url`) return
+
+			// Ignore functions listed in the `ignoreFunctions` option, including everything nested inside them
+			if (optionsMatches(opts, `ignoreFunctions`, valueNode.value)) return false
 
 			let argumentStrings = valueNode.nodes.map((node) => valueParser.stringify(node))
 


### PR DESCRIPTION
Resolves #78 

---

A couple of things to keep in mind:

1. Nesting. Not only is the function itself ignored, but everything inside it as well: `translate(min(1px,2px),1)` is treated as a single unit without line breaks. Otherwise, the option wouldn’t achieve the goal stated in the issue — “to keep short utility functions on a single line” — since the internal commas would still break the line.
2. Case sensitivity. Names are compared as written (as in the upstream `function-name-case` / `function-no-unknown`); for `TRANSLATE()`, the regex `/^translate$/i` is required. This is documented in the README.