### PR TITLE
Add the `ignoreFunctions` option to the `function-comma-space-before` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 - The `function-comma-newline-after` rule now has an additional `ignoreFunctions` option (see [#78](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/78)).
 - The `function-comma-newline-before` rule now has an additional `ignoreFunctions` option (see [#81](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/81)).
 - The `function-comma-space-after` rule now has an additional `ignoreFunctions` option (see [#82](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/82)).
+- The `function-comma-space-before` rule now has an additional `ignoreFunctions` option (see [#83](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/83)).
 
 ## [5.2.1] — 2026–07–01
 

--- a/lib/rules/function-comma-space-before/README.md
+++ b/lib/rules/function-comma-space-before/README.md
@@ -123,3 +123,43 @@ a {
     1)
 }
 ```
+
+## Optional secondary options
+
+### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+
+Ignore the commas of specified functions, including the commas of any function nested within them.
+
+Function names are matched case-sensitively as written. Use a case-insensitive regex (e.g. `"/^translate$/i"`) to match other letter cases. This is important for custom functions like `--my-function()`, whose names are case-sensitive.
+
+For example, with `"always"`.
+
+Given:
+
+```json
+["translate", "/^rgba?$/"]
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+a { transform: translate(1,1) }
+```
+
+```css
+a { color: rgba(0,0,0,0.5) }
+```
+
+```css
+a { transform: translate(min(1px,2px),1) }
+```
+
+The following patterns are still considered problems:
+
+```css
+a { transform: scale(1,1) }
+```
+
+```css
+a { background: linear-gradient(45deg,rgba(0,0,0,0.5)) }
+```

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -4,6 +4,7 @@ import { addNamespace } from "../../utils/addNamespace/index.js"
 import { functionCommaSpaceChecker } from "../../utils/functionCommaSpaceChecker/index.js"
 import { functionCommaSpaceFix } from "../../utils/functionCommaSpaceFix/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { isRegExp, isString } from "../../utils/validateTypes/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -28,14 +29,25 @@ export let meta = {
  * Requires a single space or disallows whitespace before the commas of functions.
  * @type {import('stylelint').Rule}
  */
-function rule (primary) {
+function rule (primary, secondaryOptions) {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
-		let validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [`always`, `never`, `always-single-line`, `never-single-line`],
-		})
+		let validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [`always`, `never`, `always-single-line`, `never-single-line`],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignoreFunctions: [isString, isRegExp],
+				},
+				optional: true,
+			},
+		)
 
 		if (!validOptions) return
 
@@ -44,6 +56,7 @@ function rule (primary) {
 			result,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
+			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,
 				index,

--- a/lib/rules/function-comma-space-before/index.test.js
+++ b/lib/rules/function-comma-space-before/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -377,6 +377,97 @@ testRule({
 		{
 			code: `$map: (key: value ,key2: value2)`,
 			description: `SCSS map`,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`always`, { ignoreFunctions: [`translate`, `/^rgba?$/`, /^hsl$/u] }],
+
+	accept: [
+		{
+			code: `a { transform: translate(1,1); }`,
+			description: `ignored function given as a string`,
+		},
+		{
+			code: `a { color: rgb(0,0,0); }`,
+			description: `ignored function given as a regex string`,
+		},
+		{
+			code: `a { color: rgba(0,0,0,1); }`,
+			description: `ignored function given as a regex string`,
+		},
+		{
+			code: `a { color: hsl(0,0%,0%); }`,
+			description: `ignored function given as a regex`,
+		},
+		{
+			code: `a { transform: translate(min(1px,2px),1); }`,
+			description: `function nested inside an ignored function`,
+		},
+		{
+			code: `a { transform: scale(1 ,1); }`,
+			description: `not ignored function without problems`,
+		},
+	],
+
+	reject: [
+		{
+			code: `a { transform: scale(1,1); }`,
+			fixed: `a { transform: scale(1 ,1); }`,
+			description: `not ignored function`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 23,
+		},
+		{
+			code: `a { background: linear-gradient(45deg,red,blue); }`,
+			fixed: `a { background: linear-gradient(45deg ,red ,blue); }`,
+			description: `not ignored function with two problems`,
+			warnings: [
+				{
+					message: messages.expectedBefore(),
+					line: 1,
+					column: 38,
+				},
+				{
+					message: messages.expectedBefore(),
+					line: 1,
+					column: 42,
+				},
+			],
+		},
+		{
+			code: `a { background: linear-gradient(45deg,rgba(0,0,0,1)); }`,
+			fixed: `a { background: linear-gradient(45deg ,rgba(0,0,0,1)); }`,
+			description: `ignored function nested inside a not ignored one`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 38,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`, { ignoreFunctions: [`translate`] }],
+
+	accept: [
+		{
+			code: `a { transform: translate(1 , 1); }`,
+			description: `ignored function`,
+		},
+	],
+
+	reject: [
+		{
+			code: `a { transform: scale(1 , 1); }`,
+			fixed: `a { transform: scale(1, 1); }`,
+			description: `not ignored function`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 24,
 		},
 	],
 })


### PR DESCRIPTION
Resolves #83

---

The last of the four `function-comma-*` rules, same option and same semantics as in #80, #84 and #85:

1. Nesting. Not only is the function itself ignored, but everything inside it as well: `translate(min(1px,2px),1)` is treated as a single unit.
2. Case sensitivity. Names are compared as written; for `TRANSLATE()`, the regex `/^translate$/i` is required. This is documented in the README.

The `ignoreFunctions` handling itself lives in the shared `functionCommaSpaceChecker` util, so this change only wires it up in the rule, documents it and covers it with tests.
