### PR TITLE
Preserve comments when fixing `block-opening-brace-space-before`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ## [Unreleased]
 
+### Fixed
+
+- The `block-opening-brace-space-before` rule no longer removes a comment standing between the selector and the opening brace when fixing (see [#63](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63)):
+	- a block comment is kept, and only the whitespace next to the brace changes, so such a stylesheet can now be autofixed without losing anything;
+	- an inline comment leaves the brace nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
+
 ## [5.3.0] — 2026–08–09
 
 ### Added

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -96,6 +96,13 @@ function rule (primary, secondaryOptions) {
 				index: source.length,
 				lineCheckStr: blockString(statement),
 				err: (m) => {
+					let between = statement.raws.between ?? ``
+					// Only the whitespace run right before the brace may be replaced, so that comments survive
+					let beforeWhitespace = between.replace(/\s*$/u, ``)
+					// An inline comment ends only with a line break, so the brace can never join its line,
+					// and neither option is satisfiable there: leave the code alone and let the warning stand
+					let endsWithInlineComment = (/\/\/[^\n]*$/u).test(beforeWhitespace.replaceAll(/\/\*[\s\S]*?\*\//gu, ``))
+
 					report({
 						message: m,
 						node: statement,
@@ -103,15 +110,17 @@ function rule (primary, secondaryOptions) {
 						endIndex: index,
 						result,
 						ruleName,
-						fix () {
-							if (primary.startsWith(`always`)) {
-								statement.raws.between = ` `
+						fix: endsWithInlineComment
+							? undefined
+							: () => {
+								if (primary.startsWith(`always`)) {
+									statement.raws.between = `${beforeWhitespace} `
 
-								return
-							}
+									return
+								}
 
-							if (primary.startsWith(`never`)) statement.raws.between = ``
-						},
+								if (primary.startsWith(`never`)) statement.raws.between = beforeWhitespace
+							},
 					})
 				},
 			})

--- a/lib/rules/block-opening-brace-space-before/index.test.js
+++ b/lib/rules/block-opening-brace-space-before/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -74,6 +74,32 @@ testRule({
 			message: messages.expectedBefore(),
 			line: 1,
 			column: 17,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63
+			description: `comment between the selector and the opening brace`,
+			code: `
+				.some-class /* v3+ */
+				{
+					color: green;
+				}
+			`,
+			fixed: `
+				.some-class /* v3+ */ {
+					color: green;
+				}
+			`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 22,
+		},
+		{
+			code: `.some-class /* v3+ */\r\n{ color: pink; }`,
+			fixed: `.some-class /* v3+ */ { color: pink; }`,
+			description: `CRLF with a comment before the opening brace`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 22,
 		},
 	],
 })
@@ -198,6 +224,24 @@ testRule({
 			message: messages.rejectedBefore(),
 			line: 1,
 			column: 16,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63
+			description: `comment between the selector and the opening brace`,
+			code: `
+				.some-class /* v3+ */
+				{
+					color: green;
+				}
+			`,
+			fixed: `
+				.some-class /* v3+ */{
+					color: green;
+				}
+			`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 22,
 		},
 	],
 })
@@ -539,6 +583,70 @@ testRule({
 			message: messages.rejectedBeforeMultiLine(),
 			line: 1,
 			column: 16,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63
+			description: `inline comment between the selector and the opening brace: the brace cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				.some-class // v3+
+				{
+					color: green;
+				}
+			`,
+			fixed: `
+				.some-class // v3+
+				{
+					color: green;
+				}
+			`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 19,
+		},
+		{
+			code: `.some-class // v3+\r\n{ color: pink; }`,
+			fixed: `.some-class // v3+\r\n{ color: pink; }`,
+			description: `CRLF, inline comment: the line ending survives untouched`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 19,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63
+			description: `inline comment between the selector and the opening brace: the brace cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				.some-class // v3+
+				{
+					color: green;
+				}
+			`,
+			fixed: `
+				.some-class // v3+
+				{
+					color: green;
+				}
+			`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 19,
 		},
 	],
 })

--- a/lib/rules/block-opening-brace-space-before/index.test.js
+++ b/lib/rules/block-opening-brace-space-before/index.test.js
@@ -94,6 +94,23 @@ testRule({
 			column: 22,
 		},
 		{
+			description: `comment between the selector and the opening brace with an URL`,
+			code: `
+				.some-class /* https://foo.bar/ */
+				{
+					color: green;
+				}
+			`,
+			fixed: `
+				.some-class /* https://foo.bar/ */ {
+					color: green;
+				}
+			`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 35,
+		},
+		{
 			code: `.some-class /* v3+ */\r\n{ color: pink; }`,
 			fixed: `.some-class /* v3+ */ { color: pink; }`,
 			description: `CRLF with a comment before the opening brace`,


### PR DESCRIPTION
The fix replaced the whole `raws.between`, so a comment sitting between the selector and the opening brace was thrown away along with the whitespace. Now only the whitespace run right before the brace is replaced, and everything in front of it stays as it was.

An inline `//` comment ends only with a line break, so the brace can never join its line and neither option is satisfiable there. The fix declines that case altogether: it leaves the code as it is and lets the warning stand, rather than counting the problem as fixed while the violation survives.

Closes #63.