### PR TITLE
Preserve comments and layout when fixing `declaration-block-trailing-semicolon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 - The `block-opening-brace-space-before` rule no longer removes a comment standing between the selector and the opening brace when fixing (see [#63](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/63)):
 	- a block comment is kept, and only the whitespace next to the brace changes, so such a stylesheet can now be autofixed without losing anything;
 	- an inline comment leaves the brace nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
+- The `declaration-block-trailing-semicolon` rule no longer damages the block when it adds a missing semicolon after a bodiless at-rule (see [#87](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/87)):
+	- a comment standing between the at-rule and the closing brace is kept;
+	- the closing brace stays on its own line instead of being pulled up to the at-rule;
+	- an inline comment leaves the semicolon nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -83,6 +83,14 @@ function rule (primary, secondaryOptions) {
 			const problemIndex = node.toString().trim().length - 1
 
 			if (message) {
+				let isBodilessAtRule = isAtRule(node)
+				// The whitespace before the closing brace is parsed into the at-rule, not into the block
+				let between = isBodilessAtRule ? node.raws.between ?? `` : ``
+				let beforeWhitespace = between.replace(/\s*$/u, ``)
+				// The semicolon goes right after `between`, so an inline comment there would swallow it
+				let endsWithInlineComment = (/\/\/[^\n]*$/u).test(beforeWhitespace.replaceAll(/\/\*[\s\S]*?\*\//gu, ``))
+				let isFixable = !(primary === `always` && isBodilessAtRule && endsWithInlineComment)
+
 				report({
 					message,
 					node,
@@ -90,17 +98,20 @@ function rule (primary, secondaryOptions) {
 					endIndex: problemIndex,
 					result,
 					ruleName,
-					fix () {
-						if (primary === `always` && !hasSemicolon) {
-							node.parent.raws.semicolon = true
+					fix: isFixable
+						? () => {
+							if (primary === `always` && !hasSemicolon) {
+								node.parent.raws.semicolon = true
 
-							if (isAtRule(node)) {
-								node.raws.between = ``
-								node.parent.raws.after = ` `
+								if (isBodilessAtRule) {
+									// Hand the trailing whitespace over to the block, so that the comment and the layout survive
+									node.raws.between = beforeWhitespace
+									node.parent.raws.after = between.slice(beforeWhitespace.length)
+								}
 							}
+							else if (primary === `never` && hasSemicolon) node.parent.raws.semicolon = false
 						}
-						else if (primary === `never` && hasSemicolon) node.parent.raws.semicolon = false
-					},
+						: undefined,
 				})
 			}
 		}

--- a/lib/rules/declaration-block-trailing-semicolon/index.test.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -161,6 +161,10 @@ testRule({
 			code: `a { @foo { color: pink; } }`,
 			description: `at-rule with decl block with trailing semicolon`,
 		},
+		{
+			code: `a { @includes foo /* keep me */; }`,
+			description: `at-rule with a comment and a trailing semicolon`,
+		},
 	],
 
 	reject: [
@@ -179,6 +183,80 @@ testRule({
 			message: messages.expected,
 			line: 1,
 			column: 22,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/87
+			code: `a { @includes foo /* keep me */ }`,
+			fixed: `a { @includes foo /* keep me */; }`,
+			description: `comment between the at-rule and the closing brace`,
+			message: messages.expected,
+			line: 1,
+			column: 31,
+		},
+		{
+			code: `a { @includes foo /* https://foo.bar/ */ }`,
+			fixed: `a { @includes foo /* https://foo.bar/ */; }`,
+			description: `comment between the at-rule and the closing brace with an URL`,
+			message: messages.expected,
+			line: 1,
+			column: 40,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/87
+			description: `multi-line block: the closing brace keeps its own line`,
+			code: `
+				a {
+					@includes foo
+				}
+			`,
+			fixed: `
+				a {
+					@includes foo;
+				}
+			`,
+			message: messages.expected,
+			line: 2,
+			column: 14,
+		},
+		{
+			description: `multi-line block with a comment`,
+			code: `
+				a {
+					@includes foo /* keep me */
+				}
+			`,
+			fixed: `
+				a {
+					@includes foo /* keep me */;
+				}
+			`,
+			message: messages.expected,
+			line: 2,
+			column: 28,
+		},
+		{
+			code: `a {\r\n\t@includes foo\r\n}`,
+			fixed: `a {\r\n\t@includes foo;\r\n}`,
+			description: `CRLF multi-line block`,
+			message: messages.expected,
+			line: 2,
+			column: 14,
+		},
+		{
+			description: `inline comment: the semicolon cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				a {
+					@includes foo // keep me
+				}
+			`,
+			fixed: `
+				a {
+					@includes foo // keep me
+				}
+			`,
+			message: messages.expected,
+			line: 2,
+			column: 25,
 		},
 	],
 })
@@ -215,6 +293,15 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 22,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/87
+			code: `a { @includes foo /* keep me */; }`,
+			fixed: `a { @includes foo /* keep me */ }`,
+			description: `comment between the at-rule and the semicolon`,
+			message: messages.rejected,
+			line: 1,
+			column: 31,
 		},
 	],
 })


### PR DESCRIPTION
Closes #87.

## The defect

Adding a missing semicolon after a bodiless at-rule ran two unconditional assignments:

```js
node.raws.between = ``
node.parent.raws.after = ` `
```

Neither string is whitespace-only.

For `a { @includes foo /* keep me */ }` the at-rule's `between` is `" /* keep me */ "`, so emptying it threw the comment away — the same class of defect as #63.

And the line break that puts the closing brace on its own line is parsed into the at-rule's `between` too, not into the block's `after`. Overwriting `after` with a single space therefore collapsed the block even where no comment was involved:

```scss
/* before the fix, `always` */
a {
	@includes foo
}
```

```scss
/* was rewritten to */
a {
	@includes foo; }
```

The declaration branch of the same rule never had this problem — only the at-rule branch reformatted the block.

## The change

The whitespace that trails the at-rule is handed over to the block instead of being replaced by a space invented on the spot:

```js
node.raws.between = beforeWhitespace
node.parent.raws.after = between.slice(beforeWhitespace.length)
```

Since `parent.raws.after` is always empty when a bodiless at-rule ends the block, this is a lossless move: `\r\n`, `\n\t`, a single space and “no whitespace at all” all survive as they were, and the comment in front of the whitespace is never touched.

An inline `//` comment ends only with a line break, and the semicolon is stringified right after `between`, so there is nowhere to put it that the comment would not swallow. That case is now declined outright — no `fix` callback is passed, the code is left as it is and the warning survives `--fix` instead of the problem being counted as fixed. This follows the resolution of #63 in #90. The `never` option is unaffected by the comment and stays fixable, since it only clears the semicolon flag.

## Tests

Nine new cases in `lib/rules/declaration-block-trailing-semicolon/index.test.js`: a block comment on one line and across two, a comment holding an URL (`/* https://foo.bar/ */`, which must not be mistaken for an inline comment), a multi-line block without any comment, a CRLF block, an inline comment left alone, an `accept` case for a commented at-rule that already has its semicolon, and a `never` case where the comment survives the semicolon's removal.

Against the unfixed rule exactly the six new `reject` cases fail, and every one of them fails on `fixed` alone — no `line` or `column` assertion moves, so the reported position is unchanged by this PR.

The test file is migrated to `autoStripIndent: true`, as `AGENTS.md` asks for the file being touched; its 27 existing cases pass unchanged.

Full suite: 120 files, 7192 passing. `make check`, `make lint` and `make prose-check` are clean.
