### PR TITLE
Stop `declaration-colon-space-before` from breaking code behind an inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- a comment standing between the at-rule and the closing brace is kept;
 	- the closing brace stays on its own line instead of being pulled up to the at-rule;
 	- an inline comment leaves the semicolon nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
+- The `declaration-colon-space-before` rule no longer rewrites a declaration whose property is followed by an inline comment into code that does not parse (see [#88](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88)). Such a comment ends only with a line break, so neither option can be satisfied without taking the colon into the comment, and the problem is now reported rather than fixed.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -23,6 +23,20 @@ export let meta = {
 }
 
 /**
+ * Gets everything the declaration's `between` holds in front of the colon.
+ * @param {import('postcss').Declaration} decl - The declaration to look at.
+ * @param {number} index - The index of the colon within the checked string.
+ * @returns {string} The part of `between` in front of the colon.
+ */
+function beforeColonString (decl, index) {
+	let between = decl.raws.between
+
+	if (between === null) throw new Error(`\`between\` must be present`)
+
+	return between.slice(0, index - declarationValueIndex(decl))
+}
+
+/**
  * Requires a single space or disallows whitespace before the colon of declarations.
  * @type {import('stylelint').Rule}
  */
@@ -42,20 +56,24 @@ function rule (primary) {
 			result,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
-			fix: (decl, index) => {
-				let colonIndex = index - declarationValueIndex(decl)
-				let between = decl.raws.between
+			isFixable: (decl, index) => {
+				// The colon stands right after this part, so an inline comment ending it would swallow the colon
+				let content = beforeColonString(decl, index).replace(/\s*$/u, ``)
 
-				if (between === null) throw new Error(`\`between\` must be present`)
+				return !(/\/\/[^\n]*$/u).test(content.replaceAll(/\/\*[\s\S]*?\*\//gu, ``))
+			},
+			fix: (decl, index) => {
+				let beforeColon = beforeColonString(decl, index)
+				let fromColon = decl.raws.between.slice(beforeColon.length)
 
 				if (primary === `always`) {
-					decl.raws.between = between.slice(0, colonIndex).replace(/\s*$/u, ` `) + between.slice(colonIndex)
+					decl.raws.between = beforeColon.replace(/\s*$/u, ` `) + fromColon
 
 					return true
 				}
 
 				if (primary === `never`) {
-					decl.raws.between = between.slice(0, colonIndex).replace(/\s*$/u, ``) + between.slice(colonIndex)
+					decl.raws.between = beforeColon.replace(/\s*$/u, ``) + fromColon
 
 					return true
 				}

--- a/lib/rules/declaration-colon-space-before/index.test.js
+++ b/lib/rules/declaration-colon-space-before/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -86,6 +86,15 @@ testRule({
 			line: 1,
 			column: 11,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88
+			code: `a { color/* keep // me */:/*comment*/pink; }`,
+			fixed: `a { color/* keep // me */ :/*comment*/pink; }`,
+			description: `comment holding a double slash`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 11,
+		},
 	],
 })
 
@@ -161,6 +170,87 @@ testRule({
 			code: `a { color/*comment*/ :/*comment*/pink; }`,
 			fixed: `a { color/*comment*/:/*comment*/pink; }`,
 			description: `comment`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 11,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88
+			code: `a { color/* keep // me */ :/*comment*/pink; }`,
+			fixed: `a { color/* keep // me */:/*comment*/pink; }`,
+			description: `comment holding a double slash`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 11,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88
+			description: `inline comment before the colon: the colon cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				a {
+					color // keep me
+					: pink;
+				}
+			`,
+			fixed: `
+				a {
+					color // keep me
+					: pink;
+				}
+			`,
+			message: messages.expectedBefore(),
+			line: 2,
+			column: 8,
+		},
+		{
+			code: `a { color // keep me\r\n: pink; }`,
+			fixed: `a { color // keep me\r\n: pink; }`,
+			description: `CRLF, inline comment: the line ending survives untouched`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 11,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88
+			description: `inline comment before the colon: the colon cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				a {
+					color // keep me
+					: pink;
+				}
+			`,
+			fixed: `
+				a {
+					color // keep me
+					: pink;
+				}
+			`,
+			message: messages.rejectedBefore(),
+			line: 2,
+			column: 8,
+		},
+		{
+			code: `a { color // keep me\r\n: pink; }`,
+			fixed: `a { color // keep me\r\n: pink; }`,
+			description: `CRLF, inline comment: the line ending survives untouched`,
 			message: messages.rejectedBefore(),
 			line: 1,
 			column: 11,

--- a/lib/utils/declarationColonSpaceChecker/index.js
+++ b/lib/utils/declarationColonSpaceChecker/index.js
@@ -17,6 +17,7 @@ let { utils: { report } } = stylelint
  *   root: import('postcss').Root,
  *   locationChecker: LocationChecker,
  *   fix: ((decl: import('postcss').Declaration, index: number) => boolean),
+ *   isFixable?: ((decl: import('postcss').Declaration, index: number) => boolean),
  *   result: import('stylelint').PostcssResult,
  *   checkedRuleName: string,
  * }} opts - The options object
@@ -42,6 +43,8 @@ export function declarationColonSpaceChecker (opts) {
 			if (propPlusColon[i] !== `:`) continue
 
 			const problemIndex = decl.prop.toString().length + 1
+			// A rule may know that this particular problem cannot be fixed without breaking the code
+			let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(decl, i))
 
 			opts.locationChecker({
 				source: propPlusColon,
@@ -55,7 +58,7 @@ export function declarationColonSpaceChecker (opts) {
 						endIndex: problemIndex,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: opts.fix ? () => opts.fix(decl, i) : undefined,
+						fix: isFixable ? () => opts.fix(decl, i) : undefined,
 					})
 				},
 			})


### PR DESCRIPTION
Closes #88.

## The defect

The fix trimmed the whitespace run in front of the colon with `\s*$`:

```js
decl.raws.between = between.slice(0, colonIndex).replace(/\s*$/u, ` `) + between.slice(colonIndex)
```

An SCSS `//` comment ends only with a line break, and `\s*$` counts that line break as ordinary trailing whitespace. Pulling the colon up to the comment's line took the colon and the value into the comment:

```scss
/* before the fix, `never` */
a {
	color // keep me
	: pink;
}
```

```scss
/* was rewritten to — the declaration is now inside the comment */
a {
	color // keep me: pink;
}
```

`always` did the same, one space wider. The output no longer parses (`Unknown word color`), and both options did it quietly, since passing a `fix` callback to `report` makes stylelint count the problem as fixed.

Block comments were never affected: `color /* keep me */ : pink` → `color /* keep me */: pink` is exactly right, and stays that way.

## The change

An inline comment leaves nowhere to put the colon that the comment would not swallow, so that case is declined outright: the code is left as it is and the warning stands, as in #90 and #91.

Expressing “decline” needed one change in the shared `declarationColonSpaceChecker`: it discards the boolean its `fix` callback returns, and stylelint suppresses the warning at the mere sight of a `fix` callback, so the decision has to be made before `report` is called. The checker therefore takes an optional `isFixable` predicate and passes `fix` on only when the rule agrees the problem can be fixed:

```js
let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(decl, i))
…
fix: isFixable ? () => opts.fix(decl, i) : undefined,
```

`declaration-colon-space-after` passes no predicate and is unaffected — its 51 test cases pass untouched. It does not have the defect either: the whitespace it trims stands between the colon and any comment that follows, so removing it can swallow nothing.

## Tests

Six new cases. Two of them, one per option, use a comment holding a double slash (`/* keep // me */`) to pin down that the check strips block comments before looking for an inline one — without that, a `//` inside a block comment would make the rule refuse to fix a perfectly fixable declaration. The other four live in two new `postcss-scss` groups: an inline comment across two lines and a CRLF one-liner, under `always` and under `never`, each asserting that the fixed output equals the input.

Against the unfixed rule exactly those four inline-comment cases fail, all of them on `fixed` alone — no `line` or `column` assertion moves, so the reported position is unchanged by this PR.

The test file is migrated to `autoStripIndent: true`, as `AGENTS.md` asks for the file being touched; its 24 existing cases pass unchanged.

Full suite: 120 files, 7198 passing. `make check`, `make lint` and `make prose-check` are clean.

## Noticed on the way

The test case with an URL in the comment, the one #90 was asked to add, cannot be written for this rule yet: it fails for an unrelated, pre-existing reason. `declarationColonSpaceChecker` takes the first `:` in the string, so a colon inside a comment is mistaken for the declaration's colon, and both colon rules then work on the wrong character. Filed as #92, out of scope here.
