### PR TITLE
Stop `block-opening-brace-newline-before` from breaking code behind an inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- the closing brace stays on its own line instead of being pulled up to the at-rule;
 	- an inline comment leaves the semicolon nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
 - The `declaration-colon-space-before` rule no longer rewrites a declaration whose property is followed by an inline comment into code that does not parse (see [#88](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88)). Such a comment ends only with a line break, so neither option can be satisfied without taking the colon into the comment, and the problem is now reported rather than fixed.
+- The `block-opening-brace-newline-before` rule no longer takes the opening brace into an inline comment standing in front of it (see [#89](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/89)). Such a comment ends only with a line break, so the `never-*` options cannot be satisfied without commenting the whole block out, and the problem is now reported rather than fixed.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -74,6 +74,13 @@ function rule (primary, _secondaryOptions, context) {
 				source,
 				index: source.length,
 				err: (m) => {
+					let between = typeof statement.raws.between === `string` ? statement.raws.between : ``
+					// The brace stands right after `between`, so an inline comment ending it would swallow the brace
+					let beforeWhitespace = between.replace(/\s*$/u, ``)
+					let endsWithInlineComment = (/\/\/[^\n]*$/u).test(beforeWhitespace.replaceAll(/\/\*[\s\S]*?\*\//gu, ``))
+					// `never` demands that the brace joins the comment's line, which nothing can grant
+					let isFixable = !(primary.startsWith(`never`) && endsWithInlineComment)
+
 					report({
 						message: m,
 						node: statement,
@@ -81,17 +88,19 @@ function rule (primary, _secondaryOptions, context) {
 						endIndex: index,
 						result,
 						ruleName,
-						fix () {
-							if (typeof statement.raws.between !== `string`) return
+						fix: isFixable
+							? () => {
+								if (typeof statement.raws.between !== `string`) return
 
-							if (primary.startsWith(`always`)) {
-								let spaceIndex = statement.raws.between.search(/\s+$/u)
+								if (primary.startsWith(`always`)) {
+									let spaceIndex = statement.raws.between.search(/\s+$/u)
 
-								if (spaceIndex >= 0) statement.raws.between = statement.raws.between.slice(0, spaceIndex) + context.newline + statement.raws.between.slice(spaceIndex)
-								else statement.raws.between += context.newline
+									if (spaceIndex >= 0) statement.raws.between = statement.raws.between.slice(0, spaceIndex) + context.newline + statement.raws.between.slice(spaceIndex)
+									else statement.raws.between += context.newline
+								}
+								else if (primary.startsWith(`never`)) statement.raws.between = statement.raws.between.replace(/\s*$/u, ``)
 							}
-							else if (primary.startsWith(`never`)) statement.raws.between = statement.raws.between.replace(/\s*$/u, ``)
-						},
+							: undefined,
 					})
 				},
 			})

--- a/lib/rules/block-opening-brace-newline-before/index.test.js
+++ b/lib/rules/block-opening-brace-newline-before/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -562,6 +562,107 @@ testRule({
 			message: messages.rejectedBeforeMultiLine(),
 			line: 1,
 			column: 16,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/89
+			description: `comment between the selector and the opening brace`,
+			code: `
+				.some-class /* v3+ */
+				{
+					color: green;
+					background: orange;
+				}
+			`,
+			fixed: `
+				.some-class /* v3+ */{
+					color: green;
+					background: orange;
+				}
+			`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 1,
+			column: 22,
+		},
+		{
+			description: `comment holding a double slash`,
+			code: `
+				.some-class /* keep // me */
+				{
+					color: green;
+					background: orange;
+				}
+			`,
+			fixed: `
+				.some-class /* keep // me */{
+					color: green;
+					background: orange;
+				}
+			`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 1,
+			column: 29,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never-multi-line`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/89
+			description: `inline comment between the selector and the opening brace: the brace cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				.some-class // v3+
+				{
+					color: green;
+					background: orange;
+				}
+			`,
+			fixed: `
+				.some-class // v3+
+				{
+					color: green;
+					background: orange;
+				}
+			`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 1,
+			column: 19,
+		},
+		{
+			code: `.some-class // v3+\r\n{ color: pink;\r\nbackground: orange; }`,
+			fixed: `.some-class // v3+\r\n{ color: pink;\r\nbackground: orange; }`,
+			description: `CRLF, inline comment: the line ending survives untouched`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 1,
+			column: 19,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never-single-line`],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/89
+			description: `inline comment between the selector and the opening brace: the brace cannot leave its line, so the code is left alone and the warning stands`,
+			code: `
+				.some-class // v3+
+				{ color: green; }
+			`,
+			fixed: `
+				.some-class // v3+
+				{ color: green; }
+			`,
+			message: messages.rejectedBeforeSingleLine(),
+			line: 1,
+			column: 19,
 		},
 	],
 })


### PR DESCRIPTION
Closes #89. Last of the cluster opened while fixing #63.

## The defect

The `never-*` fix trimmed the whitespace run in front of the brace:

```js
else if (primary.startsWith(`never`)) statement.raws.between = statement.raws.between.replace(/\s*$/u, ``)
```

An SCSS `//` comment ends only with a line break, and `\s*$` counts that line break as ordinary trailing whitespace. Pulling the brace up to the comment's line took the brace into the comment:

```scss
/* before the fix, `never-multi-line` */
.some-class // keep me
{
	color: green;
	background: orange;
}
```

```scss
/* was rewritten to — there is no block any more */
.some-class // keep me{
	color: green;
	background: orange;
}
```

The output does not parse (`Unknown word color`): the rule's block is gone and its declarations are left standing at the top level. `never-single-line` does the same. And it was all quiet, since passing a `fix` callback to `report` makes stylelint count the problem as fixed.

Block comments were never affected: `.some-class /* v3+ */` followed by a brace on the next line becomes `.some-class /* v3+ */{`, which is exactly right and stays that way.

## The change

An inline comment leaves nowhere to put the brace that the comment would not swallow, so that case is declined: no `fix` callback is passed, the code is left as it is and the warning stands. This is the same shape as #90, #91 and #93.

The decision is made before `report`, since stylelint suppresses the warning at the mere sight of a `fix` callback and ignores whatever the callback returns:

```js
let isFixable = !(primary.startsWith(`never`) && endsWithInlineComment)
```

The `always*` options are left alone deliberately. They insert a line break and delete nothing, and a selector ending in an inline comment already satisfies them — such input raises no warning at all, so the fix is never reached.

## Tests

Five new cases. Two in the existing `never-multi-line` group pin down what has to keep working: a block comment is preserved while the whitespace next to the brace goes, and a block comment holding a double slash (`/* keep // me */`) is still fixed rather than mistaken for an inline comment. Three more, in two new `postcss-scss` groups, assert that the fixed output equals the input: an inline comment before a multi-line block, the same over CRLF, and an inline comment before a single-line block under `never-single-line`.

Against the unfixed rule exactly those three inline-comment cases fail, all of them on `fixed` alone — no `line` or `column` assertion moves, so the reported position is unchanged by this PR.

The test file is migrated to `autoStripIndent: true`, as `AGENTS.md` asks for the file being touched; its 97 existing cases pass unchanged.

Full suite: 120 files, 7203 passing. `make check`, `make lint` and `make prose-check` are clean.

## After this

The check for “does this content end with an inline comment?” now has four call sites, identical in shape in all of them. Extracting it into a shared helper in `lib/utils/` is agreed to be a separate commit once the cluster is merged, so it is deliberately duplicated here.
