### PR TITLE
Search for the declaration's colon outside comments and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- an inline comment leaves the semicolon nowhere to go, since the comment ends only with a line break, so the problem is now reported rather than silently rewritten.
 - The `declaration-colon-space-before` rule no longer rewrites a declaration whose property is followed by an inline comment into code that does not parse (see [#88](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/88)). Such a comment ends only with a line break, so neither option can be satisfied without taking the colon into the comment, and the problem is now reported rather than fixed.
 - The `block-opening-brace-newline-before` rule no longer takes the opening brace into an inline comment standing in front of it (see [#89](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/89)). Such a comment ends only with a line break, so the `never-*` options cannot be satisfied without commenting the whole block out, and the problem is now reported rather than fixed.
+- The `declaration-colon-space-before` and `declaration-colon-space-after` rules now work on the declaration's own colon instead of the first colon they come across (see [#92](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92)). A comment standing in front of the colon may hold a colon of its own, an URL for one, and used to be taken for the declaration's:
+	- the fix no longer edits the text of such a comment;
+	- the `never` options no longer miss the real violation hiding behind it;
+	- the `always` options no longer report a declaration that is already correct.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/declaration-colon-space-after/index.test.js
+++ b/lib/rules/declaration-colon-space-after/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -42,6 +42,11 @@ testRule({
 		{
 			code: `a { background: url(data:application/font-woff;...); }`,
 			description: `data URI`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */: pink; }`,
+			description: `comment with an URL, space after the declaration's own colon`,
 		},
 	],
 
@@ -142,6 +147,23 @@ testRule({
 			line: 1,
 			column: 11,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */:pink; }`,
+			fixed: `a { color/* https://foo.bar/ */: pink; }`,
+			description: `comment with an URL`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 11,
+		},
+		{
+			code: `a { color/* a:b */:pink; }`,
+			fixed: `a { color/* a:b */: pink; }`,
+			description: `comment holding a colon`,
+			message: messages.expectedAfter(),
+			line: 1,
+			column: 11,
+		},
 	],
 })
 
@@ -173,6 +195,11 @@ testRule({
 		{
 			code: `$map: (key: value)`,
 			description: `SCSS map with no newlines`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */:pink; }`,
+			description: `comment with an URL, no space after the declaration's own colon`,
 		},
 	],
 
@@ -229,6 +256,23 @@ testRule({
 			code: `a { color/*comment*/ : /*comment*/pink; }`,
 			fixed: `a { color/*comment*/ :/*comment*/pink; }`,
 			description: `comment`,
+			message: messages.rejectedAfter(),
+			line: 1,
+			column: 11,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */: pink; }`,
+			fixed: `a { color/* https://foo.bar/ */:pink; }`,
+			description: `comment with an URL`,
+			message: messages.rejectedAfter(),
+			line: 1,
+			column: 11,
+		},
+		{
+			code: `a { color/* a:b */: pink; }`,
+			fixed: `a { color/* a:b */:pink; }`,
+			description: `comment holding a colon`,
 			message: messages.rejectedAfter(),
 			line: 1,
 			column: 11,

--- a/lib/rules/declaration-colon-space-before/index.test.js
+++ b/lib/rules/declaration-colon-space-before/index.test.js
@@ -35,6 +35,11 @@ testRule({
 			code: `a { background : url(data:application/font-woff;...); }`,
 			description: `data URI`,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */ :pink; }`,
+			description: `comment with an URL, space before the declaration's own colon`,
+		},
 	],
 
 	reject: [
@@ -95,6 +100,23 @@ testRule({
 			line: 1,
 			column: 11,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */:pink; }`,
+			fixed: `a { color/* https://foo.bar/ */ :pink; }`,
+			description: `comment with an URL`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 11,
+		},
+		{
+			code: `a { color/* a:b */:pink; }`,
+			fixed: `a { color/* a:b */ :pink; }`,
+			description: `comment holding a colon`,
+			message: messages.expectedBefore(),
+			line: 1,
+			column: 11,
+		},
 	],
 })
 
@@ -122,6 +144,11 @@ testRule({
 		{
 			code: `$map :(key :value)`,
 			description: `SCSS map with no newlines`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */:pink; }`,
+			description: `comment with an URL, no space before the declaration's own colon`,
 		},
 	],
 
@@ -179,6 +206,23 @@ testRule({
 			code: `a { color/* keep // me */ :/*comment*/pink; }`,
 			fixed: `a { color/* keep // me */:/*comment*/pink; }`,
 			description: `comment holding a double slash`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 11,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/92
+			code: `a { color/* https://foo.bar/ */ :pink; }`,
+			fixed: `a { color/* https://foo.bar/ */:pink; }`,
+			description: `comment with an URL`,
+			message: messages.rejectedBefore(),
+			line: 1,
+			column: 11,
+		},
+		{
+			code: `a { color/* a:b */ :pink; }`,
+			fixed: `a { color/* a:b */:pink; }`,
+			description: `comment holding a colon`,
 			message: messages.rejectedBefore(),
 			line: 1,
 			column: 11,

--- a/lib/utils/declarationColonSpaceChecker/index.js
+++ b/lib/utils/declarationColonSpaceChecker/index.js
@@ -1,3 +1,4 @@
+import styleSearch from "style-search"
 import stylelint from "stylelint"
 
 import { declarationValueIndex } from "../declarationValueIndex/index.js"
@@ -39,16 +40,17 @@ export function declarationColonSpaceChecker (opts) {
 			propPlusColon = `${decl.toString().slice(0, endOfPropIndex)}${decl.value}x`
 		}
 
-		for (let i = 0, l = propPlusColon.length; i < l; i += 1) {
-			if (propPlusColon[i] !== `:`) continue
-
+		// The declaration's own colon is the first one outside comments and strings.
+		// A comment in front of it may hold a colon of its own, an URL for one, and taking that
+		// one instead leaves the real problem unseen and sends the fix into the comment's text.
+		styleSearch({ source: propPlusColon, target: `:`, once: true }, ({ startIndex }) => {
 			const problemIndex = decl.prop.toString().length + 1
 			// A rule may know that this particular problem cannot be fixed without breaking the code
-			let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(decl, i))
+			let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(decl, startIndex))
 
 			opts.locationChecker({
 				source: propPlusColon,
-				index: i,
+				index: startIndex,
 				lineCheckStr: decl.value,
 				err: (message) => {
 					report({
@@ -58,11 +60,10 @@ export function declarationColonSpaceChecker (opts) {
 						endIndex: problemIndex,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: isFixable ? () => opts.fix(decl, i) : undefined,
+						fix: isFixable ? () => opts.fix(decl, startIndex) : undefined,
 					})
 				},
 			})
-			break
-		}
+		})
 	})
 }


### PR DESCRIPTION
Closes #92.

## The defect

`declarationColonSpaceChecker` looked for the declaration's colon by hand:

```js
for (let i = 0, l = propPlusColon.length; i < l; i += 1) {
	if (propPlusColon[i] !== `:`) continue
	…
	break
}
```

A comment standing in front of the colon may hold a colon of its own — every URL does, and a bare `/* a:b */` will do just as well — and the loop stopped there. From that point both colon rules worked on the wrong character, in three different ways:

```css
/* declaration-colon-space-before: "always" — a declaration that is already correct */
a { color/* https://foo.bar/ */ :pink; }   /* was reported */

/* declaration-colon-space-before: "always" — the fix goes into the comment */
a { color/* https://foo.bar/ */:pink; }    /* became a { color/* https ://foo.bar/ */:pink; } */

/* declaration-colon-space-before: "never" — the real violation is invisible */
a { color/* https://foo.bar/ */ :pink; }   /* was not reported at all */
```

`declaration-colon-space-after` did the same, one character over: `/* https: //foo.bar/ */`.

The fix case is the nastiest of the three, because `--fix` never converges. The warning is reported at the declaration's colon, since the reported index comes from the property's length, while the fix acts on the comment's colon — so every run eats one more space into the comment and the warning stays.

## The change

The scan goes through `style-search`, which is already how the sibling checkers in this repository find the characters they care about — `mediaFeatureColonSpaceChecker` looks for exactly the same colon that way. It walks past comments and strings on its own, and `once` stops it at the first colon outside them:

```js
styleSearch({ source: propPlusColon, target: `:`, once: true }, ({ startIndex }) => { … })
```

Nothing else moves. The reported position is unchanged, and so is the index handed to the rules' `fix` callbacks — it is simply the right colon now. In particular the `isFixable` predicate added in #93 still declines the same inline-comment case it declined before.

## Tests

Twelve new cases, six per rule, covering all three symptoms under both options: an `accept` case for a declaration that is already correct behind such a comment, a `reject` case pinning the fixed output, and a `reject` case for the violation that used to go unreported. Both an URL and a bare `/* a:b */` are used, so the point does not rest on URLs alone.

Against the unfixed checker exactly those ten of the twelve fail — the two `never` `accept` cases pass before and after, and are there to make sure the change does not start over-reporting.

`declaration-colon-space-after`'s test file is migrated to `autoStripIndent: true`, as `AGENTS.md` asks for the file being touched; its existing cases pass unchanged, as do `declaration-colon-space-before`'s.

Full suite: 121 files, 7228 passing. `make check`, `make lint` and `make prose-check` are clean.
