### PR TITLE
Stop `selector-combinator-space-before` from reporting a combinator behind a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- the fix no longer edits the text of such a comment;
 	- the `never` options no longer miss the real violation hiding behind it;
 	- the `always` options no longer report a declaration that is already correct.
+- The `selector-combinator-space-before` rule no longer reports a combinator that opens a selector when a comment stands in front of it (see [#66](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66)). A selector list broken over several lines and interleaved with comments is now left alone instead of being pulled onto one line. Two more things follow for this rule and for `selector-combinator-space-after` alike, whenever the selector holds an inline comment:
+	- the reported position no longer drifts two characters per comment, so it points at the combinator itself;
+	- the fix now reaches the output instead of being silently discarded, and the comment keeps its `//` spelling.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/selector-combinator-space-after/index.test.js
+++ b/lib/rules/selector-combinator-space-after/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -553,6 +553,30 @@ testRule({
 		{
 			code: `a ~, b {}`,
 			description: `scss trailing combinator`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `selector list interleaved with an inline comment: the fix reaches the output`,
+			code: `
+				.a,
+				// A comment.
+				.b >.c {
+					color: green;
+				}
+			`,
+			fixed: `
+				.a,
+				// A comment.
+				.b > .c {
+					color: green;
+				}
+			`,
+			message: messages.expectedAfter(`>`),
+			line: 3,
+			column: 4,
 		},
 	],
 })

--- a/lib/rules/selector-combinator-space-before/index.test.js
+++ b/lib/rules/selector-combinator-space-before/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -146,6 +146,15 @@ testRule({
 		{
 			code: `namespace|type#id > .foo {}, space|customtype#id_withunder > a {}`,
 			description: `qualified ID with namespace selector list`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `selector list whose second selector begins with a comment and a combinator`,
+			code: `
+				.a,
+				/* A comment. */
+				+ .b {}
+			`,
 		},
 	],
 
@@ -326,6 +335,15 @@ testRule({
 			code: `namespace|type#id> .foo {}`,
 			description: `qualified ID with namespace`,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `selector list whose second selector begins with a comment and a combinator`,
+			code: `
+				.a,
+				/* A comment. */
+				+ .b {}
+			`,
+		},
 	],
 
 	reject: [
@@ -438,6 +456,15 @@ testRule({
 			code: `.a when (@size>=60) and (@size<102) {}`,
 			description: `ignore constructs`,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `selector list whose second selector begins with a comment and a combinator`,
+			code: `
+				.a,
+				/* A comment. */
+				+ .b {}
+			`,
+		},
 	],
 
 	reject: [
@@ -468,6 +495,21 @@ testRule({
 			code: `a {> /*comment*/ a,> /*comment*/ .b {}}`,
 			description: `scss nesting, comment and comma`,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `scss nesting, selector list interleaved with inline comments`,
+			code: `
+				.some_class {
+					.blue,
+					// There's a comment here.
+					+ .green,
+					// And another.
+					> .purple {
+						background: yellow;
+					}
+				}
+			`,
+		},
 	],
 
 	reject: [
@@ -478,6 +520,27 @@ testRule({
 			message: messages.expectedBefore(`>`),
 			line: 1,
 			column: 36,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `selector list interleaved with an inline comment: the fix reaches the output`,
+			code: `
+				.a,
+				// A comment.
+				.b>.c {
+					color: green;
+				}
+			`,
+			fixed: `
+				.a,
+				// A comment.
+				.b >.c {
+					color: green;
+				}
+			`,
+			message: messages.expectedBefore(`>`),
+			line: 3,
+			column: 3,
 		},
 	],
 })
@@ -499,6 +562,21 @@ testRule({
 		{
 			code: `a { > /*comment*/ a, > /*commenttest*/ .b {}}`,
 			description: `scss nesting, comment and comma`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66
+			description: `scss nesting, selector list interleaved with inline comments`,
+			code: `
+				.some_class {
+					.blue,
+					// There's a comment here.
+					+ .green,
+					// And another.
+					> .purple {
+						background: yellow;
+					}
+				}
+			`,
 		},
 	],
 

--- a/lib/utils/selectorCombinatorSpaceChecker/index.js
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.js
@@ -12,6 +12,16 @@ let { utils: { report } } = stylelint
  */
 
 /**
+ * An inline comment of a selector, as both syntaxes spell it.
+ * @typedef {{
+ *   node: import('postcss-selector-parser').Comment,
+ *   value: string,
+ *   endIndex: number,
+ *   delta: number,
+ * }} InlineComment
+ */
+
+/**
  * Checks whitespace around selector combinators.
  * @param {{
  *   root: import('postcss').Root,
@@ -31,9 +41,13 @@ export function selectorCombinatorSpaceChecker (opts) {
 
 		hasFixed = false
 
-		let selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector
+		let selectorRaws = rule.raws.selector
+		let selector = selectorRaws ? selectorRaws.raw : rule.selector
+		let fixedRawSelector
 
 		let fixedSelector = parseSelector(selector, opts.result, rule, (selectorTree) => {
+			let inlineComments = findInlineComments(selectorTree, selectorRaws && selectorRaws.scss)
+
 			selectorTree.walkCombinators((node) => {
 				// Ignore non-standard combinators
 				if (!isStandardSyntaxCombinator(node)) return
@@ -43,7 +57,8 @@ export function selectorCombinatorSpaceChecker (opts) {
 
 				// Check the exist of node in prev of the combinator.
 				// in case some that aren't the first begin with combinators (nesting syntax)
-				if (opts.locationType === `before` && !node.prev()) return
+				// A comment does not open a selector, so it does not count as such a node either.
+				if (opts.locationType === `before` && !prevNonComment(node)) return
 
 				let parentParentNode = node.parent && node.parent.parent
 
@@ -53,12 +68,24 @@ export function selectorCombinatorSpaceChecker (opts) {
 				let sourceIndex = node.sourceIndex
 				let index = node.value.length > 1 && opts.locationType === `before` ? sourceIndex : sourceIndex + node.value.length - 1
 
-				check(selector, node, index, rule, sourceIndex)
+				check(selector, node, index, rule, toSourceIndex(sourceIndex, inlineComments))
 			})
+
+			if (!hasFixed) return
+
+			fixedRawSelector = String(selectorTree)
+
+			// Give the inline comments their source spelling back, so that the fixed selector
+			// suits the field the stringifier reads.
+			for (let comment of inlineComments) comment.node.value = comment.value
 		})
 
 		if (hasFixed && fixedSelector) {
-			if (rule.raws.selector) rule.raws.selector.raw = fixedSelector
+			if (selectorRaws) {
+				selectorRaws.raw = fixedRawSelector
+
+				if (selectorRaws.scss) selectorRaws.scss = fixedSelector
+			}
 			else rule.selector = fixedSelector
 		}
 	})
@@ -69,9 +96,9 @@ export function selectorCombinatorSpaceChecker (opts) {
 	 * @param {import('postcss-selector-parser').Combinator} combinator - The combinator node.
 	 * @param {number} index - The index to check.
 	 * @param {import('postcss').Node} node - The parent node.
-	 * @param {number} sourceIndex - The source index of the combinator.
+	 * @param {number} reportIndex - The index of the combinator in the source of the parent node.
 	 */
-	function check (source, combinator, index, node, sourceIndex) {
+	function check (source, combinator, index, node, reportIndex) {
 		opts.locationChecker({
 			source,
 			index,
@@ -80,8 +107,8 @@ export function selectorCombinatorSpaceChecker (opts) {
 				report({
 					message,
 					node,
-					index: sourceIndex,
-					endIndex: sourceIndex,
+					index: reportIndex,
+					endIndex: reportIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
 					fix: opts.fix
@@ -95,4 +122,71 @@ export function selectorCombinatorSpaceChecker (opts) {
 			},
 		})
 	}
+}
+
+/**
+ * Collects the inline comments of a selector, pairing every comment node of the parsed
+ * selector with the text it has in the source.
+ *
+ * `postcss-scss` rewrites every inline comment of a selector into a block comment inside
+ * `raws.selector.raw` and keeps the source spelling in `raws.selector.scss`, so the two
+ * strings drift apart by two characters per inline comment.
+ * @param {import('postcss-selector-parser').Root} selectorTree - The parsed selector.
+ * @param {string} [scssSelector] - The source spelling of the selector, if the two differ.
+ * @returns {InlineComment[]} The inline comments, in source order.
+ */
+function findInlineComments (selectorTree, scssSelector) {
+	/** @type {InlineComment[]} */
+	let inlineComments = []
+
+	if (!scssSelector) return inlineComments
+
+	let delta = 0
+
+	selectorTree.walkComments((node) => {
+		let sourceIndex = node.sourceIndex - delta
+
+		// A block comment is spelled the same way in both strings.
+		if (!scssSelector.startsWith(`//`, sourceIndex)) return
+
+		let lineBreakIndex = scssSelector.indexOf(`\n`, sourceIndex)
+		let value = scssSelector.slice(sourceIndex, lineBreakIndex === -1 ? undefined : lineBreakIndex)
+
+		delta += node.value.length - value.length
+
+		inlineComments.push({ node, value, endIndex: node.sourceIndex + node.value.length, delta })
+	})
+
+	return inlineComments
+}
+
+/**
+ * Gets the closest preceding sibling that is not a comment.
+ * @param {import('postcss-selector-parser').Node} node - The node to start from.
+ * @returns {import('postcss-selector-parser').Node | undefined} The node, or nothing if the node is preceded by comments only.
+ */
+function prevNonComment (node) {
+	let prev = node.prev()
+
+	while (prev && prev.type === `comment`) prev = prev.prev()
+
+	return prev
+}
+
+/**
+ * Converts an index of the parsed selector into an index of the source the node is stringified from.
+ * @param {number} index - The index in the parsed selector.
+ * @param {InlineComment[]} inlineComments - The inline comments of the selector.
+ * @returns {number} The index in the source.
+ */
+function toSourceIndex (index, inlineComments) {
+	let delta = 0
+
+	for (let inlineComment of inlineComments) {
+		if (inlineComment.endIndex > index) break
+
+		delta = inlineComment.delta
+	}
+
+	return index - delta
 }


### PR DESCRIPTION
Closes #66. Independent of the inline-comment cluster, though it lands in the middle of it.

## The defect

Three of them, in fact. The report is about the first.

### 1. The `prev()` guard does not skip comments

```js
if (opts.locationType === `before` && !node.prev()) return
```

A combinator that opens a selector has nothing in front of it to be spaced from, and `isStandardSyntaxCombinator` skips it anyway when it is the container's first node. Put a comment in front of it and it stops being first: `prev()` returns the comment node, the guard falls through, and the rule measures the whitespace between the comment and the combinator — the line break of the selector list.

```scss
/* reported at 4:4 and 6:6, with `always` */
.some_class {
	.blue,
	// There's a comment here.
	+ .green,
	// And another.
	> .purple {
		background: yellow;
	}
}
```

Comment style has nothing to do with it, and neither has the syntax. The same list with `/* */` comments in plain CSS is reported at `3:1`, and `--fix` pulls the selector up onto the comment's line:

```css
/* before the fix, `always` */
.a,
/* A comment. */
+ .b {}
```

```css
/* was rewritten to — the list is pulled onto one line */
.a,
/* A comment. */ + .b {}
```

Less with a `//` comment is the one case that never reaches the rule: `isStandardSyntaxSelector` rejects any selector containing a double slash, so the whole rule bails out first.

### 2. Columns drift two characters per inline comment

`postcss-scss` rewrites every `//` comment of a selector into `/* … */` inside `raws.selector.raw` and keeps the source spelling in a third field, `raws.selector.scss` ([scss-parser.js:59-75](https://github.com/postcss/postcss-scss/blob/main/lib/scss-parser.js#L59-L75)). The checker measured `sourceIndex` in `.raw`, but stylelint turns that index into a position by counting through the stringified node — which is `.scss`. Two coordinate systems, drifting apart by exactly the two characters each rewritten comment adds.

That is why the block-comment variant above reports the right column while the SCSS one does not.

### 3. The fix never reached the output

The write-back targeted `raws.selector.raw`, and `ScssStringifier.rawValue` prefers `raws.selector.scss` whenever it exists ([scss-stringifier.js:40-48](https://github.com/postcss/postcss-scss/blob/main/lib/scss-stringifier.js#L40-L48)) — precisely whenever the selector holds an inline comment. Running `--fix` over the repro above produced output identical to the input, and stylelint counted the problem as fixed, since passing a `fix` callback to `report` is enough for that.

Invisible while defect 1 was there, because the rule should not have been firing at all. Fixing 1 without 3 would have produced fixes that vanish without a trace.

## The change

All three in `lib/utils/selectorCombinatorSpaceChecker`.

**The guard** walks back past comment nodes:

```js
if (opts.locationType === `before` && !prevNonComment(node)) return
```

**Positions** are converted before they are reported. The selector is still parsed from `.raw` — parsing `.scss` directly would read a `>` or a comma inside a comment as selector syntax — so `findInlineComments` pairs each comment node of the parsed tree with the `//` text it has in `.scss`, accumulating the drift, and `toSourceIndex` subtracts it from the index being reported. The whitespace check itself keeps working on `.raw`, where the parsed indices belong.

**The write-back** goes to both fields. Before stringifying, the comment nodes get their `//` spelling back, so the string `processSync` returns suits `.scss`; the normalised form is taken from the tree just before that and goes to `.raw`. Writing only `.scss` would leave `.raw` stale for whatever rule reads the selector next, and its own write-back would then drop this one.

`selector-combinator-space-after` shares the checker and gets the position and the write-back with it. Its path is deliberately left without a guard of the first shape: a combinator preceded by a comment does have something to its right to be spaced from, so `.blue,` — comment — `+.green` is a genuine violation of `always` and should be reported.

## Tests

Seven cases, all of them failing against the unfixed checker.

| Group | Case |
| --- | --- |
| `before`, plain CSS `always` and `never`, `postcss-less` `always` | accept: a selector list whose second selector begins with a comment and a combinator |
| `before`, `postcss-scss` `always` and `never` | accept: the repro from the issue |
| `before`, `postcss-scss` `always` | reject: `.b>.c` behind an inline comment — position `3:3` instead of the drifted `3:5`, and a fixed output that reaches the caller with the `//` comment intact |
| `after`, `postcss-scss` `always` | reject: the same selector spaced the other way — position `3:4` instead of `3:6`, same fix assertion |

The `after` test file is migrated to `autoStripIndent: true`, as `AGENTS.md` asks for the file being touched; it had no multi-line cases, so nothing else in it moves.

`make verify` is clean: 121 files, 7235 passing.

## Notes

- The rule's `README.md` is untouched: nothing about the documented behaviour changes, only the cases the rule was wrong about.
- `findInlineComments` and `toSourceIndex` are kept local to the checker. The `.raw` / `.scss` pair bites the same way for at-rule params and declaration values, and a shared utility for it belongs in its own commit once that work lands, the way `endsWithInlineComment` was handled in the `0ef8cb45bf330230c5b0337275390664959fddc1` commit.
