### PR TITLE
Trim every line of a comment body in `no-eol-whitespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 - The `selector-combinator-space-before` rule no longer reports a combinator that opens a selector when a comment stands in front of it (see [#66](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/66)). A selector list broken over several lines and interleaved with comments is now left alone instead of being pulled onto one line. Two more things follow for this rule and for `selector-combinator-space-after` alike, whenever the selector holds an inline comment:
 	- the reported position no longer drifts two characters per comment, so it points at the combinator itself;
 	- the fix now reaches the output instead of being silently discarded, and the comment keeps its `//` spelling.
+- The `no-eol-whitespace` rule now trims every line of a comment when fixing, and not only the lines up to the first quotation mark in it (see [#67](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/67)). An apostrophe in the text of a comment, the one in `isn't` for instance, used to be taken for the opening quote of a string, and the lines after it were passed over — reported, but left as they were, however many times the fix was run.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -105,7 +105,7 @@ function rule (primary, secondaryOptions) {
 			})
 		}
 
-		eachEolWhitespace(rootString, reportFromIndex, true)
+		eachEolWhitespace(rootString, reportFromIndex, { isRootFirst: true })
 
 		let errorIndex = findErrorStartIndex(rootString.length, rootString, {
 			ignoreEmptyLines,
@@ -118,10 +118,33 @@ function rule (primary, secondaryOptions) {
 		 * Iterate each whitespace at the end of each line of the given string.
 		 * @param {string} string - the source code string.
 		 * @param {(index: number) => void} callback - callback the whitespace index at the end of each line.
-		 * @param {boolean} isRootFirst - set `true` if the given string is the first token of the root.
+		 * @param {{ isRootFirst?: boolean, isPlainText?: boolean }} [options] - `isRootFirst` marks the given string as the first token of the root, `isPlainText` marks it as text that is not CSS.
 		 * @returns {void}
 		 */
-		function eachEolWhitespace (string, callback, isRootFirst) {
+		function eachEolWhitespace (string, callback, { isRootFirst = false, isPlainText = false } = {}) {
+			/**
+			 * Reports the whitespace, if any, at the found line ending.
+			 * @param {number} startIndex - The index of the line ending.
+			 */
+			function handleEol (startIndex) {
+				let index = findErrorStartIndex(startIndex, string, {
+					ignoreEmptyLines,
+					isRootFirst,
+				})
+
+				if (index > -1) callback(index)
+			}
+
+			// A CSS-aware scanner must not be used on text that is not CSS.
+			// Without the surrounding comment delimiters,
+			// an apostrophe in prose opens a string that is never closed,
+			// and every line ending after it is skipped.
+			if (isPlainText) {
+				for (let { index } of string.matchAll(/[\n\r]/gu)) handleEol(index)
+
+				return
+			}
+
 			styleSearch(
 				{
 					source: string,
@@ -129,12 +152,7 @@ function rule (primary, secondaryOptions) {
 					comments: `check`,
 				},
 				(match) => {
-					let index = findErrorStartIndex(match.startIndex, string, {
-						ignoreEmptyLines,
-						isRootFirst,
-					})
-
-					if (index > -1) callback(index)
+					handleEol(match.startIndex)
 				},
 			)
 		}
@@ -148,7 +166,7 @@ function rule (primary, secondaryOptions) {
 					(fixed) => {
 						node.raws.before = fixed
 					},
-					isRootFirst,
+					{ isRootFirst },
 				)
 				isRootFirst = false
 
@@ -219,9 +237,14 @@ function rule (primary, secondaryOptions) {
 					}
 					else node.raws.right = node.raws.right && fixString(node.raws.right)
 
-					fixText(node.text, (fixed) => {
-						node.text = fixed
-					})
+					// The comment body is prose, not CSS: postcss has already stripped its delimiters.
+					fixText(
+						node.text,
+						(fixed) => {
+							node.text = fixed
+						},
+						{ isPlainText: true },
+					)
 				}
 
 				if (isAtRule(node) || isRule(node)) {
@@ -236,7 +259,7 @@ function rule (primary, secondaryOptions) {
 				(fixed) => {
 					root.raws.after = fixed
 				},
-				isRootFirst,
+				{ isRootFirst },
 			)
 
 			if (typeof root.raws.after === `string`) {
@@ -253,9 +276,9 @@ function rule (primary, secondaryOptions) {
 		 * Fixes EOL whitespace in a text value.
 		 * @param {string | undefined} value - The value to fix.
 		 * @param {(text: string) => void} fixFn - The function to apply the fix.
-		 * @param {boolean} [isRootFirst] - Whether this is the first token of the root.
+		 * @param {{ isRootFirst?: boolean, isPlainText?: boolean }} [options] - The scanning options, forwarded to `eachEolWhitespace`.
 		 */
-		function fixText (value, fixFn, isRootFirst = false) {
+		function fixText (value, fixFn, options) {
 			if (!value) return
 
 			let fixed = ``
@@ -269,7 +292,7 @@ function rule (primary, secondaryOptions) {
 					fixed += fixString(value.slice(lastIndex, newlineIndex))
 					lastIndex = newlineIndex
 				},
-				isRootFirst,
+				options,
 			)
 
 			if (lastIndex) {

--- a/lib/rules/no-eol-whitespace/index.test.js
+++ b/lib/rules/no-eol-whitespace/index.test.js
@@ -590,6 +590,23 @@ testRule({
 				},
 			],
 		},
+		{
+			code: `/* a "b \n c" d \n */`,
+			fixed: `/* a "b\n c" d\n */`,
+			description: `every line of a comment containing a balanced pair of quotes`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 8,
+				},
+				{
+					message: messages.rejected,
+					line: 2,
+					column: 6,
+				},
+			],
+		},
 	],
 })
 
@@ -645,6 +662,34 @@ testRule({
 					message: messages.rejected,
 					line: 1,
 					column: 31,
+				},
+			],
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [true],
+	customSyntax: `postcss-less`,
+
+	reject: [
+		{
+			// Unlike `postcss-scss`, `postcss-less` does not end an inline comment
+			// at a carriage return, so the comment holds two lines of its own.
+			code: `// it's \r ok \na { color: red }\n`,
+			fixed: `// it's\r ok\na { color: red }\n`,
+			description: `both lines of an inline comment containing an apostrophe`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 8,
+				},
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 13,
 				},
 			],
 		},

--- a/lib/rules/no-eol-whitespace/index.test.js
+++ b/lib/rules/no-eol-whitespace/index.test.js
@@ -506,6 +506,90 @@ testRule({
 				},
 			],
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/67
+			code: `/* This \n * fix \n * isn't \n * working. \n */`,
+			fixed: `/* This\n * fix\n * isn't\n * working.\n */`,
+			description: `every line of a comment containing an apostrophe`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 8,
+				},
+				{
+					message: messages.rejected,
+					line: 2,
+					column: 7,
+				},
+				{
+					message: messages.rejected,
+					line: 3,
+					column: 9,
+				},
+				{
+					message: messages.rejected,
+					line: 4,
+					column: 12,
+				},
+			],
+		},
+		{
+			code: `/* This \r\n * isn't \r\n * ok. \r\n */`,
+			fixed: `/* This\r\n * isn't\r\n * ok.\r\n */`,
+			description: `every line of a CRLF comment containing an apostrophe`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 8,
+				},
+				{
+					message: messages.rejected,
+					line: 2,
+					column: 9,
+				},
+				{
+					message: messages.rejected,
+					line: 3,
+					column: 7,
+				},
+			],
+		},
+		{
+			code: `/* say " \n hi \n */`,
+			fixed: `/* say "\n hi\n */`,
+			description: `every line of a comment containing an unbalanced double quote`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 9,
+				},
+				{
+					message: messages.rejected,
+					line: 2,
+					column: 4,
+				},
+			],
+		},
+		{
+			code: `/* a { color: 'x \n b \n */`,
+			fixed: `/* a { color: 'x\n b\n */`,
+			description: `every line of a comment containing quoted code`,
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 17,
+				},
+				{
+					message: messages.rejected,
+					line: 2,
+					column: 3,
+				},
+			],
+		},
 	],
 })
 


### PR DESCRIPTION
Closes #67. Independent of the inline-comment cluster — it touches neither comment delimiters nor fixer refusals, only how a comment's body is searched.

## The defect

`no-eol-whitespace` fixes a node field by field, and for a comment one of those fields is `node.text` — the body, with `/*` and `*/` already taken off by postcss:

```js
fixText(node.text, (fixed) => {
	node.text = fixed
})
```

`fixText` finds the line endings through `eachEolWhitespace`, which is a `style-search` scan. That scanner is CSS-aware, and its string-opening branch is guarded by `!insideComment`:

```js
// style-search/index.js:128
if (!insideComment && !insideString && (currentChar === "\"" || currentChar === "'")) {
```

Over the stylesheet itself the guard holds — the `/*` is there and `insideComment` is true. Over a bare body it does not, so an apostrophe in prose opens a string:

```css
/* This 
 * fix 
 * isn't 
 * working. 
 */
```

Nothing closes that string, and there is no reset at a line break — an unterminated string runs to the end of the source. Every character after `isn` short-circuits at `style-search/index.js:147` before reaching the match test, so the line ending that closes line 3 never reaches the callback and line 3 is never trimmed.

The warnings are correct throughout: they come from a separate scan over `root.source.input.css`, where the comment keeps its delimiters. So the rule reported the whitespace, `--fix` left it in place, and running the fix again changed nothing.

**Line 4 of the report's own example was trimmed all the same**, which makes the defect look like it hits one line. It does not. That whitespace is not part of the body: postcss keeps it in `raws.right` (`" \n "`), a field of its own, scanned by a call of its own with a fresh scanner. An apostrophe suppresses everything after it, to the end of the body, and here that happened to be a single line.

Measured on the repro:

```text
comment.text                  = "This \n * fix \n * isn't \n * working."
newline offsets in it         : 5, 13, 23
match offsets reported to us  : 5, 13          <- 23 missing
same, with the apostrophe cut : 5, 13, 22
```

## The change

Stop handing text that is not CSS to a CSS-aware scanner.

Both `eachEolWhitespace` and `fixText` take their third argument as an options object now — `{ isRootFirst, isPlainText }` — matching the shape `findErrorStartIndex` already had. The handling of a single match is lifted into a local `handleEol`, so the two branches share the whitespace test rather than repeat it, and under `isPlainText` the line endings come from a plain search:

```js
if (isPlainText) {
	for (let { index } of string.matchAll(/[\n\r]/gu)) handleEol(index)

	return
}
```

Only the `node.text` call site passes it. Every other field keeps the CSS-aware scan unchanged.

### Why (a) and not restoring the delimiters

The alternative was to scan `"/*" + text + "*/"` and shift the offsets back by two, keeping one code path. It was rejected: the CSS-aware scan offers exactly two things over a plain search, and over a comment body one of them is a straight loss and the other is meaningless. Skipping the insides of strings is the bug itself — prose has no strings, only apostrophes. Looking inside comments (`comments: "check"`) is beside the point once we are already inside one. Nothing in `fixText` needs CSS awareness over a body, so there is nothing to pay an off-by-two offset translation for.

`raws.left` and `raws.right` are left on the CSS-aware path deliberately: postcss puts nothing but whitespace in them, so the scanner cannot be misled there, and the `raws.right` call is what trims the last line.

## Tests

Six cases, all failing against the parent of the fix. The first five sit in the plain-CSS `config: [true]` block; the last one needed a `postcss-less` block, the first in this file.

| Case | Input |
| --- | --- |
| the repro from the issue | `/* This \n * fix \n * isn't \n * working. \n */` |
| the same in a CRLF source | `/* This \r\n * isn't \r\n * ok. \r\n */` |
| an unpaired double quote | `/* say " \n hi \n */` |
| a quote inside code quoted in prose | `/* a { color: 'x \n b \n */` |
| a balanced pair of quotes | `/* a "b \n c" d \n */` |
| an inline comment under `postcss-less` | `// it's \r ok \na { color: red }\n` |

Each asserts the full warning list as well as the fixed output — the warnings were already right and must stay right.

The balanced pair is worth pinning down separately: the scanner stopped at the *opening* quote, so the line ending it was looking for came before the closing one, and only the lines after the pair were trimmed. Balance never helped.

The `postcss-less` case is there because `postcss-scss` cannot express it. SCSS ends an inline comment at a carriage return, so a `//` comment holds no line ending of its own and the scan had nothing to lose:

```text
scss  text = "it's"            (the CR ends the comment)
less  text = "it's \r ok"      (the CR is part of the body)
```

Less keeps reading past the carriage return, so the body reaches the scan as two lines with an apostrophe between them — the defect exactly. Measured against the parent commit: `"// it's \r ok \n…"` fixed to `"// it's \r ok\n…"` before, to `"// it's\r ok\n…"` now.

Checked by hand and left uncovered, because none of them was ever broken: a backslash in the body, `*/`-like text in it, a body with no trailing whitespace at all (no edit is produced), an empty body, `ignore: ["empty-lines"]` inside a body (the empty line is still spared), and inline `//` comments under `postcss-scss` in both LF and CRLF — postcss-scss puts no line ending in their `text` at all, so the new branch has nothing to find there.

`make verify` is clean: 121 files, 7241 passing.

## Notes

- The rule's `README.md` is untouched: the documented behaviour does not change, only the cases where the fix failed to deliver it.
- The other 15 files using `style-search` are left alone. Stylelint has dropped the package and moved to real tokenizers per rule, which is worth doing here eventually, but it is a migration and not this fix.
- `style-search` itself is left alone too. `0.1.0` is the only release it has ever had, and it behaves exactly as documented — it was simply given a source it was never meant to see.

