### PR TITLE
Scan values and params in raw coordinates in `string-quotes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- the reported position no longer drifts two characters per comment, so it points at the combinator itself;
 	- the fix now reaches the output instead of being silently discarded, and the comment keeps its `//` spelling.
 - The `no-eol-whitespace` rule now trims every line of a comment when fixing, and not only the lines up to the first quotation mark in it (see [#67](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/67)). An apostrophe in the text of a comment, the one in `isn't` for instance, used to be taken for the opening quote of a string, and the lines after it were passed over — reported, but left as they were, however many times the fix was run.
+- The `string-quotes` rule no longer loses its bearings in a declaration's value or an at-rule's parameters holding a comment (see [#61](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/61), [#33](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/33)):
+	- the reported position now points at the quote itself instead of drifting by the length of every comment standing in front of it;
+	- the fix now changes the quote characters and nothing else, so every comment in the value survives it;
+	- a string standing in front of an inline comment under `postcss-scss` is now reported rather than silently rewritten, since such a value cannot be edited at all without losing the spelling of its comments;
+	- a string standing behind such a comment is passed over instead of being reported two characters off per comment, until an inline comment can be told apart from the code around it.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -4,9 +4,13 @@ import stylelint from "stylelint"
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
+import { getAtRuleParams } from "../../utils/getAtRuleParams/index.js"
+import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.js"
 import { parseSelector } from "../../utils/parseSelector/index.js"
+import { setAtRuleParams } from "../../utils/setAtRuleParams/index.js"
+import { setDeclarationValue } from "../../utils/setDeclarationValue/index.js"
 import { isAtRule } from "../../utils/typeGuards/index.js"
 import { assertString, isBoolean } from "../../utils/validateTypes/index.js"
 
@@ -60,10 +64,10 @@ function rule (primary, secondaryOptions) {
 		root.walk((node) => {
 			switch (node.type) {
 				case `atrule`:
-					checkDeclOrAtRule(node, node.params, atRuleParamIndex)
+					checkDeclOrAtRule(node, getAtRuleParams(node), atRuleParamIndex)
 					break
 				case `decl`:
-					checkDeclOrAtRule(node, node.value, declarationValueIndex)
+					checkDeclOrAtRule(node, getDeclarationValue(node), declarationValueIndex)
 					break
 				case `rule`:
 					checkRule(node)
@@ -172,7 +176,7 @@ function rule (primary, secondaryOptions) {
 		 * Checks a declaration or at-rule node for quote violations.
 		 * @template {import('postcss').AtRule | import('postcss').Declaration} T
 		 * @param {T} node - The node to check.
-		 * @param {string} value - The value to check.
+		 * @param {string} value - The value to check, in the coordinates of the source file.
 		 * @param {(node: T) => number} getIndex - Function to get the index of the node.
 		 * @returns {void}
 		 */
@@ -182,6 +186,16 @@ function rule (primary, secondaryOptions) {
 
 			// Get out quickly if there are no erroneous quotes
 			if (!value.includes(erroneousQuote)) return
+
+			let raws = isAtRule(node) ? node.raws.params : node.raws.value
+
+			// `postcss-scss` rewrites every `//` comment inside the raw into `/* … */`, keeps the
+			// source spelling in a third field and prefers that field on output. The two texts run
+			// character for character up to the first such comment, so a string in front of it is
+			// still in the coordinates of the file while one behind it is two characters off per
+			// comment, and a fix written into the raw would not reach the output at all.
+			let hasInlineComment = Boolean(raws && raws.scss)
+			let inlineCommentIndex = hasInlineComment ? commonPrefixLength(raws.raw, raws.scss) : Infinity
 
 			if (isAtRule(node) && node.name === `charset`) {
 				let hasValidQuotes = node.params.startsWith(`"`) && node.params.endsWith(`"`)
@@ -200,6 +214,10 @@ function rule (primary, secondaryOptions) {
 					}
 
 					const openIndex = valueNode.sourceIndex
+
+					// Behind an inline comment the raw no longer measures the file
+					if (openIndex >= inlineCommentIndex) return
+
 					const problemIndex = getIndex(node) + openIndex
 
 					report({
@@ -210,24 +228,44 @@ function rule (primary, secondaryOptions) {
 						endIndex: problemIndex,
 						result,
 						ruleName,
-						fix () {
-							// we currently don't fix escapes
-							if (!needsEscape) {
-								let closeIndex = openIndex + valueNode.value.length + erroneousQuote.length
+						fix: hasInlineComment
+							? undefined
+							: () => {
+								// we currently don't fix escapes
+								if (!needsEscape) {
+									let closeIndex = openIndex + valueNode.value.length + erroneousQuote.length
 
-								fixPositions.push(openIndex, closeIndex)
-							}
-						},
+									fixPositions.push(openIndex, closeIndex)
+								}
+							},
 					})
 				}
 			})
 
-			for (let fixIndex of fixPositions) {
-				if (isAtRule(node)) node.params = replaceQuote(node.params, fixIndex, correctQuote)
-				else node.value = replaceQuote(node.value, fixIndex, correctQuote)
-			}
+			if (fixPositions.length === 0) return
+
+			let fixed = value
+
+			for (let fixIndex of fixPositions) fixed = replaceQuote(fixed, fixIndex, correctQuote)
+
+			if (isAtRule(node)) setAtRuleParams(node, fixed)
+			else setDeclarationValue(node, fixed)
 		}
 	}
+}
+
+/**
+ * Counts the characters two strings begin with in common.
+ * @param {string} one - The first string.
+ * @param {string} other - The second string.
+ * @returns {number} The length of the common prefix.
+ */
+function commonPrefixLength (one, other) {
+	let index = 0
+
+	while (index < one.length && index < other.length && one[index] === other[index]) index += 1
+
+	return index
 }
 
 /**

--- a/lib/rules/string-quotes/index.test.js
+++ b/lib/rules/string-quotes/index.test.js
@@ -1,6 +1,6 @@
 import { messages, ruleName } from "./index.js"
 
-const testRule = createTestRule({ ruleName })
+const testRule = createTestRule({ ruleName, autoStripIndent: true })
 
 testRule({
 	ruleName,
@@ -198,6 +198,39 @@ testRule({
 			line: 1,
 			column: 10,
 		},
+		{
+			description: `accurate positions on both sides of a comment inside the value`,
+			code: `
+				a {
+					content: 'x' /* c */ 'y';
+				}
+			`,
+			fixed: `
+				a {
+					content: "x" /* c */ "y";
+				}
+			`,
+			warnings: [
+				{
+					message: messages.expected(`double`),
+					line: 2,
+					column: 11,
+				},
+				{
+					message: messages.expected(`double`),
+					line: 2,
+					column: 23,
+				},
+			],
+		},
+		{
+			description: `accurate position after a comment inside at-rule params`,
+			code: `@import 'x' /* c */ screen;`,
+			fixed: `@import "x" /* c */ screen;`,
+			message: messages.expected(`double`),
+			line: 1,
+			column: 9,
+		},
 	],
 })
 
@@ -273,6 +306,15 @@ testRule({
 			code: `@charset "utf-8"`,
 			description: `ignore @charset rules`,
 		},
+		{
+			description: `a string behind an inline comment inside the value, whose position the raw no longer measures`,
+			code: `
+				$m: (
+				  // c
+				  'a': 1
+				);
+			`,
+		},
 	],
 
 	reject: [
@@ -291,6 +333,92 @@ testRule({
 			message: messages.expected(`double`),
 			line: 5,
 			column: 12,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/33
+			description: `accurate position after a comment inside at-rule params`,
+			code: `
+				@mixin foo(
+				  /* Comment */
+				  $bar: 'baz'
+				) {}
+			`,
+			fixed: `
+				@mixin foo(
+				  /* Comment */
+				  $bar: "baz"
+				) {}
+			`,
+			message: messages.expected(`double`),
+			line: 3,
+			column: 9,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/61
+			description: `comments within a map literal are kept`,
+			code: `
+				$somevar: ( /* This is a comment */
+				 /* comment here */
+					'a_property': 0 /* Don't forget this one! */
+				)
+			`,
+			fixed: `
+				$somevar: ( /* This is a comment */
+				 /* comment here */
+					"a_property": 0 /* Don't forget this one! */
+				)
+			`,
+			message: messages.expected(`double`),
+			line: 3,
+			column: 2,
+		},
+		{
+			description: `a string in front of an inline comment inside the value: the fix cannot reach the output, so the code is left alone and the warning stands`,
+			code: `
+				$m: (
+				  'a': 1 // c
+				);
+			`,
+			fixed: `
+				$m: (
+				  'a': 1 // c
+				);
+			`,
+			message: messages.expected(`double`),
+			line: 2,
+			column: 3,
+		},
+		{
+			description: `a string in front of an inline comment inside at-rule params`,
+			code: `
+				@include foo(
+				  'x' // c
+				);
+			`,
+			fixed: `
+				@include foo(
+				  'x' // c
+				);
+			`,
+			message: messages.expected(`double`),
+			line: 2,
+			column: 3,
+		},
+		{
+			description: `a double slash inside a string opens no comment`,
+			code: `
+				$m: (
+				  'http://x': 1 // c
+				);
+			`,
+			fixed: `
+				$m: (
+				  'http://x': 1 // c
+				);
+			`,
+			message: messages.expected(`double`),
+			line: 2,
+			column: 3,
 		},
 	],
 })
@@ -323,6 +451,31 @@ testRule({
 			message: messages.expected(`double`),
 			line: 5,
 			column: 12,
+		},
+		{
+			description: `accurate positions on both sides of a comment inside the value`,
+			code: `
+				a {
+					content: 'x' /* c */ 'y';
+				}
+			`,
+			fixed: `
+				a {
+					content: "x" /* c */ "y";
+				}
+			`,
+			warnings: [
+				{
+					message: messages.expected(`double`),
+					line: 2,
+					column: 11,
+				},
+				{
+					message: messages.expected(`double`),
+					line: 2,
+					column: 23,
+				},
+			],
 		},
 	],
 })

--- a/lib/utils/getAtRuleParams/index.js
+++ b/lib/utils/getAtRuleParams/index.js
@@ -1,0 +1,10 @@
+/**
+ * Gets the params of an at-rule.
+ * @param {import('postcss').AtRule} atRule - The at-rule node.
+ * @returns {string} The at-rule params, including any comment dropped from the property.
+ */
+export function getAtRuleParams (atRule) {
+	let raws = atRule.raws
+
+	return (raws.params && raws.params.raw) || atRule.params
+}

--- a/lib/utils/getAtRuleParams/index.test.js
+++ b/lib/utils/getAtRuleParams/index.test.js
@@ -1,0 +1,30 @@
+import { parse } from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { getAtRuleParams } from "./index.js"
+
+describe(`getAtRuleParams`, () => {
+	it(`has no params`, () => {
+		expect(getAtRuleParams(atRule(`@font-face {}`))).toBe(``)
+	})
+
+	it(`has no comment in the params`, () => {
+		expect(getAtRuleParams(atRule(`@media screen {}`))).toBe(`screen`)
+	})
+
+	it(`has a comment in front of the params`, () => {
+		expect(getAtRuleParams(atRule(`@media /* c */ screen {}`))).toBe(`screen`)
+	})
+
+	it(`has a comment inside the params`, () => {
+		expect(getAtRuleParams(atRule(`@mixin foo(\n\t/* c */\n\t$bar: 1\n) {}`))).toBe(`foo(\n\t/* c */\n\t$bar: 1\n)`)
+	})
+})
+
+function atRule (css) {
+	let list = []
+
+	parse(css).walkAtRules((rule) => list.push(rule))
+
+	return list[0]
+}

--- a/lib/utils/getDeclarationValue/index.test.js
+++ b/lib/utils/getDeclarationValue/index.test.js
@@ -1,0 +1,30 @@
+import { parse } from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { getDeclarationValue } from "./index.js"
+
+describe(`getDeclarationValue`, () => {
+	it(`has no comment in the value`, () => {
+		expect(getDeclarationValue(decl(`a { color: pink }`))).toBe(`pink`)
+	})
+
+	it(`has a comment in front of the value`, () => {
+		expect(getDeclarationValue(decl(`a { color: /* c */ pink }`))).toBe(`pink`)
+	})
+
+	it(`has a comment inside the value`, () => {
+		expect(getDeclarationValue(decl(`a { margin: 0 /* c */ 1px }`))).toBe(`0 /* c */ 1px`)
+	})
+
+	it(`has a comment inside a custom property`, () => {
+		expect(getDeclarationValue(decl(`a { --foo: 0 /* c */ 1px }`))).toBe(`0 /* c */ 1px `)
+	})
+})
+
+function decl (css) {
+	let list = []
+
+	parse(css).walkDecls((d) => list.push(d))
+
+	return list[0]
+}

--- a/lib/utils/setAtRuleParams/index.js
+++ b/lib/utils/setAtRuleParams/index.js
@@ -1,0 +1,16 @@
+/** @typedef {import('postcss').AtRule} AtRule */
+
+/**
+ * Sets the params of an at-rule.
+ * @param {AtRule} atRule - The at-rule node.
+ * @param {string} params - The new params to set.
+ * @returns {AtRule} The at-rule that was passed in.
+ */
+export function setAtRuleParams (atRule, params) {
+	let raws = atRule.raws
+
+	if (raws.params) raws.params.raw = params
+	else atRule.params = params
+
+	return atRule
+}

--- a/lib/utils/setAtRuleParams/index.test.js
+++ b/lib/utils/setAtRuleParams/index.test.js
@@ -1,0 +1,45 @@
+import { parse } from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { setAtRuleParams } from "./index.js"
+
+describe(`setAtRuleParams`, () => {
+	it(`has no comment in the params`, () => {
+		let node = atRule(`@media screen {}`)
+
+		setAtRuleParams(node, `print`)
+
+		expect(node.params).toBe(`print`)
+		expect(node.toString()).toBe(`@media print {}`)
+	})
+
+	it(`has a comment inside the params`, () => {
+		let node = atRule(`@mixin foo(\n\t/* c */\n\t$bar: 1\n) {}`)
+
+		setAtRuleParams(node, `foo(\n\t/* c */\n\t$bar: 2\n)`)
+
+		expect(node.toString()).toBe(`@mixin foo(\n\t/* c */\n\t$bar: 2\n) {}`)
+	})
+
+	it(`keeps the cleaned params untouched when a comment was dropped from them`, () => {
+		let node = atRule(`@mixin foo(\n\t/* c */\n\t$bar: 1\n) {}`)
+
+		setAtRuleParams(node, `foo(\n\t/* c */\n\t$bar: 2\n)`)
+
+		expect(node.params).toBe(`foo(\n\t\n\t$bar: 1\n)`)
+	})
+
+	it(`returns the at-rule it was given`, () => {
+		let node = atRule(`@media screen {}`)
+
+		expect(setAtRuleParams(node, `print`)).toBe(node)
+	})
+})
+
+function atRule (css) {
+	let list = []
+
+	parse(css).walkAtRules((rule) => list.push(rule))
+
+	return list[0]
+}

--- a/lib/utils/setDeclarationValue/index.test.js
+++ b/lib/utils/setDeclarationValue/index.test.js
@@ -1,0 +1,45 @@
+import { parse } from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { setDeclarationValue } from "./index.js"
+
+describe(`setDeclarationValue`, () => {
+	it(`has no comment in the value`, () => {
+		let node = decl(`a { color: pink }`)
+
+		setDeclarationValue(node, `red`)
+
+		expect(node.value).toBe(`red`)
+		expect(node.toString()).toBe(`color: red`)
+	})
+
+	it(`has a comment inside the value`, () => {
+		let node = decl(`a { margin: 0 /* c */ 1px }`)
+
+		setDeclarationValue(node, `0 /* c */ 2px`)
+
+		expect(node.toString()).toBe(`margin: 0 /* c */ 2px`)
+	})
+
+	it(`keeps the cleaned value untouched when a comment was dropped from it`, () => {
+		let node = decl(`a { margin: 0 /* c */ 1px }`)
+
+		setDeclarationValue(node, `0 /* c */ 2px`)
+
+		expect(node.value).toBe(`0  1px`)
+	})
+
+	it(`returns the declaration it was given`, () => {
+		let node = decl(`a { color: pink }`)
+
+		expect(setDeclarationValue(node, `red`)).toBe(node)
+	})
+})
+
+function decl (css) {
+	let list = []
+
+	parse(css).walkDecls((d) => list.push(d))
+
+	return list[0]
+}


### PR DESCRIPTION
Closes #33. Closes #61. Explicitly closes nothing else: #32 is a separate defect in the same file (a `//` comment reaching the value tokenizer), #65 is the same class of mismatch inside `indentation`, and #66 was fixed on its own in #96. Each has its own spec.

## The defect

Two halves of one index, counted over two different strings.

Postcss drops a comment out of a declaration's `value` or an at-rule's `params` and records both versions as a pair (`postcss/lib/parser.js:520`):

```js
if (!clean) {
	node.raws[prop] = { raw, value }
}
node[prop] = value
```

`checkDeclOrAtRule` was handed the cleaned half, tokenized it, and reported an offset built out of both:

```js
const problemIndex = getIndex(node) + valueNode.sourceIndex
```

`getIndex` is `declarationValueIndex` or `atRuleParamIndex`. Both count their base offset over the **raw** text — `declarationValueIndex` literally adds `raws.value.prefix`. `sourceIndex` counts characters in the **cleaned** string. The two agree only as long as no comment was removed, and drift by the full length of every comment that was.

For #33 the reported position landed inside the comment itself:

```text
input            : "@mixin foo(\n  /* Comment */\n  $bar: 'baz'\n) {}\n"
params (cleaned) : "foo(\n  \n  $bar: 'baz'\n)"
'baz' opens at   : 16 of the cleaned params
atRuleParamIndex : 7
offset 23 in the file is the `t` of `/* Comment */`
reported         : 2:12    expected 3:9
```

For #61, a map literal with three comments, it landed two lines above the string it was about — `1:17` instead of `3:2`.

Then the fix wrote the cleaned string back to the property:

```js
if (isAtRule(node)) node.params = replaceQuote(node.params, fixIndex, correctQuote)
else node.value = replaceQuote(node.value, fixIndex, correctQuote)
```

which fails the `raw.value === value` test in the stringifier (`postcss/lib/stringifier.js:419`) and takes `raws[prop].raw` down with every comment it holds:

```text
#33 fixed to : "@mixin foo(\n  \n  $bar: \"baz\"\n) {}\n"
#61 fixed to : "$somevar: ( \n \n\t\"a_property\": 0 \n)\n"
```

So the rule reported the wrong place and then deleted the user's comments while fixing it.

## The change

Read through raw-preferring getters, write through matching setters — the convention this repository already vendored for declarations, and stylelint's own.

`getDeclarationValue` and `setDeclarationValue` were already here, used by sixteen rules. At-rules had no equivalent, so two utilities are added mirroring them exactly:

```js
export function getAtRuleParams (atRule) {
	let raws = atRule.raws

	return (raws.params && raws.params.raw) || atRule.params
}
```

The rule now scans the raw and writes the raw:

```js
case `atrule`:
	checkDeclOrAtRule(node, getAtRuleParams(node), atRuleParamIndex)
	break
case `decl`:
	checkDeclOrAtRule(node, getDeclarationValue(node), declarationValueIndex)
	break
```

Neither index helper is touched. They were counting in the right coordinates all along — it was the scanned string that had to move to meet them.

`postcss-value-parser` needs no help with the comments this brings into view: it tokenizes `/* … */` as `comment` nodes of its own, so the apostrophe in `/* Don't forget this one! */` in the #61 repro opens no string and produces no second warning.

### The shortcut not taken

Subtracting comment lengths from `sourceIndex` would have carried both reported issues and failed on the first comment standing *between* two strings. Cases of that shape are in the tests for plain CSS and for `postcss-less`, and they pin the direction down: `a { content: 'x' /* c */ 'y'; }` reports at `2:11` and `2:23`, where that approach would put the second one at `2:16`.

### Inline comments under `postcss-scss`

`postcss-scss` rewrites every `//` comment inside `raws[prop].raw` into `/* */`, keeps the source spelling in a third field `raws[prop].scss`, and its stringifier prefers that field (`postcss-scss/lib/scss-stringifier.js:40-48`). Two consequences, and they are not the same size.

**The fix cannot be delivered at all**, anywhere in such a node. An edit written into the raw reaches no output, and the run would count the problem as fixed while leaving the file untouched. So the fixer declines the node — the same course already taken for the brace of #89 and the colon of #88, which an inline comment leaves nowhere to go.

**The position, on the other hand, is only lost behind the first such comment.** The raw and the source spelling run character for character up to that point, so the boundary is the length of their common prefix:

```js
let hasInlineComment = Boolean(raws && raws.scss)
let inlineCommentIndex = hasInlineComment ? commonPrefixLength(raws.raw, raws.scss) : Infinity
```

A string opening before it is reported normally; one opening behind it is passed over, since every comment ahead of it costs two characters. A double slash inside a quoted string opens no comment and moves no boundary, because the two fields do not part company over it.

This is the one behaviour change here that is not a repair: a string behind an inline comment is now silently skipped. `CHANGELOG.md` records both halves.

## Tests

Nine rule cases and sixteen unit tests. Every reject case fails against `main`; the accept case records a deliberate false negative and passes either way.

| Case | Syntax | Input |
| --- | --- | --- |
| #33, position after a comment in params | `postcss-scss` | `@mixin foo(\n  /* Comment */\n  $bar: 'baz'\n) {}` |
| #61, comments in a map literal are kept | `postcss-scss` | `$somevar: ( /* … */\n /* … */\n\t'a_property': 0 /* … */\n)` |
| positions on both sides of a comment | plain CSS | `a {\n\tcontent: 'x' /* c */ 'y';\n}` |
| position after a comment in params | plain CSS | `@import 'x' /* c */ screen;` |
| the same, in the syntax #32 is filed against | `postcss-less` | `a {\n\tcontent: 'x' /* c */ 'y';\n}` |
| a string in front of an inline comment, reported but not fixed | `postcss-scss` | `$m: (\n  'a': 1 // c\n);` |
| the same in at-rule params | `postcss-scss` | `@include foo(\n  'x' // c\n);` |
| a double slash inside a string opens no comment | `postcss-scss` | `$m: (\n  'http://x': 1 // c\n);` |
| a string behind an inline comment, passed over (accept) | `postcss-scss` | `$m: (\n  // c\n  'a': 1\n);` |

The plain-CSS cases are not decoration. The pair postcss keeps is the work of its core, not of any custom syntax, so both branches take exactly this path in the plugin's main syntax and had no coverage there at all.

The utilities carry their own tests. `getAtRuleParams` and `setAtRuleParams` were landed with them; `getDeclarationValue` and `setDeclarationValue` had none in sixteen rules of service and get the same treatment now, including the custom property whose trailing space postcss keeps where an ordinary value loses it.

`make verify` is clean: 125 files, 7266 passing.

## Notes

- The two at-rule utilities are landed as their own commit because `indentation` needs them next, for #65.
- **A known consequence of the convention, not introduced by this PR but newly reached by it.** Sixteen rules write a value through `setDeclarationValue`; nine write `decl.value` directly (`color-hex-case`, `unit-case`, `number-leading-zero`, `number-no-trailing-zeros`, `linebreaks`, `no-eol-whitespace`, `indentation`, `function-parentheses-newline-inside`, `declaration-block-semicolon-newline-before`). When both kinds fire on one declaration that holds a comment, the direct write makes `raws.value.value !== decl.value` and the stringifier drops the raw, taking the other rule's edit with it. `string-quotes` has just moved from the second group into the first, so `a { margin: 'a' /* c */ 0.50px; }` with `number-no-trailing-zeros` now converges on the second `--fix` pass rather than the first. Worth a separate issue; it is not specific to this rule.
- The rule's `README.md` is untouched. Its one claim that could have gone stale — "Quotes within comments are ignored" — is truer than before: the comments are now discarded by the tokenizer rather than by the parser ahead of it.
- The `@charset` guard and the selector branch are left as they are. Selectors go through `parseSelector` and never had this problem.

