### PR TITLE
Mirror a Less at-variable's params into the value that is printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- the fix now changes the quote characters and nothing else, so every comment in the value survives it;
 	- a string standing in front of an inline comment under `postcss-scss` is now reported rather than silently rewritten, since such a value cannot be edited at all without losing the spelling of its comments;
 	- a string standing behind such a comment is passed over instead of being reported two characters off per comment, until an inline comment can be told apart from the code around it.
+- A Less at-variable now keeps the fix written to it (see [#99](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/99)). `postcss-less` gives such a variable two copies of its text and prints the one no rule writes, so `--fix` used to leave the file exactly as it was and drop the warning along with it, reporting a clean pass on a file it never touched. This held for every rule that fixes an at-rule's parameters: `indentation`, `no-eol-whitespace`, `number-leading-zero`, `number-no-trailing-zeros` and `string-quotes`.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/indentation/at-rules.test.js
+++ b/lib/rules/indentation/at-rules.test.js
@@ -274,3 +274,30 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [1],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	reject: [
+		{
+			code: `
+				@foo: (
+						'a'
+				);
+			`,
+			fixed: `
+				@foo: (
+				 'a'
+				);
+			`,
+			description: `a Less at-variable keeps the fix written to its params`,
+
+			message: messages.expected(`1 space`),
+			line: 2,
+			column: 3,
+		},
+	],
+})

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -8,6 +8,7 @@ import { hasBlock } from "../../utils/hasBlock/index.js"
 import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration/index.js"
 import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode/index.js"
 import { optionsMatches } from "../../utils/optionsMatches/index.js"
+import { syncLessVariableValue } from "../../utils/syncLessVariableValue/index.js"
 import { isAtRule, isDeclaration, isRoot, isRule } from "../../utils/typeGuards/index.js"
 import { assertString, isBoolean, isNumber, isString } from "../../utils/validateTypes/index.js"
 
@@ -434,6 +435,8 @@ function rule (primary, secondaryOptions = {}) {
 								fixPosition.expectedIndentation,
 								fixPosition.startIndex - atRuleName.length - atRuleAfterName.length - 1,
 							)
+
+							syncLessVariableValue(node, node.params)
 						}
 					}
 				}

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -6,6 +6,7 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { isOnlyWhitespace } from "../../utils/isOnlyWhitespace/index.js"
 import { isStandardSyntaxComment } from "../../utils/isStandardSyntaxComment/index.js"
 import { optionsMatches } from "../../utils/optionsMatches/index.js"
+import { syncLessVariableValue } from "../../utils/syncLessVariableValue/index.js"
 import { isAtRule, isComment, isDeclaration, isRule } from "../../utils/typeGuards/index.js"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -180,11 +181,13 @@ function rule (primary, secondaryOptions) {
 					if (rawsParams) {
 						fixText(rawsParams.raw, (fixed) => {
 							rawsParams.raw = fixed
+							syncLessVariableValue(node, fixed)
 						})
 					}
 					else {
 						fixText(node.params, (fixed) => {
 							node.params = fixed
+							syncLessVariableValue(node, fixed)
 						})
 					}
 				}

--- a/lib/rules/no-eol-whitespace/index.test.js
+++ b/lib/rules/no-eol-whitespace/index.test.js
@@ -2,6 +2,9 @@ import { messages, ruleName } from "./index.js"
 
 const testRule = createTestRule({ ruleName })
 
+// A space no editor trims from the end of a line.
+const S = ` `
+
 testRule({
 	ruleName,
 	config: [true],
@@ -692,6 +695,25 @@ testRule({
 					column: 13,
 				},
 			],
+		},
+		{
+			autoStripIndent: true,
+			code: `
+				@foo: (
+					a,${S}${S}${S}
+					b
+				);
+			`,
+			fixed: `
+				@foo: (
+					a,
+					b
+				);
+			`,
+			description: `a Less at-variable keeps the fix written to its params`,
+			message: messages.rejected,
+			line: 2,
+			column: 6,
 		},
 	],
 })

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -5,6 +5,7 @@ import { addNamespace } from "../../utils/addNamespace/index.js"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { syncLessVariableValue } from "../../utils/syncLessVariableValue/index.js"
 import { isAtRule } from "../../utils/typeGuards/index.js"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -122,7 +123,10 @@ function rule (primary) {
 				for (let fixPosition of alwaysFixPositions) {
 					let index = fixPosition.index
 
-					if (isAtRule(node)) node.params = addLeadingZero(node.params, index)
+					if (isAtRule(node)) {
+						node.params = addLeadingZero(node.params, index)
+						syncLessVariableValue(node, node.params)
+					}
 					else node.value = addLeadingZero(node.value, index)
 				}
 			}
@@ -132,7 +136,10 @@ function rule (primary) {
 					let startIndex = fixPosition.startIndex
 					let endIndex = fixPosition.endIndex
 
-					if (isAtRule(node)) node.params = removeLeadingZeros(node.params, startIndex, endIndex)
+					if (isAtRule(node)) {
+						node.params = removeLeadingZeros(node.params, startIndex, endIndex)
+						syncLessVariableValue(node, node.params)
+					}
 					else node.value = removeLeadingZeros(node.value, startIndex, endIndex)
 				}
 			}

--- a/lib/rules/number-leading-zero/index.test.js
+++ b/lib/rules/number-leading-zero/index.test.js
@@ -345,3 +345,37 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+
+	reject: [
+		{
+			code: `@foo: .5px;`,
+			fixed: `@foo: 0.5px;`,
+			description: `a Less at-variable keeps the fix written to its params`,
+			message: messages.expected,
+			line: 1,
+			column: 7,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-less`,
+
+	reject: [
+		{
+			code: `@foo: 0.5px;`,
+			fixed: `@foo: .5px;`,
+			description: `a Less at-variable keeps the fix written to its params`,
+			message: messages.rejected,
+			line: 1,
+			column: 7,
+		},
+	],
+})

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -5,6 +5,7 @@ import { addNamespace } from "../../utils/addNamespace/index.js"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
+import { syncLessVariableValue } from "../../utils/syncLessVariableValue/index.js"
 import { isAtRule } from "../../utils/typeGuards/index.js"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -106,7 +107,10 @@ function rule (primary) {
 					let startIndex = fixPosition.startIndex
 					let endIndex = fixPosition.endIndex
 
-					if (isAtRule(node)) node.params = removeTrailingZeros(node.params, startIndex, endIndex)
+					if (isAtRule(node)) {
+						node.params = removeTrailingZeros(node.params, startIndex, endIndex)
+						syncLessVariableValue(node, node.params)
+					}
 					else node.value = removeTrailingZeros(node.value, startIndex, endIndex)
 				}
 			}

--- a/lib/rules/number-no-trailing-zeros/index.test.js
+++ b/lib/rules/number-no-trailing-zeros/index.test.js
@@ -179,3 +179,20 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [true],
+	customSyntax: `postcss-less`,
+
+	reject: [
+		{
+			code: `@foo: 1.50px;`,
+			fixed: `@foo: 1.5px;`,
+			description: `a Less at-variable keeps the fix written to its params`,
+			message: messages.rejected,
+			line: 1,
+			column: 10,
+		},
+	],
+})

--- a/lib/rules/string-quotes/index.test.js
+++ b/lib/rules/string-quotes/index.test.js
@@ -477,5 +477,31 @@ testRule({
 				},
 			],
 		},
+		{
+			description: `a Less at-variable`,
+			code: `@foo: 'bar';`,
+			fixed: `@foo: "bar";`,
+			message: messages.expected(`double`),
+			line: 1,
+			column: 7,
+		},
+		{
+			description: `a Less at-variable holding a comment`,
+			code: `
+				@foo: (
+					/* c */
+					'a'
+				);
+			`,
+			fixed: `
+				@foo: (
+					/* c */
+					"a"
+				);
+			`,
+			message: messages.expected(`double`),
+			line: 3,
+			column: 2,
+		},
 	],
 })

--- a/lib/utils/setAtRuleParams/index.js
+++ b/lib/utils/setAtRuleParams/index.js
@@ -1,3 +1,5 @@
+import { syncLessVariableValue } from "../syncLessVariableValue/index.js"
+
 /** @typedef {import('postcss').AtRule} AtRule */
 
 /**
@@ -11,6 +13,8 @@ export function setAtRuleParams (atRule, params) {
 
 	if (raws.params) raws.params.raw = params
 	else atRule.params = params
+
+	syncLessVariableValue(atRule, params)
 
 	return atRule
 }

--- a/lib/utils/syncLessVariableValue/index.js
+++ b/lib/utils/syncLessVariableValue/index.js
@@ -1,0 +1,15 @@
+/** @typedef {import('postcss').AtRule} AtRule */
+
+/**
+ * Mirrors the params just written to an at-rule into the value that `postcss-less` prints.
+ * A Less variable (`@foo: "bar";`) is given two copies of its text, `params` and `value`, and the
+ * Less stringifier discards `params`, so a fix written to `params` alone never reaches the output.
+ * @param {AtRule} atRule - The at-rule whose params have just been set.
+ * @param {string} params - The text that was written to the params.
+ * @returns {AtRule} The at-rule that was passed in.
+ */
+export function syncLessVariableValue (atRule, params) {
+	if (`variable` in atRule && atRule.variable) atRule.value = params
+
+	return atRule
+}

--- a/lib/utils/syncLessVariableValue/index.test.js
+++ b/lib/utils/syncLessVariableValue/index.test.js
@@ -1,0 +1,66 @@
+import postcss from "postcss"
+import postcssLess from "postcss-less"
+import { describe, expect, it } from "vitest"
+
+import { syncLessVariableValue } from "./index.js"
+
+describe(`syncLessVariableValue`, () => {
+	it(`takes a Less variable's params to the output`, () => {
+		let node = lessAtRule(`@foo: "bar";`)
+
+		node.params = `'bar'`
+		syncLessVariableValue(node, node.params)
+
+		expect(less(node)).toBe(`@foo: 'bar';`)
+	})
+
+	it(`keeps a comment that the params it is given still hold`, () => {
+		let node = lessAtRule(`@foo: (\n\t/* c */\n\t"a"\n);`)
+
+		syncLessVariableValue(node, `(\n\t/* c */\n\t'a'\n)`)
+
+		expect(less(node)).toBe(`@foo: (\n\t/* c */\n\t'a'\n);`)
+	})
+
+	it(`leaves an ordinary at-rule alone`, () => {
+		let node = lessAtRule(`@media screen {}`)
+
+		node.params = `print`
+		syncLessVariableValue(node, node.params)
+
+		expect(`value` in node).toBe(false)
+		expect(less(node)).toBe(`@media print {}`)
+	})
+
+	it(`leaves a plain CSS at-rule alone`, () => {
+		let node = atRule(`@media screen {}`)
+
+		node.params = `print`
+		syncLessVariableValue(node, node.params)
+
+		expect(`value` in node).toBe(false)
+		expect(node.toString()).toBe(`@media print {}`)
+	})
+
+	it(`returns the at-rule it was given`, () => {
+		let node = lessAtRule(`@foo: "bar";`)
+
+		expect(syncLessVariableValue(node, `'bar'`)).toBe(node)
+	})
+})
+
+function atRule (code, parser = postcss) {
+	let list = []
+
+	parser.parse(code).walkAtRules((rule) => list.push(rule))
+
+	return list[0]
+}
+
+function lessAtRule (code) {
+	return atRule(code, postcssLess)
+}
+
+function less (node) {
+	return node.root().toString(postcssLess)
+}


### PR DESCRIPTION
Closes #99. Independent of the inline-comment cluster: nothing here touches how a comment is found or spelled, only where a fix is written.

## The defect

`postcss-less` recognises `@foo: "bar";` as an at-rule and then gives it a second copy of its text — `lib/nodes/variable.js:25` sets `node.value = node.params` — and its stringifier prints that copy, discarding the params outright:

```js
// LessStringifier.js:19
if (node.variable) {
  params = node.value;
}
```

Every rule that fixes an at-rule's parameters writes `params`. For such a node the write reached no output, while Stylelint counted the problem as fixed and dropped the warning with it. A run over a project therefore reported a clean pass on files it never touched, and a second `--fix` changed nothing either.

The issue names `string-quotes` and `indentation`. Three more rules lose a fix the same way, and are fixed here as well: `no-eol-whitespace`, `number-leading-zero` and `number-no-trailing-zeros`.

## The fix

`syncLessVariableValue` takes the text a rule has just written and mirrors it into the copy that is printed, doing nothing for any other at-rule. `setAtRuleParams` calls it, which covers `string-quotes`; the four rules that write the params directly call it where they write.

It takes the text rather than reading the node back, because the two copies part ways as soon as the params hold a comment: `postcss-less` keeps the comment in the raw and copies the cleaned text into `value`. A rule working in raw coordinates therefore hands over the spelling with the comment still in it, and the comment survives a fix it used to be dropped by:

```less
@foo: (
	/* c */
	"a"
);
```

## Why `indentation` does not go through `setAtRuleParams`

The issue proposes routing it there. That would break it, in two ways worth recording:

- `setAtRuleParams` writes `raws.params.raw` whenever a raw exists, while `indentation` computes its positions from `beforeBlockString()`, that is from the **cleaned** `node.params`. The coordinates part company on any parameters holding a comment.
- When the raw comes from `postcss-scss` — the `raws.params.scss` field — the stringifier prefers that field, and a write into `raw` is lost outright. That is the very defect this PR is about, in a new place.

So no rule changes *where* it writes; each one gains a mirror, and nothing but a Less at-variable behaves differently. Checked against `main` byte for byte on `postcss-scss` with an inline comment in the parameters, on plain CSS with a block comment in them, and on ordinary `@media`.

## Follow-ups

Two defects found on the way, each with its own issue and branch, neither included here:

- #103 — `indentation` applies only one of several fix positions to an at-rule's parameters, so the issue's own `@foo: (…)` example still comes out half-fixed until that lands. Plain CSS reproduces it.
- #104 — `unit-case` silently drops a fix in an at-rule whose name is not in lower case.
