### PR TITLE
Apply every fix position to an at-rule's parameters in `indentation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 	- a string standing in front of an inline comment under `postcss-scss` is now reported rather than silently rewritten, since such a value cannot be edited at all without losing the spelling of its comments;
 	- a string standing behind such a comment is passed over instead of being reported two characters off per comment, until an inline comment can be told apart from the code around it.
 - A Less at-variable now keeps the fix written to it (see [#99](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/99)). `postcss-less` gives such a variable two copies of its text and prints the one no rule writes, so `--fix` used to leave the file exactly as it was and drop the warning along with it, reporting a clean pass on a file it never touched. This held for every rule that fixes an at-rule's parameters: `indentation`, `no-eol-whitespace`, `number-leading-zero`, `number-no-trailing-zeros` and `string-quotes`.
+- The `indentation` rule now corrects every mis-indented line of an at-rule, and not only one of them (see [#103](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/103)). This holds for the parameters and for anything standing between the name and them, a multi-line comment for one. The remaining lines used to keep their indentation while all of the warnings disappeared, so a second run reported nothing left to fix.
 
 ## [5.3.0] — 2026–08–09
 

--- a/lib/rules/indentation/at-rules.test.js
+++ b/lib/rules/indentation/at-rules.test.js
@@ -278,6 +278,100 @@ testRule({
 testRule({
 	ruleName,
 	config: [1],
+	autoStripIndent: true,
+
+	reject: [
+		{
+			code: `
+				@media (min-width: 1px),
+							(max-width: 2px),
+							(min-height: 3px) {}
+			`,
+			fixed: `
+				@media (min-width: 1px),
+				 (max-width: 2px),
+				 (min-height: 3px) {}
+			`,
+			description: `every mis-indented line of the params, and not only one of them`,
+
+			warnings: [
+				{
+					message: messages.expected(`1 space`),
+					line: 2,
+					column: 4,
+				},
+				{
+					message: messages.expected(`1 space`),
+					line: 3,
+					column: 4,
+				},
+			],
+		},
+		{
+			code: `
+				@media
+						print,
+						screen {}
+			`,
+			fixed: `
+				@media
+				 print,
+				 screen {}
+			`,
+			description: `every mis-indented line, whichever side of the params it falls on`,
+
+			warnings: [
+				{
+					message: messages.expected(`1 space`),
+					line: 2,
+					column: 3,
+				},
+				{
+					message: messages.expected(`1 space`),
+					line: 3,
+					column: 3,
+				},
+			],
+		},
+		{
+			code: `
+				@media
+						/* a */
+						/* b */
+						print {}
+			`,
+			fixed: `
+				@media
+				 /* a */
+				 /* b */
+				 print {}
+			`,
+			description: `every mis-indented line in front of the params as well`,
+
+			warnings: [
+				{
+					message: messages.expected(`1 space`),
+					line: 2,
+					column: 3,
+				},
+				{
+					message: messages.expected(`1 space`),
+					line: 3,
+					column: 3,
+				},
+				{
+					message: messages.expected(`1 space`),
+					line: 4,
+					column: 3,
+				},
+			],
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [1],
 	customSyntax: `postcss-less`,
 	autoStripIndent: true,
 
@@ -298,6 +392,34 @@ testRule({
 			message: messages.expected(`1 space`),
 			line: 2,
 			column: 3,
+		},
+		{
+			code: `
+				@foo: (
+							'a',
+							'b'
+				);
+			`,
+			fixed: `
+				@foo: (
+				 'a',
+				 'b'
+				);
+			`,
+			description: `a Less at-variable keeps every fix written to its params`,
+
+			warnings: [
+				{
+					message: messages.expected(`1 space`),
+					line: 2,
+					column: 4,
+				},
+				{
+					message: messages.expected(`1 space`),
+					line: 3,
+					column: 4,
+				},
+			],
 		},
 	],
 })

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -414,26 +414,31 @@ function rule (primary, secondaryOptions = {}) {
 				if (isAtRule(node)) {
 					let atRuleName = node.name
 					let atRuleAfterName = node.raws.afterName
-					let atRuleParams = node.params
 
 					if (!isString(atRuleAfterName)) throw new TypeError(`The \`afterName\` property must be a string`)
 
+					// 1 — it's a @ length
+					let paramsStartIndex = 1 + atRuleName.length + atRuleAfterName.length
+
+					// The positions come in reverse order, so a fix never moves one still to be applied,
+					// and the text each of them edits is the one the previous fixes have left behind
 					for (let fixPosition of fixPositions) {
-						// 1 — it's a @ length
-						if (fixPosition.startIndex < 1 + atRuleName.length + atRuleAfterName.length) {
-							node.raws.afterName = replaceIndentation(
+						if (fixPosition.startIndex < paramsStartIndex) {
+							atRuleAfterName = replaceIndentation(
 								atRuleAfterName,
 								fixPosition.currentIndentation,
 								fixPosition.expectedIndentation,
 								fixPosition.startIndex - atRuleName.length - 1,
 							)
+
+							node.raws.afterName = atRuleAfterName
 						}
 						else {
 							node.params = replaceIndentation(
-								atRuleParams,
+								node.params,
 								fixPosition.currentIndentation,
 								fixPosition.expectedIndentation,
-								fixPosition.startIndex - atRuleName.length - atRuleAfterName.length - 1,
+								fixPosition.startIndex - paramsStartIndex,
 							)
 
 							syncLessVariableValue(node, node.params)


### PR DESCRIPTION
Closes #103. Second layer of the stack — the diff shown here is this layer alone; the one below it is #105.

## The defect

The at-rule branch of the fixer reads the parameters once, before the loop over the fix positions, and replays each of them against that copy:

```js
let atRuleParams = node.params

for (let fixPosition of fixPositions) {
  …
  node.params = replaceIndentation(atRuleParams, …)
}
```

Only the last write survives. The rule's other branches read the node again on each turn — `node.selector` for a rule, `node.value` for a declaration — and are unaffected.

The remaining lines keep their indentation while Stylelint counts every problem as fixed and drops all of the warnings, so a second run reports nothing left to do. Nothing preprocessor-specific is involved:

```css
@media (min-width: 1px),
			(max-width: 2px),
			(min-height: 3px) {}
```

With `"@stylistic/indentation": 1` this is reported at `2:4` and `3:4`, and `--fix` corrects line 2 alone.

## The fix

Each position is now applied to the text the previous ones have left behind, on both sides of the parameters — `raws.afterName` accumulates the same way, so a multi-line comment standing in front of the parameters is corrected line by line as well.

Only the length of the original prefix, `1 + name.length + afterName.length`, is kept from before the loop, for the offset arithmetic. The positions come in reverse order, so a write never moves one still to be applied and the offsets stay valid.

## Why it travels with #99

The Less example filed in #99 has two mis-indented lines, so it needs this layer as well as the one below to come out right:

```less
@foo: (
			'a',
			'b'
);
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
