### PR TITLE
Stop the `function-comma-*` rules from writing into an inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
+- The `function-comma-space-before`, `function-comma-space-after`, `function-comma-newline-before` and `function-comma-newline-after` rules no longer write into an inline comment standing in a function's arguments (see [#135](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135)):
+	- a comma standing behind such a comment is no longer taken onto its line, since the line break in front of the comma is what closes the comment, so the problem is now reported rather than fixed;
+	- a comma standing inside the text of such a comment is no longer taken for a comma of the value at all, so nothing is reported for it and nothing written near it.
 - The `declaration-colon-space-after` rule now looks for the whitespace after the colon where a custom property whose value holds a comment actually keeps it (see [#109](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/109)) ([@VChet](https://github.com/VChet)):
 	- the `always` options no longer report `--a: /*comment*/ !important;`, whose single space is already in place, and no longer pass over `--a:/*comment*/ !important;`, which has none at all;
 	- their fix no longer adds a space of its own on every run, so two spaces or a tab after the colon now become the single space asked for;

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -55,6 +55,7 @@ function rule (primary, secondaryOptions, context) {
 			result,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
+			fixPosition: `after`,
 			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,

--- a/lib/rules/function-comma-newline-after/index.test.js
+++ b/lib/rules/function-comma-newline-after/index.test.js
@@ -550,3 +550,33 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is asked for no line break of its own`,
+			code: `a { t: translate(1px,\n  2px // a, b\n  ); }`,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never-multi-line`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px,2px // a, b\n  ); }`,
+		},
+	],
+})

--- a/lib/rules/function-comma-newline-before/index.js
+++ b/lib/rules/function-comma-newline-before/index.js
@@ -55,6 +55,7 @@ function rule (primary, secondaryOptions, context) {
 			result,
 			locationChecker: checker.beforeAllowingIndentation,
 			checkedRuleName: ruleName,
+			fixPosition: `before`,
 			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,

--- a/lib/rules/function-comma-newline-before/index.test.js
+++ b/lib/rules/function-comma-newline-before/index.test.js
@@ -441,3 +441,45 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`never-multi-line`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px, // a , b\n  2px); }`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the value is left alone and the warning stands`,
+			code: `a { t: translate(1px // c\n  ,2px); }`,
+			fixed: `a { t: translate(1px // c\n  ,2px); }`,
+			message: messages.rejectedBeforeMultiLine(),
+			line: 2,
+			column: 3,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is asked for no line break of its own`,
+			code: `a { t: translate(1px\n, // a, b\n  2px); }`,
+		},
+	],
+})

--- a/lib/rules/function-comma-space-after/index.js
+++ b/lib/rules/function-comma-space-after/index.js
@@ -56,6 +56,7 @@ function rule (primary, secondaryOptions) {
 			result,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
+			fixPosition: `after`,
 			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,

--- a/lib/rules/function-comma-space-after/index.test.js
+++ b/lib/rules/function-comma-space-after/index.test.js
@@ -564,3 +564,33 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px,2px // a, b\n  ); }`,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px, 2px // a, b\n  ); }`,
+		},
+	],
+})

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -56,6 +56,7 @@ function rule (primary, secondaryOptions) {
 			result,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
+			fixPosition: `before`,
 			ignoreFunctions: secondaryOptions?.ignoreFunctions,
 			fix: (div, index, nodes) => functionCommaSpaceFix({
 				div,

--- a/lib/rules/function-comma-space-before/index.test.js
+++ b/lib/rules/function-comma-space-before/index.test.js
@@ -471,3 +471,57 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px , // a, b\n  2px); }`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the value is left alone and the warning stands`,
+			code: `a { t: translate(1px // c\n  ,2px); }`,
+			fixed: `a { t: translate(1px // c\n  ,2px); }`,
+			message: messages.expectedBefore(),
+			line: 2,
+			column: 3,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `a { t: translate(1px, // a , b\n  2px); }`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the value is left alone and the warning stands`,
+			code: `a { t: translate(1px // c\n  ,2px); }`,
+			fixed: `a { t: translate(1px // c\n  ,2px); }`,
+			message: messages.rejectedBefore(),
+			line: 2,
+			column: 3,
+		},
+	],
+})

--- a/lib/utils/functionCommaSpaceChecker/index.js
+++ b/lib/utils/functionCommaSpaceChecker/index.js
@@ -2,6 +2,8 @@ import valueParser from "postcss-value-parser"
 import stylelint from "stylelint"
 
 import { declarationValueIndex } from "../declarationValueIndex/index.js"
+import { endsWithInlineComment } from "../endsWithInlineComment/index.js"
+import { findInlineCommentSpans } from "../findInlineCommentSpans/index.js"
 import { getDeclarationValue } from "../getDeclarationValue/index.js"
 import { isStandardSyntaxFunction } from "../isStandardSyntaxFunction/index.js"
 import { optionsMatches } from "../optionsMatches/index.js"
@@ -26,12 +28,17 @@ let { utils: { report } } = stylelint
  *   fix: ((node: ValueParserDivNode, index: number, nodes: ValueParserNode[]) => boolean),
  *   result: import('stylelint').PostcssResult,
  *   checkedRuleName: string,
+ *   fixPosition?: 'before' | 'after',
  *   ignoreFunctions?: string | RegExp | Array<string | RegExp>,
  * }} opts - The options object
  */
 export function functionCommaSpaceChecker (opts) {
 	opts.root.walkDecls((decl) => {
 		let declValue = getDeclarationValue(decl)
+		// A double slash opens a comment that runs to the end of its line, and `postcss-value-parser`
+		// knows nothing of the kind: it reads the text of such a comment as code of the value, and
+		// every comma standing in that text as a comma of the value
+		let inlineComments = findInlineCommentSpans(declValue)
 
 		let hasFixed
 		let parsedValue = valueParser(declValue)
@@ -82,6 +89,9 @@ export function functionCommaSpaceChecker (opts) {
 			for (let [nodeIndex, node] of valueNode.nodes.entries()) {
 				if (node.type !== `div` || node.value !== `,`) continue
 
+				// A comma inside the text of an inline comment is a comma of that text and of nothing else
+				if (isCommentedOut(node)) continue
+
 				let checkIndex = getCommaCheckIndex(node, nodeIndex)
 
 				commaDataList.push({
@@ -89,6 +99,37 @@ export function functionCommaSpaceChecker (opts) {
 					checkIndex,
 					nodeIndex,
 				})
+			}
+
+			/**
+			 * Asks whether a comma stands in the text of an inline comment rather than in the value.
+			 * @param {ValueParserDivNode} commaNode - The comma to place.
+			 * @returns {boolean} True if the comma is inside a comment.
+			 */
+			function isCommentedOut (commaNode) {
+				// A div node begins where its own leading whitespace does, and that whitespace is what
+				// closed the comment where one stands in front of the comma: the comma itself is what
+				// has to be placed, and it stands behind that whitespace.
+				let commaIndex = commaNode.sourceIndex + commaNode.before.length
+
+				return inlineComments.some(({ start, end }) => commaIndex >= start && commaIndex < end)
+			}
+
+			/**
+			 * Asks whether the comma can be moved at all.
+			 *
+			 * The `before` rules write the whitespace standing in front of the comma, and where an inline
+			 * comment ends that whitespace, the line break it holds is what closes the comment. Neither
+			 * option can be satisfied without taking the comma, and everything the declaration has left,
+			 * into the comment's text: leave the value alone and let the warning stand. The `after` rules
+			 * write behind the comma, where no comment can be open, so they ask nothing.
+			 * @param {ValueParserDivNode} commaNode - The comma being fixed.
+			 * @returns {boolean} True if the fix can write without commenting the comma out.
+			 */
+			function isFixable (commaNode) {
+				if (opts.fixPosition !== `before`) return true
+
+				return !endsWithInlineComment(declValue.slice(0, commaNode.sourceIndex))
 			}
 
 			function createErrHandler (commaNode, nodeIndex) {
@@ -102,7 +143,7 @@ export function functionCommaSpaceChecker (opts) {
 						node: decl,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: opts.fix
+						fix: opts.fix && isFixable(commaNode)
 							? () => {
 								hasFixed = true
 


### PR DESCRIPTION
Closes #135.

## The defect

`functionCommaSpaceChecker` hands the value to `postcss-value-parser`, which knows nothing of a comment opened by a double slash. Two things follow, and all four rules suffer both.

A comma standing **inside** the text of such a comment is read as a comma of the value. The `space` rules then write a space into the comment's text, and the `newline` rules a line break, which cuts the comment in two and gives the rest of its text back to the code:

```less
a { t: translate(1px, // a, b
  2px); }
```

```less
a { t: translate(1px
, // a
, b
  2px); }
```

A comma standing **behind** such a comment is a real one, but the whitespace the `before` rules write is what holds the line break closing the comment, so either option takes the comma, and everything the declaration has left, into the comment's text:

```less
a { t: translate(1px // c
  ,2px); }
```

```less
a { t: translate(1px // c ,2px); }
```

No warning survives either run: `--fix` reports a clean pass on a file it has just broken.

## The fix

The checker places every comma against the spans `findInlineCommentSpans` reports, and passes over the ones standing inside a comment.

Each rule says where its fix writes, through the new `fixPosition` option, and where that is in front of the comma, `endsWithInlineComment` is asked about the text the write lands after: the warning stands and the value is left alone where it says yes. This is the guard #113, #114, #116 and #117 already use. The `after` rules write behind the comma, where no comment can be open, so they ask nothing and pay nothing.

The question is asked once at most per comma, and only where a problem has been found: reading the value in front of a comma is no work to do for one nothing is the matter with.

## Testing

Eleven cases across the four rules, each written against `postcss-less`, which keeps a double slash in a value as ordinary text and therefore breaks today. Nine of them were checked by mutation: taking the placing out fails six, and disabling the guard fails the other three.

The remaining two are the `never` and `never-multi-line` accepts, and they document the contract rather than pin it. The checker's own index mapping already neutralises a commented-out comma for those options: `getCommaCheckIndex` strips the comment away and lands the check on the character straight after the real comma, which is the comma itself, so a `before` checker asking for no whitespace is satisfied whatever the placing does. No input can make them fail while that mapping stands.

Under `postcss-scss` the same fixes are discarded on the way out, so nothing there can be asserted until #115 lets them through — which is what this branch is under.
