### PR TITLE
Stop `media-query-list-comma-space-before` from taking the comma into an inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
+- The `media-query-list-comma-space-before` rule no longer takes a comma standing behind an inline comment onto that comment's line (see [#137](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/137)). The line break in front of the comma is what closes such a comment, so neither option can be satisfied without commenting out the rest of the query and the block behind it, and the problem is now reported rather than fixed.
 - The `value-list-comma-space-before` rule no longer takes a comma standing behind an inline comment onto that comment's line (see [#136](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/136)). The line break in front of the comma is what closes such a comment, so neither option can be satisfied without commenting out the rest of the declaration, and the problem is now reported rather than fixed.
 - The `function-comma-space-before`, `function-comma-space-after`, `function-comma-newline-before` and `function-comma-newline-after` rules no longer write into an inline comment standing in a function's arguments (see [#135](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135)):
 	- a comma standing behind such a comment is no longer taken onto its line, since the line break in front of the comma is what closes the comment, so the problem is now reported rather than fixed;

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -2,6 +2,7 @@ import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.js"
+import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { mediaQueryListCommaWhitespaceChecker } from "../../utils/mediaQueryListCommaWhitespaceChecker/index.js"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.js"
@@ -44,6 +45,11 @@ function rule (primary) {
 			result,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
+			// The comma goes right after this text, and the whitespace run the fix writes ends it.
+			// Where an inline comment stands there, the line break that run holds is what closes the
+			// comment, so either option would take the comma, and the whole query behind it, into the
+			// comment's text: leave the parameters alone and let the warning stand
+			isFixable: (params, index) => !endsWithInlineComment(params.slice(0, index)),
 			fix: (atRule, index) => {
 				let paramCommaIndex = index - atRuleParamIndex(atRule)
 

--- a/lib/rules/media-query-list-comma-space-before/index.test.js
+++ b/lib/rules/media-query-list-comma-space-before/index.test.js
@@ -407,3 +407,64 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/137
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the parameters are left alone and the warning stands`,
+			code: `
+				@media (min-width: 1px) // c
+				,(max-width: 2px) { a { color: red; } }
+			`,
+			fixed: `
+				@media (min-width: 1px) // c
+				,(max-width: 2px) { a { color: red; } }
+			`,
+			message: messages.expectedBefore(),
+			line: 2,
+			column: 1,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/137
+			description: `a comma inside the text of an inline comment is no comma of the query`,
+			code: `
+				@media (min-width: 1px), // a , b
+				(max-width: 2px) { a { color: red; } }
+			`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/137
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the parameters are left alone and the warning stands`,
+			code: `
+				@media (min-width: 1px) // c
+				,(max-width: 2px) { a { color: red; } }
+			`,
+			fixed: `
+				@media (min-width: 1px) // c
+				,(max-width: 2px) { a { color: red; } }
+			`,
+			message: messages.rejectedBefore(),
+			line: 2,
+			column: 1,
+		},
+	],
+})

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.js
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.js
@@ -14,6 +14,7 @@ let { utils: { report } } = stylelint
  *   locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
  *   checkedRuleName: string,
  *   fix?: ((atRule: import('postcss').AtRule, index: number) => boolean) | undefined,
+ *   isFixable?: ((params: string, index: number) => boolean),
  *   allowTrailingComments?: boolean,
  * }} opts - The options object
  */
@@ -58,6 +59,10 @@ export function mediaQueryListCommaWhitespaceChecker (opts) {
 			index,
 			err: (message) => {
 				let commaIndex = index + atRuleParamIndex(node)
+				// A rule may know that this particular problem cannot be fixed without breaking the code.
+				// The question is asked here rather than in front of the check, so that a set of
+				// parameters whose commas are all in order is not read through once per comma for nothing.
+				let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(source, index))
 
 				report({
 					message,
@@ -66,7 +71,7 @@ export function mediaQueryListCommaWhitespaceChecker (opts) {
 					endIndex: commaIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: opts.fix ? () => opts.fix(node, commaIndex) : undefined,
+					fix: isFixable ? () => opts.fix(node, commaIndex) : undefined,
 				})
 			},
 		})


### PR DESCRIPTION
Closes #137.

The twin of #136 in the parameters of an at-rule, and the same repair.

## The defect

The comma goes right after the whitespace the fix writes, and where an inline comment stands there, the line break that whitespace holds is what closes the comment. Either option therefore takes the comma, the rest of the query and the block behind it into the comment's text:

```less
@media (min-width: 1px) // c
  ,(max-width: 2px) { a { color: red; } }
```

```less
@media (min-width: 1px) // c ,(max-width: 2px) { a { color: red; } }
```

`never` does the same without the space. No warning survives the run: `--fix` reports a clean pass on a file it has just broken.

## The fix

The rule asks `endsWithInlineComment` about the text the write lands after, and reports without writing where it says yes. `mediaQueryListCommaWhitespaceChecker` gained the optional `isFixable` its siblings carry for the same reason, and the rule answers it with the parameters the checker has already read.

## Testing

Two cases, one per option, written against `postcss-less`, which keeps a double slash in a set of parameters as ordinary text and therefore breaks today. Both were checked by mutation: with the guard answering yes to everything, both fail.

Under `postcss-scss` the same fix is discarded on the way out, so nothing there can be asserted until #115 lets it through — which is what this branch is under.
