### PR TITLE
Stop `value-list-comma-space-before` from taking the comma into an inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 
 ### Fixed
 
+- The `value-list-comma-space-before` rule no longer takes a comma standing behind an inline comment onto that comment's line (see [#136](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/136)). The line break in front of the comma is what closes such a comment, so neither option can be satisfied without commenting out the rest of the declaration, and the problem is now reported rather than fixed.
 - The `function-comma-space-before`, `function-comma-space-after`, `function-comma-newline-before` and `function-comma-newline-after` rules no longer write into an inline comment standing in a function's arguments (see [#135](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/135)):
 	- a comma standing behind such a comment is no longer taken onto its line, since the line break in front of the comma is what closes the comment, so the problem is now reported rather than fixed;
 	- a comma standing inside the text of such a comment is no longer taken for a comma of the value at all, so nothing is reported for it and nothing written near it.

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -2,6 +2,7 @@ import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
+import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.js"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.js"
@@ -50,11 +51,16 @@ function rule (primary) {
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// Stylelint counts a fixer as applied whatever it does, so a rule that cannot
-			// repair a problem has to say so here rather than from inside the fixer.
-			// A comma standing before the value is one such: it belongs to the property
-			// name, and nothing this rule could write would reach it. The boundary is off
-			// by one and takes a comma opening the value with it, which is #134.
-			isFixable: (declNode, index) => index > declarationValueIndex(declNode),
+			// repair a problem has to say so here rather than from inside the fixer. Two of them
+			// are such, and the comma has to clear both.
+			// A comma standing before the value belongs to the property name, and nothing this
+			// rule could write would reach it. The boundary is off by one and takes a comma
+			// opening the value with it, which is #134.
+			// A comma standing behind an inline comment cannot be moved either: the comma goes
+			// right after the whitespace the fix writes, and the line break that whitespace holds
+			// is what closes the comment, so either option would take the comma, and everything
+			// the declaration has left, into the comment's text.
+			isFixable: (declNode, index, declString) => index > declarationValueIndex(declNode) && !endsWithInlineComment(declString.slice(0, index)),
 			fix: (declNode, index) => {
 				fixData = fixData || (new Map())
 

--- a/lib/rules/value-list-comma-space-before/index.test.js
+++ b/lib/rules/value-list-comma-space-before/index.test.js
@@ -351,3 +351,74 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/136
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the value is left alone and the warning stands`,
+			code: `
+				a {
+					b: 'x' // c
+					,'y';
+				}
+			`,
+			fixed: `
+				a {
+					b: 'x' // c
+					,'y';
+				}
+			`,
+			message: messages.expectedBefore(),
+			line: 3,
+			column: 2,
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [`never`],
+	customSyntax: `postcss-less`,
+	autoStripIndent: true,
+
+	accept: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/136
+			description: `a comma inside the text of an inline comment is no comma of the value`,
+			code: `
+				a {
+					b: 'x', // a , b
+						'y';
+				}
+			`,
+		},
+	],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/136
+			description: `inline comment before the comma: the comma cannot join the comment's line, so the value is left alone and the warning stands`,
+			code: `
+				a {
+					b: 'x' // c
+					,'y';
+				}
+			`,
+			fixed: `
+				a {
+					b: 'x' // c
+					,'y';
+				}
+			`,
+			message: messages.rejectedBefore(),
+			line: 3,
+			column: 2,
+		},
+	],
+})

--- a/lib/utils/valueListCommaWhitespaceChecker/index.js
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.js
@@ -13,7 +13,7 @@ let { utils: { report } } = stylelint
  * @property {(opts: { source: string, index: number, err: (msg: string) => void }) => void} locationChecker - The location checker function
  * @property {string} checkedRuleName - The name of the rule being checked.
  * @property {((node: import('postcss').Declaration, index: number) => void)} [fix] - The fix function.
- * @property {((node: import('postcss').Declaration, index: number) => boolean)} [isFixable] - Tells whether this particular problem can be fixed.
+ * @property {((node: import('postcss').Declaration, index: number, declString: string) => boolean)} [isFixable] - Tells whether this particular problem can be fixed. The declaration comes with it as the checker has already printed it, so that a rule reading the text in front of the comma need not print it again.
  * @property {((declString: string, match: import('style-search').StyleSearchMatch) => number | false)} [determineIndex] - The index determination function.
  */
 
@@ -52,15 +52,17 @@ export function valueListCommaWhitespaceChecker (opts) {
 	 * @returns {void}
 	 */
 	function checkComma (source, index, node) {
-		// A rule may know that this particular problem cannot be fixed without breaking the code.
-		// Stylelint counts a fixer as applied whatever it does, so a fixer that declines from the
-		// inside takes the warning down with it; the decision has to be made before the report.
-		let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(node, index))
-
 		opts.locationChecker({
 			source,
 			index,
 			err: (message) => {
+				// A rule may know that this particular problem cannot be fixed without breaking the code.
+				// Stylelint counts a fixer as applied whatever it does, so a fixer that declines from the
+				// inside takes the warning down with it; the decision has to be made before the report.
+				// It is made here rather than in front of the check, so that a declaration whose commas
+				// are all in order is not read through once per comma for nothing.
+				let isFixable = opts.fix && (!opts.isFixable || opts.isFixable(node, index, source))
+
 				report({
 					message,
 					node,


### PR DESCRIPTION
Closes #136.

## The defect

The comma goes right after the whitespace the fix writes, and where an inline comment stands there, the line break that whitespace holds is what closes the comment. Either option therefore takes the comma, and everything the declaration has left, into the comment's text:

```less
a {
  b: 'x' // c
  ,'y';
}
```

```less
a {
  b: 'x' // c ,'y';
}
```

`never` does the same without the space. No warning survives the run: `--fix` reports a clean pass on a file it has just broken.

A comma inside the text of a comment is not affected here: `style-search`, which finds the commas of a value, skips an inline comment already.

## The fix

The rule asks `endsWithInlineComment` about the text the write lands after, and reports without writing where it says yes — the guard #113, #114, #116 and #117 already use.

`valueListCommaWhitespaceChecker` grew its `isFixable` option in #126, for the other thing this rule cannot repair: a comma standing in the property name, which no fix of its own could reach. The two are independent, and a comma has to clear both, so they compose into one predicate. The option gains a third argument — the declaration as the checker has already printed it — so that a rule reading the text in front of the comma need not print it again, and the two rules that answer `isFixable` with `(declNode, index)` are untouched.

The question is also moved inside `err`, where a problem has actually been found. It ran once per comma before, reported or not, and `endsWithInlineComment` reads the declaration from the start each time: on a value carrying two thousand commas and no problem at all, that was 652 ms against the 29 ms of a rule with no guard.

## Testing

Three cases, written against `postcss-less`, which keeps a double slash in a value as ordinary text and therefore breaks today: one per option showing that the comma is reported and the value left alone, and one showing that a comma inside a comment's text is no comma of the value.

Both halves of the composed guard are pinned: dropping the inline-comment half fails the two rejects, and dropping #126's boundary fails the case that rule brought — the comma standing in a property name.

Under `postcss-scss` the same fix is discarded on the way out, so nothing there can be asserted until #115 lets it through — which is what this branch is under.
