### PR TITLE
Move the inline-comment helpers of `string-quotes` into `lib/utils/`

### DIFF
--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -3,12 +3,15 @@ import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.js"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.js"
+import { blankInlineComments } from "../../utils/blankInlineComments/index.js"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.js"
+import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.js"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.js"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.js"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.js"
 import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.js"
 import { parseSelector } from "../../utils/parseSelector/index.js"
+import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.js"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.js"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.js"
 import { isAtRule } from "../../utils/typeGuards/index.js"
@@ -32,10 +35,7 @@ export let meta = {
 let singleQuote = `'`
 let doubleQuote = `"`
 
-/**
- * The span an inline comment occupies in a value, in the coordinates of the file, and how far the copy a syntax rewrote its comments in has run away from that value by the end of the comment.
- * @typedef {{ start: number, end: number, delta?: number }} InlineCommentSpan
- */
+/** @typedef {import('../../utils/findInlineCommentSpans/index.js').InlineCommentSpan} InlineCommentSpan */
 
 /**
  * Specifies single or double quotes around strings.
@@ -336,102 +336,6 @@ function syntaxKeepsInlineComments (syntax) {
 }
 
 /**
- * Finds the spans the inline comments of a string occupy in it. A double slash belonging to an address opens no comment, whether the address is quoted or bare inside `url()`, and neither does one inside a block comment; a comment ends with its line rather than with the string.
- * @param {string} text - The string to scan.
- * @returns {InlineCommentSpan[]} The spans, in the coordinates of the scanned string.
- */
-function findInlineCommentSpans (text) {
-	/** @type {InlineCommentSpan[]} */
-	let spans = []
-	let index = 0
-
-	while (index < text.length) {
-		let character = text[index]
-		let next = text[index + 1]
-
-		if (character === `"` || character === `'`) {
-			index = skipString(text, index)
-		}
-		else if (character === `u` || character === `U`) {
-			let behindUrl = skipUrl(text, index)
-
-			index = behindUrl === index ? index + 1 : behindUrl
-		}
-		else if (character === `/` && next === `*`) {
-			let closeIndex = text.indexOf(`*/`, index + 2)
-
-			index = closeIndex === -1 ? text.length : closeIndex + 2
-		}
-		else if (character === `/` && next === `/`) {
-			let lineBreakIndex = text.indexOf(`\n`, index)
-			let end = lineBreakIndex === -1 ? text.length : lineBreakIndex
-
-			spans.push({ start: index, end })
-			index = end
-		}
-		else {
-			index += 1
-		}
-	}
-
-	return spans
-}
-
-/**
- * Skips a `url()` token, whose address carries its double slashes as ordinary characters whether it is quoted or bare. The name has to stand on its own — `image-url(` and `@{prefix}url(` end in the same four characters while being ordinary calls, whose arguments may hold a comment — and the parentheses are counted rather than searched for, since an interpolated address brings its own. A parenthesis that is escaped, quoted or commented out is none, and a token left open is taken for no token at all, so that a comment standing behind it is still seen.
- * @param {string} text - The string being scanned.
- * @param {number} openIndex - The index the token would start at.
- * @returns {number} The index behind the closing parenthesis, or the given one if no `url()` starts and ends there.
- */
-function skipUrl (text, openIndex) {
-	if (text.slice(openIndex, openIndex + 4).toLowerCase() !== `url(`) return openIndex
-
-	if (openIndex > 0 && (/[\w}-]/u).test(text[openIndex - 1])) return openIndex
-
-	let depth = 1
-	let index = openIndex + 4
-
-	while (index < text.length && depth > 0) {
-		let character = text[index]
-
-		if (character === `\\`) {
-			index += 2
-		}
-		else if (character === `"` || character === `'`) {
-			index = skipString(text, index)
-		}
-		else if (character === `/` && text[index + 1] === `*`) {
-			let closeIndex = text.indexOf(`*/`, index + 2)
-
-			index = closeIndex === -1 ? text.length : closeIndex + 2
-		}
-		else {
-			if (character === `(`) depth += 1
-			else if (character === `)`) depth -= 1
-
-			index += 1
-		}
-	}
-
-	return depth > 0 ? openIndex : index
-}
-
-/**
- * Skips a quoted string, from its opening quote to the character behind its closing one. An escaped quotation mark closes nothing, and a string mistaken for closed here would leave the text of the next one exposed to the scan.
- * @param {string} text - The string being scanned.
- * @param {number} openIndex - The index of the opening quote.
- * @returns {number} The index behind the closing quote, or the end of the scanned string.
- */
-function skipString (text, openIndex) {
-	let quote = text[openIndex]
-	let index = openIndex + 1
-
-	while (index < text.length && text[index] !== quote) index += text[index] === `\\` ? 2 : 1
-
-	return index + 1
-}
-
-/**
  * Finds the spans the inline comments of a value occupy in it, out of the two copies `postcss-scss` keeps of that value: one with every inline comment rewritten into a block comment, and one spelled as the file spells it. Only the comments set the two apart, so the first character they disagree on is the second character of one — the asterisk of a block comment against the second slash of an inline one. A comment ends with its line in both copies, and none of them holds a line break, so the next line break puts the two back in step whatever the rewriting did to the text in between, and the distance between them there is what a position behind the comment has to be moved by to be read in the rewritten copy.
  *
  * Everything here rests on the two copies being the two copies of one text, which holds only until a rule writes to one of them and leaves the other where it was — a line break of the raw taken away, a colour spelled differently in it, a space put in front of it. The reading is therefore checked against the raw before it is handed out, by rewriting the comments it found the way the syntax rewrote them, and nothing is returned unless the raw comes back character for character.
@@ -474,40 +378,6 @@ function findRewrittenCommentSpans (rewritten, spelled) {
 
 	// A reading of one copy against the other proves nothing by itself: the walk above sees where the two part company, not whether they ever meant the same text. Rewriting the comments it found the way the syntax rewrites them does prove it — the raw comes back or it does not.
 	return rewriteInlineComments(spelled, spans) === rewritten ? spans : null
-}
-
-/**
- * Rewrites the inline comments of a value into block comments, as `postcss-scss` does when it fills the raw of that value: the two slashes opening a comment become the two characters opening a block comment, its line break becomes the two closing them, and a `*` followed by `/` in the text — or the other way round — is cut in two so that it closes nothing.
- * @param {string} spelled - The copy spelled as the file spells it.
- * @param {InlineCommentSpan[]} spans - The spans its inline comments occupy in it.
- * @returns {string} The value with each of those comments rewritten.
- */
-function rewriteInlineComments (spelled, spans) {
-	let rewritten = ``
-	let index = 0
-
-	for (let { start, end } of spans) {
-		let text = spelled.slice(start + 2, end).replaceAll(/(\*\/|\/\*)/gu, `*//*`)
-
-		rewritten += `${spelled.slice(index, start)}/*${text}*/`
-		index = end
-	}
-
-	return `${rewritten}${spelled.slice(index)}`
-}
-
-/**
- * Blanks the text of the inline comments a value carries out of it, so that the tokenizer reading that value finds no code in them. A quotation mark inside a comment would open a string for it otherwise, and every string on the far side of the comment would be read one quotation mark out of step, the fix then taking those readings for the code and pulling the value apart. The spaces standing in leave every position of the value where it was, and no comment holds a line break for them to swallow.
- * @param {string} value - The value to blank the comments of.
- * @param {InlineCommentSpan[]} spans - The spans of the inline comments the value carries.
- * @returns {string} The value, with the text of each of its inline comments replaced by spaces.
- */
-function blankInlineComments (value, spans) {
-	let blanked = value
-
-	for (let { start, end } of spans) blanked = blanked.slice(0, start) + ` `.repeat(end - start) + blanked.slice(end)
-
-	return blanked
 }
 
 /**

--- a/lib/utils/blankInlineComments/index.js
+++ b/lib/utils/blankInlineComments/index.js
@@ -1,0 +1,17 @@
+import { findInlineCommentSpans } from "../findInlineCommentSpans/index.js"
+
+/** @typedef {import('../findInlineCommentSpans/index.js').InlineCommentSpan} InlineCommentSpan */
+
+/**
+ * Blanks the text of the inline comments a value carries out of it, so that a parser reading that value finds no code in them. A quotation mark inside a comment would open a string for it otherwise, and every string on the far side of the comment would be read one quotation mark out of step, the fix then taking those readings for the code and pulling the value apart. The spaces standing in leave every position of the value where it was, and no comment holds a line break for them to swallow.
+ * @param {string} value - The value to blank the comments of.
+ * @param {InlineCommentSpan[]} [spans] - The spans its inline comments occupy in it, where they are already known.
+ * @returns {string} The value, with the text of each of its inline comments replaced by spaces.
+ */
+export function blankInlineComments (value, spans = findInlineCommentSpans(value)) {
+	let blanked = value
+
+	for (let { start, end } of spans) blanked = blanked.slice(0, start) + ` `.repeat(end - start) + blanked.slice(end)
+
+	return blanked
+}

--- a/lib/utils/blankInlineComments/index.test.js
+++ b/lib/utils/blankInlineComments/index.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import { blankInlineComments } from "./index.js"
+
+/**
+ * Spaces, spelled out so that no editor trims them off the end of a line.
+ * @param {number} count - How many.
+ * @returns {string} That many spaces.
+ */
+function spaces (count) {
+	return ` `.repeat(count)
+}
+
+describe(`blankInlineComments`, () => {
+	it(`no comment`, () => {
+		expect(blankInlineComments(`1px 2px`)).toBe(`1px 2px`)
+	})
+
+	it(`a comment running to the end`, () => {
+		expect(blankInlineComments(`1px // c`)).toBe(`1px ${spaces(4)}`)
+	})
+
+	it(`a comment ending with its line`, () => {
+		expect(blankInlineComments(`1px // c\n2px`)).toBe(`1px ${spaces(4)}\n2px`)
+	})
+
+	it(`the value keeps its length`, () => {
+		let value = `1px // a, b\n2px // c\n3px`
+
+		expect(blankInlineComments(value)).toHaveLength(value.length)
+	})
+
+	it(`a quotation mark inside a comment opens no string`, () => {
+		expect(blankInlineComments(`1px // it's\n'x'`)).toBe(`1px ${spaces(7)}\n'x'`)
+	})
+
+	it(`a double slash of an address is left alone`, () => {
+		expect(blankInlineComments(`url(http://x/y.png)`)).toBe(`url(http://x/y.png)`)
+	})
+
+	it(`the spans may be handed in`, () => {
+		expect(blankInlineComments(`1px // c\n2px`, [])).toBe(`1px // c\n2px`)
+	})
+})

--- a/lib/utils/findInlineCommentSpans/index.js
+++ b/lib/utils/findInlineCommentSpans/index.js
@@ -1,0 +1,100 @@
+/**
+ * The span an inline comment occupies in a value, in the coordinates of the file, and how far the copy a syntax rewrote its comments in has run away from that value by the end of the comment.
+ * @typedef {{ start: number, end: number, delta?: number }} InlineCommentSpan
+ */
+
+/**
+ * Finds the spans the inline comments of a string occupy in it. A double slash belonging to an address opens no comment, whether the address is quoted or bare inside `url()`, and neither does one inside a block comment; a comment ends with its line rather than with the string.
+ * @param {string} text - The string to scan.
+ * @returns {InlineCommentSpan[]} The spans, in the coordinates of the scanned string.
+ */
+export function findInlineCommentSpans (text) {
+	/** @type {InlineCommentSpan[]} */
+	let spans = []
+	let index = 0
+
+	while (index < text.length) {
+		let character = text[index]
+		let next = text[index + 1]
+
+		if (character === `"` || character === `'`) {
+			index = skipString(text, index)
+		}
+		else if (character === `u` || character === `U`) {
+			let behindUrl = skipUrl(text, index)
+
+			index = behindUrl === index ? index + 1 : behindUrl
+		}
+		else if (character === `/` && next === `*`) {
+			let closeIndex = text.indexOf(`*/`, index + 2)
+
+			index = closeIndex === -1 ? text.length : closeIndex + 2
+		}
+		else if (character === `/` && next === `/`) {
+			let lineBreakIndex = text.indexOf(`\n`, index)
+			let end = lineBreakIndex === -1 ? text.length : lineBreakIndex
+
+			spans.push({ start: index, end })
+			index = end
+		}
+		else {
+			index += 1
+		}
+	}
+
+	return spans
+}
+
+/**
+ * Skips a `url()` token, whose address carries its double slashes as ordinary characters whether it is quoted or bare. The name has to stand on its own — `image-url(` and `@{prefix}url(` end in the same four characters while being ordinary calls, whose arguments may hold a comment — and the parentheses are counted rather than searched for, since an interpolated address brings its own. A parenthesis that is escaped, quoted or commented out is none, and a token left open is taken for no token at all, so that a comment standing behind it is still seen.
+ * @param {string} text - The string being scanned.
+ * @param {number} openIndex - The index the token would start at.
+ * @returns {number} The index behind the closing parenthesis, or the given one if no `url()` starts and ends there.
+ */
+function skipUrl (text, openIndex) {
+	if (text.slice(openIndex, openIndex + 4).toLowerCase() !== `url(`) return openIndex
+
+	if (openIndex > 0 && (/[\w}-]/u).test(text[openIndex - 1])) return openIndex
+
+	let depth = 1
+	let index = openIndex + 4
+
+	while (index < text.length && depth > 0) {
+		let character = text[index]
+
+		if (character === `\\`) {
+			index += 2
+		}
+		else if (character === `"` || character === `'`) {
+			index = skipString(text, index)
+		}
+		else if (character === `/` && text[index + 1] === `*`) {
+			let closeIndex = text.indexOf(`*/`, index + 2)
+
+			index = closeIndex === -1 ? text.length : closeIndex + 2
+		}
+		else {
+			if (character === `(`) depth += 1
+			else if (character === `)`) depth -= 1
+
+			index += 1
+		}
+	}
+
+	return depth > 0 ? openIndex : index
+}
+
+/**
+ * Skips a quoted string, from its opening quote to the character behind its closing one. An escaped quotation mark closes nothing, and a string mistaken for closed here would leave the text of the next one exposed to the scan.
+ * @param {string} text - The string being scanned.
+ * @param {number} openIndex - The index of the opening quote.
+ * @returns {number} The index behind the closing quote, or the end of the scanned string.
+ */
+function skipString (text, openIndex) {
+	let quote = text[openIndex]
+	let index = openIndex + 1
+
+	while (index < text.length && text[index] !== quote) index += text[index] === `\\` ? 2 : 1
+
+	return index + 1
+}

--- a/lib/utils/findInlineCommentSpans/index.test.js
+++ b/lib/utils/findInlineCommentSpans/index.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import { findInlineCommentSpans } from "./index.js"
+
+describe(`findInlineCommentSpans`, () => {
+	it(`no comment`, () => {
+		expect(findInlineCommentSpans(`1px 2px`)).toEqual([])
+	})
+
+	it(`a comment running to the end`, () => {
+		expect(findInlineCommentSpans(`1px // c`)).toEqual([{ start: 4, end: 8 }])
+	})
+
+	it(`a comment ending with its line`, () => {
+		expect(findInlineCommentSpans(`1px // c\n2px`)).toEqual([{ start: 4, end: 8 }])
+	})
+
+	it(`two comments`, () => {
+		expect(findInlineCommentSpans(`1px // c\n2px // d\n3px`)).toEqual([{ start: 4, end: 8 }, { start: 13, end: 17 }])
+	})
+
+	it(`a double slash inside a string`, () => {
+		expect(findInlineCommentSpans(`"//" 1px`)).toEqual([])
+	})
+
+	it(`a double slash inside an escaped string`, () => {
+		expect(findInlineCommentSpans(`"a\\" // b" 1px`)).toEqual([])
+	})
+
+	it(`a double slash inside a bare address`, () => {
+		expect(findInlineCommentSpans(`url(http://x/y.png)`)).toEqual([])
+	})
+
+	it(`a double slash inside a quoted address`, () => {
+		expect(findInlineCommentSpans(`url("http://x/y.png")`)).toEqual([])
+	})
+
+	it(`a comment behind an address`, () => {
+		expect(findInlineCommentSpans(`url(http://x/y.png) // c`)).toEqual([{ start: 20, end: 24 }])
+	})
+
+	it(`a call whose name ends in the letters of an address token`, () => {
+		expect(findInlineCommentSpans(`image-url(a) // c`)).toEqual([{ start: 13, end: 17 }])
+	})
+
+	it(`a double slash inside a block comment`, () => {
+		expect(findInlineCommentSpans(`/* // */ 1px`)).toEqual([])
+	})
+
+	it(`a block comment inside an inline one`, () => {
+		expect(findInlineCommentSpans(`// /* c\n1px`)).toEqual([{ start: 0, end: 7 }])
+	})
+})

--- a/lib/utils/rewriteInlineComments/index.js
+++ b/lib/utils/rewriteInlineComments/index.js
@@ -1,0 +1,23 @@
+import { findInlineCommentSpans } from "../findInlineCommentSpans/index.js"
+
+/** @typedef {import('../findInlineCommentSpans/index.js').InlineCommentSpan} InlineCommentSpan */
+
+/**
+ * Rewrites the inline comments of a value into block comments, as `postcss-scss` does when it fills the raw of that value: the two slashes opening a comment become the two characters opening a block comment, its line break becomes the two closing them, and a `*` followed by `/` in the text — or the other way round — is cut in two so that it closes nothing.
+ * @param {string} spelled - The copy spelled as the file spells it.
+ * @param {InlineCommentSpan[]} [spans] - The spans its inline comments occupy in it, where they are already known.
+ * @returns {string} The value with each of those comments rewritten.
+ */
+export function rewriteInlineComments (spelled, spans = findInlineCommentSpans(spelled)) {
+	let rewritten = ``
+	let index = 0
+
+	for (let { start, end } of spans) {
+		let text = spelled.slice(start + 2, end).replaceAll(/(\*\/|\/\*)/gu, `*//*`)
+
+		rewritten += `${spelled.slice(index, start)}/*${text}*/`
+		index = end
+	}
+
+	return `${rewritten}${spelled.slice(index)}`
+}

--- a/lib/utils/rewriteInlineComments/index.test.js
+++ b/lib/utils/rewriteInlineComments/index.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { rewriteInlineComments } from "./index.js"
+
+describe(`rewriteInlineComments`, () => {
+	it(`no comment`, () => {
+		expect(rewriteInlineComments(`1px 2px`)).toBe(`1px 2px`)
+	})
+
+	it(`a comment running to the end`, () => {
+		expect(rewriteInlineComments(`1px // c`)).toBe(`1px /* c*/`)
+	})
+
+	it(`a comment ending with its line`, () => {
+		expect(rewriteInlineComments(`1px // c\n2px`)).toBe(`1px /* c*/\n2px`)
+	})
+
+	it(`two comments`, () => {
+		expect(rewriteInlineComments(`1px // c\n2px // d\n3px`)).toBe(`1px /* c*/\n2px /* d*/\n3px`)
+	})
+
+	it(`a comment whose text would close the block comment early`, () => {
+		expect(rewriteInlineComments(`1px // a */ b\n2px`)).toBe(`1px /* a *//* b*/\n2px`)
+	})
+
+	it(`a comment whose text would open a block comment of its own`, () => {
+		expect(rewriteInlineComments(`1px // a /* b\n2px`)).toBe(`1px /* a *//* b*/\n2px`)
+	})
+
+	it(`a block comment is left as it stands`, () => {
+		expect(rewriteInlineComments(`1px /* c */ 2px`)).toBe(`1px /* c */ 2px`)
+	})
+
+	it(`a double slash of an address opens nothing`, () => {
+		expect(rewriteInlineComments(`url(http://x/y.png)`)).toBe(`url(http://x/y.png)`)
+	})
+
+	it(`the spans may be handed in`, () => {
+		expect(rewriteInlineComments(`1px // c\n2px`, [])).toBe(`1px // c\n2px`)
+	})
+})


### PR DESCRIPTION
The bottom of the stack that repairs #115, and the only branch of it that closes no issue: it moves code and changes nothing about what that code does.

## Why

`string-quotes` was the first rule of the comment cluster to need to know where the inline comments of a value stand, so the three helpers that answer it were written where they were used:

- `findInlineCommentSpans` scans a text and says where its `//` comments run, passing over the double slash of an address, quoted or bare, and the one inside a block comment;
- `blankInlineComments` replaces the text of those comments with spaces of the same width, so that a parser reading the value finds no code in them and every position stays where it was;
- `rewriteInlineComments` spells them the way `postcss-scss` spells them in the raw of a value.

Every one of them is now needed elsewhere, by the branches above this one:

- a value handed to `postcss-value-parser` has to have its comments placed before a comma or a parenthesis is read out of one — #135, #138 and #141;
- a value written back into the copy `postcss-scss` prints has to have its comments rewritten for the raw beside it to stay in step — #115.

## What is here

The three functions, and the two private ones they lean on — `skipString` and `skipUrl` — move to `lib/utils/`, one directory apiece, with the `InlineCommentSpan` typedef going to `findInlineCommentSpans` and the other two importing it from there. `blankInlineComments` and `rewriteInlineComments` take the spans as an optional second argument now, and scan the text themselves when they are not given any, which is what every new caller wants.

`string-quotes` imports the three and keeps handing them the spans it already has.

## Testing

The three utils get the tests they never had while they lived inside a rule: 28 cases covering an address quoted and bare, a call whose name merely ends in the letters of one, a comment whose text would close or open a block comment of its own, an escaped quotation mark, and a comment running to the end of the text rather than to the end of a line.

Nothing else changes, and `string-quotes` passes its own 99 cases untouched.
