### PR TITLE
Say where the plugin belongs when it is listed in `extends`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and 
 ### Added
 
 - The `max-line-length` rule now has an additional `tabSize` option (see [#10](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/10)). A tab used to count as one character, so a file indented with tabs measured shorter than the editor showed it; with the option a tab reaches the next tab stop of the given width, as the CSS `tab-size` property has it, and the limit is the one the editor's ruler shows.
+- The plugin now says so when it is listed in `extends` instead of `plugins` (see [#14](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/14)). It is a plugin rather than a shareable config, and Stylelint could not tell the one use from the other: it loaded the package as a config, found no rules in it, and reported every `@stylistic/` rule of the config as unknown — an error about the rules, whose cause is the field they were never reached from. A run now stops with a configuration error naming the field to move the package to.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Create the `.stylelintrc` config file (or open the existing one), add `@styli
 }
 ```
 
-To avoid listing a lot of rules, you can use [`@stylistic/stylelint-config`](https://www.npmjs.com/package/@stylistic/stylelint-config), which returns the stylistic rules removed in [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard/releases/tag/30.0.0) and [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended/releases/tag/10.0.1).
-
 ---
 
 Please refer to [Stylelint docs](https://stylelint.io/user-guide/get-started) for detailed info on using this linter.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add `@stylistic/stylelint-plugin` and `stylelint` itself to your project:
 npm add -D stylelint @stylistic/stylelint-plugin
 ```
 
-Create the `.stylelintrc` config file (or open the existing one), add `@stylistic/stylelint-plugin` to the plugins array and the rules you need to the rules list. [All rules from `@stylistic/stylelint-plugin`](https://github.com/stylelint-stylistic/stylelint-stylistic/blob/main/docs/user-guide/rules.md) need to be namespaced with `@stylistic/`:
+Create the `.stylelintrc` config file (or open the existing one), add `@stylistic/stylelint-plugin` to the plugins array and the rules you need to the rules list. [All rules from `@stylistic/stylelint-plugin`](https://github.com/stylelint-stylistic/stylelint-stylistic/blob/main/docs/user-guide/rules.md) need to be namespaced with `@stylistic/`. That prefix is the whole difference — an unprefixed name in the rules list is a rule of Stylelint's own, a prefixed one is a rule of this plugin:
 
 ```json
 {
@@ -26,11 +26,9 @@ Create the `.stylelintrc` config file (or open the existing one), add `@styli
 		"@stylistic/stylelint-plugin"
 	],
 	"rules": {
-		// syntax rules from stylelint:
 		"color-function-notation": "modern",
 		"selector-max-compound-selectors": 2,
 
-		// stylistic rules from @stylistic/stylelint-plugin:
 		"@stylistic/color-hex-case": "lower",
 		"@stylistic/number-leading-zero": "always",
 		"@stylistic/unit-case": "lower"

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,21 @@ import stylelint from "stylelint"
 import rules from "./rules/index.js"
 import { addNamespace } from "./utils/addNamespace/index.js"
 
+/** The code Stylelint exits with when its configuration is invalid. */
+let EXIT_CODE_INVALID_CONFIG = 78
+
 let rulesPlugins = Object.keys(rules).map((name) => stylelint.createPlugin(addNamespace(name), rules[name]))
+
+/** Stylelint reads `extends` on every config it is told to extend, and never on a plugin, so this getter runs only where the package has been listed in the wrong field. Without it Stylelint loads the package as a config, finds no rules in it, and reports every `@stylistic/` rule as unknown — an error about the rules, whose cause is the field they were never reached from. */
+Object.defineProperty(rulesPlugins, `extends`, {
+	get () {
+		let error = new Error(`"@stylistic/stylelint-plugin" is a plugin, not a shareable config, so it cannot be used in "extends". List it in "plugins" instead, and put the rules you need, each namespaced with "@stylistic/", in "rules".`)
+
+		error.name = `ConfigurationError`
+		error.code = EXIT_CODE_INVALID_CONFIG
+
+		throw error
+	},
+})
 
 export default rulesPlugins

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,0 +1,31 @@
+import stylelint from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import plugins from "./index.js"
+
+describe(`the plugin in the wrong field of a config`, () => {
+	it(`lints as usual where it is listed in "plugins"`, async () => {
+		let { results } = await stylelint.lint({
+			code: `a { color: #FFF; }`,
+			config: {
+				plugins: [plugins],
+				rules: { "@stylistic/color-hex-case": `lower` },
+			},
+		})
+
+		expect(results[0].warnings).toHaveLength(1)
+		expect(results[0].warnings[0].rule).toBe(`@stylistic/color-hex-case`)
+	})
+
+	it(`stops the run with a configuration error where it is listed in "extends"`, async () => {
+		let lint = stylelint.lint({
+			code: `a { color: #FFF; }`,
+			config: {
+				"extends": [plugins],
+				"rules": { "@stylistic/color-hex-case": `lower` },
+			},
+		})
+
+		await expect(lint).rejects.toThrow(/is a plugin, not a shareable config/u)
+	})
+})


### PR DESCRIPTION
`@stylistic/stylelint-plugin` is a plugin, and Stylelint cannot tell it from a shareable config until it looks inside: what it finds there is an array of rule definitions with no rules of its own. A config listing the package in `extends` therefore loaded it, took nothing from it, and then reported every `@stylistic/` rule the author had written as unknown — an error naming the rules, while the mistake is in the field the package was listed in. That is what [#14](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/14) ran into, and the readme could say nothing about it, since nothing in the error points at the readme:

```
{ "extends": ["@stylistic/stylelint-plugin"], "rules": { "@stylistic/color-hex-case": "lower" } }
  before   a.css  1:1  ✖  Unknown rule @stylistic/color-hex-case                      exit 2
  after    ConfigurationError: "@stylistic/stylelint-plugin" is a plugin, not a
           shareable config, so it cannot be used in "extends". List it in
           "plugins" instead, and put the rules you need, each namespaced with
           "@stylistic/", in "rules".                                                 exit 78
```

`extends` is read on a config and never on a plugin, so a getter of that name on the exported array runs in the wrong case alone and leaves the right one untouched. It throws the kind of error Stylelint throws for any other bad configuration, named `ConfigurationError` and carrying the exit code the CLI reserves for one, so a run stops with a sentence naming the field to move the package to. Two commits ahead of it take the readme down to the one lesson it has to teach.

## What the review turned up

- **Nothing else moved**: the whole suite passes, 8017 tests, and the correct path was replayed through the real CLI as well, with the package resolved out of `node_modules` by a config listing it in `plugins` — it lints exactly as before. The getter is non-enumerable, so spreading the export or reading its keys never reaches it, and Stylelint reads `extends` on an extended config alone.
- **The error keeps Stylelint's own shape**: `ConfigurationError` and exit code `78`, the code the CLI reserves for an invalid configuration, so a job telling a configuration error apart from a lint failure goes on doing so.
- **The readme no longer names the shareable config**: whoever needs it has long since found it, and naming a second package in the middle of the lesson about the first only blurs the one into the other.
- **The readme snippet now copies into a working config**: a `.stylelintrc` with no extension is read as YAML, so the `//` comments the snippet carried made the parse fail before Stylelint saw a single rule — a reader following the instructions to the letter was stopped by an error having nothing to do with the lesson. The comments labelled the two groups of rules, the blank line between them already does as much, and what they said is now said in the paragraph above the block.
- **Making `extends` work instead was tried and dropped**: a `plugins` property on the exported array pointing back at the array itself does make both fields work, but it leaks 78 numeric keys into `stylelint --print-config`, and, more to the point, it hides the difference between a plugin and a config rather than teaching it.

Closes #14.
