### PR TITLE
Keep the test run out of the scratch directory

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,13 @@
 import { env } from "node:process"
 
-import { defineConfig } from "vitest/config"
+import { configDefaults, defineConfig } from "vitest/config"
 
 export default defineConfig({
 	test: {
 		setupFiles: [`./vitest.setup.ts`],
 		reporters: env.CI ? [`github-actions`, `default`] : [`dot`],
+		// `tmp/` holds work that belongs to a session rather than to the repository, and a checkout of another revision parked there brings a whole second suite with it — one that the setup file would test against this revision's plugin. The defaults are kept so that a later version of Vitest can add to them.
+		exclude: [...configDefaults.exclude, `tmp/**`],
 		isolate: false,
 		watch: false,
 		coverage: {


### PR DESCRIPTION
Closes #256.

Vitest was given no `exclude` in [vitest.config.ts](vitest.config.ts), and its defaults name `node_modules` and `.git` and nothing else. So any `*.test.js` left under `tmp/` joined the run — the directory [AGENTS.md](AGENTS.md) reserves for "plans, notes, throwaway scripts, captured output", work that belongs to a session rather than to the repository.

It was found while working on #230: a checkout of an older `lib/` was parked under `tmp/` to lint the same fixture with both revisions, and `make test FILE=lib/rules/function-whitespace-after/index.test.js` quietly began running two test files instead of one. Reproduced on `main` at `eaeadd2`:

```
mkdir -p tmp/scratch
git archive HEAD lib/rules/color-hex-case | tar -x -C tmp/scratch
make test FILE=lib/rules/color-hex-case/index.test.js
 before  the run fails, the copy under tmp/ having been tested against this revision's plugin
 after   1 test file, 31 tests, green
```

The copy is the worst of it: `vitest.setup.ts` loads `lib/index.js` from the repository, so an older suite parked under `tmp/` is run against the *current* plugin and its failures say nothing about either revision. Short of that, the counts `make test` and `make verify` print include files nobody meant to run, and because `tmp/` is git-ignored, what runs on a developer's machine differs from what runs in CI with nothing in the diff to say why.

The defaults are spread into the new list rather than replaced, so a later version of Vitest can add to them without this file standing in the way.

## What the review turned up

- **`raw/` needs nothing.** It is ignored globally, holds the raw materials a project was given rather than any JavaScript, and no test file can reach it.
- **The `pre-commit` hook is untouched.** It runs `vitest related` over the staged `.js` files, and nothing under `tmp/` can be staged.
- **No changelog entry.** [AGENTS.md](AGENTS.md) has purely internal changes — build tooling, test layout, CI — take none, since any entry forces a release.
