### PR TITLE
Describe the case each fixture actually is

### DIFF
--- a/lib/rules/function-whitespace-after/index.test.js
+++ b/lib/rules/function-whitespace-after/index.test.js
@@ -20,75 +20,75 @@ testRule({
 			code: `a::before { content: attr(data-foo); }`,
 		},
 		{
-			description: `a call closing the value, with a semicolon behind it`,
+			description: `the same call in a declaration a semicolon closes, which is none of the value`,
 			code: `a { transform: translate(1, 1); }`,
 		},
 		{
-			description: `a call closing the value, with a space and a brace behind it`,
+			description: `the same call in a declaration with no semicolon, the block closing a space behind it`,
 			code: `a { transform: translate(1, 1) }`,
 		},
 		{
-			description: `a space between two calls`,
+			description: `the same declaration with the block closing straight behind the call`,
 			code: `a { transform: translate(1, 1)}`,
 		},
 		{
-			description: `a nested call, with the space behind the inner one`,
+			description: `a single space between two calls, which is what this option asks for`,
 			code: `a { transform: translate(1, 1) scale(3); }`,
 		},
 		{
-			description: `comma-separated calls, whose commas this rule says nothing about`,
+			description: `a space behind a call nested inside another`,
 			code: `a { color: color(rgb(0,0,0) lightness(50%)) };`,
 		},
 		{
-			description: `a call nested inside another among space-separated values`,
+			description: `two calls separated by a comma, which this rule accepts behind a parenthesis`,
 			code: `a { background-image: linear-gradient(#f3c, #4ec), linear-gradient(#f3c, #4ec); }`,
 		},
 		{
-			description: `two spaces between two calls`,
+			description: `a call nested inside another, standing among space-separated values`,
 			code: `a { border-color: color(rgb(0,0,0) lightness(50%)) red pink orange; }`,
 		},
 		{
-			description: `a break between two calls`,
+			description: `two spaces between two calls`,
 			code: `a { transform: translate(1, 1)  scale(3); }`,
 		},
 		{
-			description: `the same break spelled with a carriage return`,
+			description: `a break between two calls`,
 			code: `a { transform: translate(1, 1)\nscale(3); }`,
 		},
 		{
-			description: `two spaces behind a nested call`,
+			description: `the same break spelled with a carriage return and a line feed`,
 			code: `a { transform: translate(1, 1)\r\nscale(3); }`,
 		},
 		{
-			description: `a break behind a nested call`,
+			description: `two spaces behind that nested call`,
 			code: `a { color: color(rgb(0,0,0)  lightness(50%)) };`,
 		},
 		{
-			description: `the same break spelled with a carriage return`,
+			description: `a break behind that nested call`,
 			code: `a { color: color(rgb(0,0,0)\nlightness(50%)) };`,
 		},
 		{
-			description: `a call in the params of an at-rule, with the space behind it`,
+			description: `the same break behind the nested call spelled with a carriage return and a line feed`,
 			code: `a { color: color(rgb(0,0,0)\r\nlightness(50%)) };`,
 		},
 		{
-			description: `an SCSS list, whose parentheses open no call`,
+			description: `a call in the parameters of an at-rule, with a space behind it`,
 			code: `@import url(example.css) screen;`,
 		},
 		{
-			description: `a postcss-simple-vars interpolation standing as the whole property name`,
+			description: `a list in parentheses that open no call`,
 			code: `$list: (value, value2);$thingTwo: 0px`,
 		},
 		{
-			description: `the same interpolation standing inside a property name`,
+			description: `an interpolation standing as the whole property name, whose parentheses are no part of any value`,
 			code: `.foo { $(x): calc(1px + 0px); }`,
 		},
 		{
-			description: `a calc() closing in front of a slash, which is the shorthand's separator rather than whitespace this rule asks for`,
+			description: `the same interpolation standing inside a property name`,
 			code: `.foo { border-$(x)-left: 10px; }`,
 		},
 		{
-			description: `a call abutting the call behind it`,
+			description: `a call closing in front of a slash, which is the shorthand's separator rather than whitespace this rule asks for`,
 			code: `.foo { font: calc(16px + .2vw)/1 }`,
 		},
 		{
@@ -108,7 +108,7 @@ testRule({
 
 	reject: [
 		{
-			description: `a nested call abutting the one behind it`,
+			description: `a call abutting the call behind it`,
 			code: `a { transform: translate(1, 1)scale(3); }`,
 			fixed: `a { transform: translate(1, 1) scale(3); }`,
 			line: 1,
@@ -116,7 +116,7 @@ testRule({
 			message: messages.expected,
 		},
 		{
-			description: `a call in the params of an at-rule abutting what follows`,
+			description: `a call nested inside another, abutting what follows it inside the outer one`,
 			code: `a { color: color(rgb(0,0,0)lightness(50%)) };`,
 			fixed: `a { color: color(rgb(0,0,0) lightness(50%)) };`,
 			line: 1,
@@ -124,7 +124,7 @@ testRule({
 			message: messages.expected,
 		},
 		{
-			description: `three calls abutting one another`,
+			description: `a call in the parameters of an at-rule abutting what follows`,
 			code: `@import url(example.css)screen;`,
 			fixed: `@import url(example.css) screen;`,
 			line: 1,
@@ -132,7 +132,7 @@ testRule({
 			message: messages.expected,
 		},
 		{
-			description: `a comment standing inside the word behind the call`,
+			description: `three calls abutting one another`,
 			code: `a { transform: translateX(1)translateY(1)scale(3); }`,
 			fixed: `a { transform: translateX(1) translateY(1) scale(3); }`,
 			warnings: [
@@ -149,7 +149,7 @@ testRule({
 			],
 		},
 		{
-			description: `a comment inside the arguments, with the call abutting what follows`,
+			description: `a comment standing inside the word behind the call`,
 			code: `@import url(example.css)scree/**/n;`,
 			fixed: `@import url(example.css) scree/**/n;`,
 			line: 1,
@@ -184,7 +184,7 @@ testRule({
 		},
 		{
 			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/225
-			description: `calls spelled inside a string, whose parentheses close no call`,
+			description: `a bare address inside a url(), where plain CSS spells no comment with a double slash either`,
 			code: `a { b: url(http://x/y.png)red; }`,
 			fixed: `a { b: url(http://x/y.png) red; }`,
 			line: 1,
@@ -252,39 +252,39 @@ testRule({
 
 	accept: [
 		{
-			description: `the same calls spelled inside a url()`,
+			description: `calls spelled inside a string, whose parentheses close no call`,
 			code: `a::before { content: "var(--hoot) color(blue)"; }`,
 		},
 		{
-			description: `a call closing the value, with nothing behind it to space from`,
+			description: `the same calls spelled inside a url()`,
 			code: `a::before { background: url('var(--hoot) color(blue)'); }`,
 		},
 		{
-			description: `a call closing the value, with a semicolon behind it`,
+			description: `a call closing the value, with nothing behind it to close up`,
 			code: `a::before { content: attr(data-foo); }`,
 		},
 		{
-			description: `a call closing the value, with a space and a brace behind it`,
+			description: `the same call in a declaration a semicolon closes, which is none of the value`,
 			code: `a { transform: translate(1, 1); }`,
 		},
 		{
-			description: `a call abutting the call behind it`,
+			description: `the same call in a declaration with no semicolon, the block closing a space behind it`,
 			code: `a { transform: translate(1, 1) }`,
 		},
 		{
-			description: `a nested call abutting the one behind it`,
+			description: `the same declaration with the block closing straight behind the call`,
 			code: `a { transform: translate(1, 1)}`,
 		},
 		{
-			description: `a nested call abutting the one behind it`,
+			description: `two calls abutting one another`,
 			code: `a { transform: translate(1, 1)scale(3); }`,
 		},
 		{
-			description: `a calc() closing in front of a slash, which is the shorthand's separator`,
+			description: `a call nested inside another, abutting what follows it inside the outer one`,
 			code: `a { color: color(rgb(0,0,0)lightness(50%)) };`,
 		},
 		{
-			description: `a space between two calls`,
+			description: `a call closing in front of a slash, which is the shorthand's separator`,
 			code: `.foo { font: calc(16px + .2vw)/1 }`,
 		},
 		{
@@ -300,7 +300,7 @@ testRule({
 
 	reject: [
 		{
-			description: `two spaces between two calls`,
+			description: `a single space between two calls`,
 			code: `a { transform: translate(1, 1) scale(3); }`,
 			fixed: `a { transform: translate(1, 1)scale(3); }`,
 			line: 1,
@@ -308,7 +308,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `a break between two calls`,
+			description: `two spaces between two calls`,
 			code: `a { transform: translate(1, 1)  scale(3); }`,
 			fixed: `a { transform: translate(1, 1)scale(3); }`,
 			line: 1,
@@ -316,7 +316,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `the same break spelled with a carriage return`,
+			description: `a break between two calls`,
 			code: `a { transform: translate(1, 1)\nscale(3); }`,
 			fixed: `a { transform: translate(1, 1)scale(3); }`,
 			line: 1,
@@ -324,7 +324,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `a space behind a nested call`,
+			description: `the same break spelled with a carriage return and a line feed`,
 			code: `a { transform: translate(1, 1)\r\nscale(3); }`,
 			fixed: `a { transform: translate(1, 1)scale(3); }`,
 			line: 1,
@@ -332,7 +332,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `two spaces behind a nested call`,
+			description: `a space behind a call nested inside another`,
 			code: `a { color: color(rgb(0,0,0) lightness(50%)) };`,
 			fixed: `a { color: color(rgb(0,0,0)lightness(50%)) };`,
 			line: 1,
@@ -340,7 +340,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `a break behind a nested call`,
+			description: `two spaces behind that nested call`,
 			code: `a { color: color(rgb(0,0,0)  lightness(50%)) };`,
 			fixed: `a { color: color(rgb(0,0,0)lightness(50%)) };`,
 			line: 1,
@@ -348,7 +348,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `three calls, each spaced from the next`,
+			description: `a break behind that nested call`,
 			code: `a { color: color(rgb(0,0,0)\nlightness(50%)) };`,
 			fixed: `a { color: color(rgb(0,0,0)lightness(50%)) };`,
 			line: 1,
@@ -356,7 +356,7 @@ testRule({
 			message: messages.rejected,
 		},
 		{
-			description: `comments and spaces standing between three calls`,
+			description: `three calls, each spaced from the next`,
 			code: `a { transform: translateX(1) translateY(1) scale(3); }`,
 			fixed: `a { transform: translateX(1)translateY(1)scale(3); }`,
 			warnings: [
@@ -373,7 +373,7 @@ testRule({
 			],
 		},
 		{
-			description: `a call in the params of an at-rule with a space behind it`,
+			description: `comments and spaces standing between three calls`,
 			code: `a { transform: /**/ translateX(1) /**/ translateY(1) /**/ scale(3); }`,
 			fixed: `a { transform: /**/ translateX(1)/**/ translateY(1)/**/ scale(3); }`,
 			warnings: [
@@ -390,7 +390,7 @@ testRule({
 			],
 		},
 		{
-			description: `a comment behind that call, with spaces on both sides`,
+			description: `a call in the parameters of an at-rule with a space behind it`,
 			code: `@import url(example.css) screen;`,
 			fixed: `@import url(example.css)screen;`,
 			line: 1,


### PR DESCRIPTION
Closes #255.

The descriptions of `function-whitespace-after/index.test.js` stood over the wrong fixtures. From the fourth case of the first block onward each one named its neighbour, and the slip ran through every block of the file:

```
description                                          fixture
a space between two calls                            a { transform: translate(1, 1)}
a nested call, with the space behind the inner one   a { transform: translate(1, 1) scale(3); }
comma-separated calls, whose commas this rule …      a { color: color(rgb(0,0,0) lightness(50%)) };
the same break spelled with a carriage return        a { transform: translate(1, 1)\nscale(3); }
an SCSS list, whose parentheses open no call         @import url(example.css) screen;
```

The first holds no space and one call, the second no nested call, the third no comma, the fourth no carriage return, the fifth no list. It came in with `543abb4`, "Describe every test case of every rule", where the descriptions of this one file were written a position out of step. No other rule's test file goes the same way: a sweep for a description naming a carriage return over a fixture spelling none finds three, and all three are here.

Forty-three descriptions are rewritten against the fixture standing under them, rather than shifted back by one, because several named what the fixture is only loosely even where they lined up. A semicolon closing a declaration is none of the value this rule reads, so `a call closing the value, with a semicolon behind it` becomes `the same call in a declaration a semicolon closes, which is none of the value`. A call nested inside another is not the same case as two calls side by side, and the two were used for each other in both directions.

## What the review turned up

- **Nothing but descriptions moved.** The diff is 43 lines changed in one file, every one of them a `description` field; no fixture, assertion, column or message is touched, so no output moves and there is no changelog entry.
- **No description repeats inside its own block now.** Two cases of the first block would both have read `the same break spelled with a carriage return and a line feed`, one about a break between two calls and one about a break behind a nested call, so the second says which it is. Repeats across blocks are left as they are: the `always` and `never` blocks mirror each other case for case, as do the `postcss-scss` and `postcss-less` ones, and the same wording over the same fixture is what says so.
- **The convention is met.** Every description is a lower-case noun phrase continuing "accepts …" or "rejects …", ends without a period, holds no backticks, and names what the fixture is rather than what the rule does with it. The `#230` and `#225` descriptions already written that way are untouched, along with the comments naming those issues.
- **`make verify` is green**, 8020 tests.
