### PR TITLE
Leave unread the two trees the prose binder means to skip

### DIFF
--- a/scripts/bind-prose.js
+++ b/scripts/bind-prose.js
@@ -5,8 +5,8 @@ import { argv, exit, stdout } from "node:process"
 
 const NBSP = `\u00A0`
 
-/** Every directory holding Markdown the repository does not carry: what a package manager put there, what a build wrote, and the two the working tree keeps for a session rather than for the project. */
-const SKIPPED_DIRS = [`node_modules`, `dist`, `coverage`, `.git`, `.claude`, `tmp`]
+/** Every name of a directory holding Markdown the repository does not carry: what a package manager put there, what a build wrote, and the two the working tree keeps for a session rather than for the project. A name rather than a path, so that it is refused wherever in the tree it stands. */
+const SKIPPED_DIR_NAMES = new Set([`node_modules`, `dist`, `coverage`, `.git`, `.claude`, `tmp`])
 
 /** The license text is quoted verbatim, so it is left exactly as its source has it. */
 const SKIPPED_FILES = new Set([`LICENSE.md`])
@@ -96,16 +96,35 @@ function bindDocument (source) {
 }
 
 /**
+ * Collects the Markdown of one directory and of everything under it, declining to descend into a skipped name.
+ *
+ * `readdirSync` takes no list of subtrees to leave unread, so a walk asking it for the whole tree at once reads `node_modules` and `tmp` in full before any filter over its result can drop them — and a single entry under either that cannot be read ends the run over a directory the repository does not carry. Reading one directory at a time is what lets the name be refused before it costs anything.
+ *
+ * @param {string} directory - The directory to read, relative to the current one, and empty for that one itself.
+ * @param {string[]} paths - Where the Markdown found so far is collected.
+ */
+function collectMarkdownFrom (directory, paths) {
+	for (let entry of readdirSync(directory || `.`, { withFileTypes: true })) {
+		let path = directory ? `${directory}/${entry.name}` : entry.name
+
+		if (entry.isDirectory()) {
+			if (!SKIPPED_DIR_NAMES.has(entry.name)) collectMarkdownFrom(path, paths)
+		}
+		else if (path.endsWith(`.md`) && !SKIPPED_FILES.has(path)) paths.push(path)
+	}
+}
+
+/**
  * Collects every Markdown file the convention applies to.
  *
  * @returns {string[]} The paths, relative to the current directory.
  */
 function collectMarkdown () {
-	return readdirSync(`.`, { recursive: true })
-		.filter((path) => path.endsWith(`.md`))
-		.filter((path) => !SKIPPED_DIRS.some((dir) => path.startsWith(`${dir}/`)))
-		.filter((path) => !SKIPPED_FILES.has(path))
-		.toSorted()
+	let paths = []
+
+	collectMarkdownFrom(``, paths)
+
+	return paths.toSorted()
 }
 
 let isCheck = argv.includes(`--check`)


### PR DESCRIPTION
Closes #307.

`collectMarkdown` in `scripts/bind-prose.js` read the whole working tree with one `readdirSync({ recursive: true })` and dropped the skipped directories out of the result afterwards. By then `node_modules` and `tmp` had been read to the bottom, so the two directories the script means to leave alone were the two it spent nearly all its time in — and a single entry under either that cannot be read ended the run, since nothing catches what `readdirSync` throws.

```
a mode-000 directory under tmp/…/node_modules/     ./scripts/bind-prose.js --check
  before   Error: EACCES: permission denied, scandir 'tmp/…/node_modules/blocked'
           exit 1
  after    exit 0

entries the walk reads under node_modules/.pnpm    (the disk holds 8 850)
  before   24 706
  after    0

the walk itself
  before   the better part of a third of a second
  after    3 ms
```

`make verify` failed on that, naming a directory the repository does not carry and the script never meant to open. Neither directory is hypothetical: `node_modules/.pnpm` is a tree of symbolic links, and the recursive walk follows one into the directory it names, so it comes back at nearly three times the entries the disk holds there; `tmp/` is where AGENTS.md sets aside whatever a session keeps for itself, a throwaway install among it. The issue reports `ENOENT` from an entry that is no longer there — a different errno, the same shape.

`readdirSync` takes no list of subtrees to leave unread, so the pruning has to happen at the walk rather than after it. It reads one directory at a time now, with `withFileTypes`, and declines to descend into a directory whose name the skip list holds.

The name is refused wherever it stands rather than at the root alone, which is what the comment above the list always said and what the path in the report shows twice over: `tmp/…/node_modules/.pnpm/…` was held out of the result by its first segment and by nothing else. So the list is `SKIPPED_DIR_NAMES` now, since a name is what it is asked for, while `SKIPPED_FILES` goes on naming a path from the root: `LICENSE.md` is quoted verbatim, and a `docs/LICENSE.md` would be prose like any other.

The set of files comes back exactly as it was — ninety paths, in the same order — and there is no changelog entry, since no rule's output moves.

## What the review turned up

Two passes of a review subagent, each reading the diff against the spec and checking it by running rather than by reading alone. Both ran the real `HEAD~1` and `HEAD` scripts side by side rather than a transcription of them, and both came back with nothing substantive. `make verify` is green: tsc, oxlint, 8 516 tests, `prose-check`, `breaks-check`.

What the passes moved:

- **A third divergence the spec had not named.** The old walk listed directories alongside files, so a directory named `weird.md` went into the result and `readFileSync` over it threw `EISDIR`. The new walk descends into it and does not emit it. No such directory stands here, and the divergence runs in the direction where the run stops failing — but the two differences the spec named were not the whole list. It names three now.
- **Two names were left describing what they had stopped being.** The list is asked for the name of an entry rather than for the start of a path, and the helper reads directories rather than Markdown: `SKIPPED_DIR_NAMES` and `collectMarkdownFrom`.
- **Two sentences claimed more than the tree holds.** "The repository carries a single such link" is true only outside `node_modules`, which carries 608 of them, and the timing figure had a precision no reader could reproduce.

A fourth divergence exists in principle and is left alone: `readdirSync({ recursive: true })` joins with the platform separator, so on Windows the old walk returned `docs\a.md`, which the root-anchored filter could never have matched, while the new one always returns `/`. Both CI workflows are `ubuntu-latest`, and nothing here claims Windows.
