### PR TITLE
Say what the two fixers refuse rather than promise every fix

### DIFF
--- a/lib/rules/function-parentheses-newline-inside/README.md
+++ b/lib/rules/function-parentheses-newline-inside/README.md
@@ -13,7 +13,7 @@ Require a newline or disallow whitespace on the inside of the parentheses
  * The newline inside these two parentheses */
 ```
 
-The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix the problems reported by this rule, except two kinds of them under `"never-multi-line"`. Where an inline comment stands in front of the whitespace and the line break that whitespace holds is the one closing it, emptying the whitespace would leave the first argument, or the closing parenthesis, and everything the declaration has behind it, inside the comment's text. And behind the opening parenthesis the fixer may not reach every stretch of the whitespace the option was measured against: the walk that measures it steps over an inline comment and counts what hangs behind the comment's end, while the fix stops at the double slash that opens one, and emptying only the stretches it does reach would leave the option violated behind a problem reported as fixed. Both times the whitespace is left alone and the warning stands. `"always"` and `"always-multi-line"` put a line break in and take nothing away, so neither kind holds them back.
 
 ## Options
 

--- a/lib/rules/function-parentheses-space-inside/README.md
+++ b/lib/rules/function-parentheses-space-inside/README.md
@@ -8,7 +8,7 @@ a { transform: translate( 1, 1 ); }
  * The space inside these two parentheses */
 ```
 
-The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix the problems reported by this rule, except the ones where an inline comment stands in front of the whitespace and the line break that whitespace holds is the one closing it: writing over that break would leave the first argument, or the closing parenthesis, and everything the declaration has behind it, inside the comment's text, so the whitespace is left alone and the warning stands. Only `"always"` and `"never"` ever meet such a break, since whitespace holding one makes the function multi-line and so puts it outside what the two single-line options are about.
 
 ## Options
 


### PR DESCRIPTION
Closes #317.

Both `README.md` files carried the sentence the rule template gives every fixable rule:

> The `fix` option can automatically fix all of the problems reported by this rule.

Neither rule has been able to say that for some time. A sweep of 2 500 values — a `calc()` whose two ends carry every combination of a line feed, a carriage return, a form feed and a CRLF, with a `//` comment, a block comment or neither in front of each — run under both custom syntaxes and under every option both rules declare, 35 000 runs in all:

```
                                                              refused   unparseable input
function-parentheses-newline-inside  always              scss        0                 200
function-parentheses-newline-inside  always              less        0                   0
function-parentheses-newline-inside  always-multi-line   scss        0                 200
function-parentheses-newline-inside  always-multi-line   less        0                   0
function-parentheses-newline-inside  never-multi-line    scss     1200                 200
function-parentheses-newline-inside  never-multi-line    less     1240                   0
function-parentheses-space-inside    always              scss     1000                 200
function-parentheses-space-inside    always              less     1000                   0
function-parentheses-space-inside    never               scss     1000                 200
function-parentheses-space-inside    never               less     1000                   0
function-parentheses-space-inside    always-single-line  scss        0                 200
function-parentheses-space-inside    always-single-line  less        0                   0
function-parentheses-space-inside    never-single-line   scss        0                 200
function-parentheses-space-inside    never-single-line   less        0                   0
```

`refused` counts the values that come out of `--fix` with the rule's own problem still reported; `unparseable input` counts the ones the corpus writes that the syntax throws on before any rule sees them, which are none of this.

Every refusal is a guard doing its work. `function-parentheses-newline-inside` turns down a write where emptying the whitespace would take the closing parenthesis into an inline comment (#113, #131, #132), where it would take the first argument there (#129, #141, #281), and — since #285 — where the fixer cannot reach every stretch of the whitespace the option was measured against. `function-parentheses-space-inside` turns down the first two (#114, #280). Each such value is reported and left exactly as it was, which is the honest behaviour and the opposite of what the sentence promised.

`selector-pseudo-class-parentheses-space-inside/README.md` was reworded when #123 landed, for the same reason, and `declaration-block-trailing-semicolon/README.md` gives the shape: one line, the refusals named after a colon, pointing at what the guard turns away rather than at an issue number, so the line stays true as the guards grow.

So each file names two kinds of refusal. One belongs to both rules and stands at either parenthesis: where an inline comment stands in front of the whitespace and the line break that whitespace holds is the one closing it, writing over that break would leave the first argument, or the closing parenthesis, and everything the declaration has behind it, inside the comment's text. The other is `function-parentheses-newline-inside`'s alone, and only behind its opening parenthesis: the walk that measures the whitespace steps over an inline comment and counts what hangs behind the comment's end, while the fix stops at the double slash that opens one, so emptying only the stretches it does reach would leave `never-multi-line` violated behind a problem reported as fixed.

Which options can meet either shape is said as well, and the sweep is what says it. A fix that puts a line break in and takes nothing away is held back by neither, so `always` and `always-multi-line` are free of both; and whitespace holding a break that closes a comment makes a function multi-line, so the two single-line options of `function-parentheses-space-inside` never meet one either.

Two lines change and nothing else. No rule behaviour is touched, so there is no changelog entry.

## What the review turned up

Two passes of a review subagent, each reading the diff against the spec and checking it against the rules' own source and by running rather than by reading alone. The second came back with nothing substantive; `make verify` is green through both: tsc, oxlint, 8 516 tests, `prose-check`, `breaks-check`.

What the first pass moved:

- **The four options were not four.** The line claimed every option of `function-parentheses-space-inside` could meet the refusal. `isSingleLineString` counts `\n`, `\r` and `\f`, which is exactly the set a comment can end on once the form-feed reading is taken in, so whitespace holding such a break always makes the function multi-line and the two single-line options never see one. The sweep above prints that as two zero rows.
- **What is left alone is the whitespace, not the value.** A refusal drops one write; another write of the same run may still reach the value elsewhere, and both lines said "the value" instead.
- **The second kind was written as though it stood at either parenthesis.** It stands behind the opening one alone: `getCheckAfter` and `fixAfterForNever` walk the same nodes and cannot diverge, and the reach check sits only in the opening branch.
- **A tail was hung on one parenthesis that belongs to both.** Where the first argument goes into the comment's text, everything the declaration has behind it goes with it, exactly as for the closing parenthesis.
