### PR TITLE
Count only the whitespace a node overruns an inline comment with

### DIFF
--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -389,7 +389,7 @@ function rule (primary, _secondaryOptions, context) {
  * @param {number} openingIndex - Where the text behind the function's opening parenthesis begins.
  * @param {string} declValue - The value the node was parsed from, which its positions count in.
  * @param {import('../../utils/findInlineCommentSpans/index.js').InlineCommentSpan[]} inlineComments - The spans the inline comments of the value occupy in it.
- * @returns {{ before: string, firstIndex: number, measured: number[][] }} The whitespace, the index the first significant node begins at, and the stretches the whitespace was gathered from.
+ * @returns {{ before: string, firstIndex: number, measured: number[][] }} The whitespace, the index the first significant thing behind it begins at — the node the parser hands back where one stands, the code a node of a comment's text reaches past that comment's end with where the parser filed one under such a node, and the function's own closing parenthesis where it holds neither — and the stretches the whitespace was gathered from.
  */
 function getCheckBefore (valueNode, openingIndex, declValue, inlineComments) {
 	let before = valueNode.before
@@ -402,10 +402,21 @@ function getCheckBefore (valueNode, openingIndex, declValue, inlineComments) {
 		let span = findInlineCommentSpanHolding(node, inlineComments)
 
 		if (span) {
-			// The value parser hangs the whitespace behind a node on that node rather than emitting a node of its own for it, so the break closing the comment reaches past the comment's end whenever the last thing it spells is a division sign, a colon or a comma. It is whitespace of the value like any other, and the walk would drop it with the node it hangs on. A node the comment opened inside of rather than one carrying whitespace behind it — a call, or the word an `url()` hands back whole — reaches past that end with code, and counting that code as whitespace is #303; it is measured here as it always was, and the fix reaches none of it either way.
+			// The value parser hangs the whitespace behind a node on that node rather than emitting a node of its own for it, so the break closing the comment reaches past the comment's end whenever the last thing it spells is a division sign, a colon or a comma. It is whitespace of the value like any other, and the walk would drop it with the node it hangs on. A node the comment opened inside of, rather than one carrying whitespace behind it, goes on past that end with code: a call the parser closed a line below, a string it closed there, or a word. A word reaches that far two ways — as the whole of what an `url()` hands back, wherever a parenthesis or a quotation mark left unbalanced has the scan reading no address there, and as the word a backslash at the end of a comment's text carries across the break. Only the whitespace at the front of the overrun is the value's, and counting the code along with it is #303. A block comment the parser opened inside such a text is stepped over by its kind three lines above and never reaches here at all.
+			//
+			// A run is read rather than the one break the comment is closed by, since the indentation of the line below stands behind that break and is whitespace of the value as much as it is. Reading a run also asks nothing of where the span came from, and there are two places: the scan of this value cuts a span that ends in front of a break, or at the end of the value where the comment runs to it and nothing can reach past it at all, while a span found again over what the fixes collected so far would leave behind is mapped back, and an end standing inside text a fix wrote maps to the index that text was written at.
 			if (node.sourceEndIndex > span.end) {
-				before += declValue.slice(span.end, node.sourceEndIndex)
-				measured.push([span.end, node.sourceEndIndex])
+				let overrun = declValue.slice(span.end, node.sourceEndIndex)
+				let whitespace = overrun.match(LEADING_WHITESPACE)[0]
+
+				before += whitespace
+				measured.push([span.end, span.end + whitespace.length])
+
+				// The code behind that whitespace is the first significant thing the function holds, whatever the parser made of the boundaries of the node it filed the code under, so the walk ends on it. Going on instead would gather the whitespace of the nodes behind it into a run the file does not spell, since code stands in the middle of that run.
+				if (whitespace.length !== overrun.length) {
+					firstIndex = span.end + whitespace.length
+					break
+				}
 			}
 
 			continue

--- a/lib/rules/function-parentheses-newline-inside/index.test.js
+++ b/lib/rules/function-parentheses-newline-inside/index.test.js
@@ -1201,6 +1201,25 @@ testRule({
 			column: 3,
 			message: messages.rejectedClosingMultiLine,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `an inline comment whose text opens a call the parser closes a line below: the whitespace behind the opening parenthesis is the break that closes the comment and the indentation behind it, and nothing of the code the parser filed under that call, and the fix reaches no stretch of it, so nothing is written and the problem is reported`,
+			code: `
+				a {
+					t: foo(// c(
+						1px));
+				}
+			`,
+			fixed: `
+				a {
+					t: foo(// c(
+						1px));
+				}
+			`,
+			line: 2,
+			column: 9,
+			message: messages.rejectedOpeningMultiLine,
+		},
 	],
 })
 
@@ -1271,6 +1290,17 @@ testRule({
 			description: `the same comment closed by a bare carriage return, the option's break spelled with one too`,
 			code: `a { t: translate( // c\r  1px, 2px\r); }`,
 		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `an inline comment whose text opens a call the parser closes a line below, the break that closes the comment being the very break the option asks for`,
+			code: `
+				a {
+					t: foo(// c(
+						1px)
+					);
+				}
+			`,
+		},
 	],
 
 	reject: [
@@ -1308,6 +1338,17 @@ testRule({
 			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/141
 			description: `an inline comment whose last character is a division sign, which the value parser hangs the closing break on`,
 			code: `a { t: translate( // see MDN:\n  1px, 2px\n); }`,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `an inline comment whose text opens a call the parser closes a line below, the break that closes the comment being the very break the option asks for`,
+			code: `
+				a {
+					t: foo(// c(
+						1px)
+					);
+				}
+			`,
 		},
 	],
 })
@@ -1364,6 +1405,63 @@ testRule({
 			fixed: `a { t: translate( // c\n /*x*/\n , 1px); }`,
 			line: 1,
 			column: 18,
+			message: messages.rejectedOpeningMultiLine,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `an inline comment whose text opens a call the parser closes a line below: the whitespace behind the opening parenthesis is the break that closes the comment and the indentation behind it, and nothing of the code the parser filed under that call, and the fix reaches no stretch of it, so nothing is written and the problem is reported`,
+			code: `
+				a {
+					t: foo(// c(
+						1px));
+				}
+			`,
+			fixed: `
+				a {
+					t: foo(// c(
+						1px));
+				}
+			`,
+			line: 2,
+			column: 9,
+			message: messages.rejectedOpeningMultiLine,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `a quotation mark in the same place, opening a string the parser closes a line below, which is another node able to reach past the break`,
+			code: `
+				a {
+					t: foo(// c"
+						1px");
+				}
+			`,
+			fixed: `
+				a {
+					t: foo(// c"
+						1px");
+				}
+			`,
+			line: 2,
+			column: 9,
+			message: messages.rejectedOpeningMultiLine,
+		},
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/303
+			description: `an unbalanced parenthesis in the text of a comment standing inside an address, which leaves the scan reading no address there and the parser handing the whole of what follows back as one word`,
+			code: `
+				a {
+					t: url(// c(
+						2px);
+				}
+			`,
+			fixed: `
+				a {
+					t: url(// c(
+						2px);
+				}
+			`,
+			line: 2,
+			column: 9,
 			message: messages.rejectedOpeningMultiLine,
 		},
 	],


### PR DESCRIPTION
Closes #303.

`function-parentheses-newline-inside` measures the whitespace standing between a function's opening parenthesis and its first argument. `postcss-value-parser` knows nothing of a comment opened by a double slash, so the nodes such a comment is spelled with are stepped over by their place in the value rather than by their kind, and whatever a stepped-over node reached past the end of the comment with was counted into that whitespace whole:

```less
a {
	t: foo(// c(
		1px));
}
```

The parenthesis inside the comment's text opens a call to the parser, which closes it a line below, so the node begins inside the comment and ends outside it. `\n\t\t1px)` went into the whitespace behind `foo(`, where the file spells the break, the indentation of the next line, and then code.

For a division sign, a colon and a comma the overrun really is whitespace — the parser hangs it on the node rather than emitting a node of its own for it, which is what the reading was written for, and a case has pinned that since #141. Three kinds of node reach past the end with code: a call the parser closed a line below, a string it closed there, and a word. A word reaches that far two ways — as the whole of what an `url()` hands back, wherever a parenthesis or a quotation mark left unbalanced has the scan reading no address there, and as the word a backslash at the end of a comment's text carries across the break.

## The fix

The whitespace at the front of the overrun is counted and the code behind it is not, and that code is the first significant thing the function holds, whatever the parser made of the boundaries of the node it filed the code under. So the walk ends on it rather than going on to gather the whitespace of the nodes behind it into a run the file does not spell: `foo(// c(` followed by a line break and `1px) 2px)` was read as holding `\n1px) ` behind the parenthesis where the file spells one break and no more.

The run is read rather than the one break the comment is closed by, for two reasons. The indentation of the line below stands behind that break and is whitespace of the value as much as it is. And reading a run asks nothing of where the span came from: the scan of the value cuts a span ending in front of a break, while a span found again over what the fixes collected so far would leave behind is mapped back (#288), and an end standing inside text a fix wrote maps to the index that text was written at.

## No output moves, and that is the finding

Two facts say why, and they hold whatever the syntax and whatever the option:

- The whitespace is read by two questions — does it hold a line break, and is it empty. A run whose first character is the one the comment closed on answers both the same way whether the code behind it is counted or not.
- The stretches it was measured from are read by one — does the fix reach every one of them. None is ever reached: `getFixEmptiedBefore` stops at the first node that is neither whitespace nor a block comment, which is the node the parser files the comment's first slash under, while every stretch of an overrun begins past the comment's end. So `isOpeningFixable` is false wherever the branch fires, and `firstIndex` — which only the guards standing behind that check consume — never reaches a question.

**It was a fix when it was reported, and the commit that silenced it says so.** #271 (`c3acc0d`) turns away every call whose name stands inside the text of an inline comment, and the `calc(` and the `a(` of the issue's own fixture stand there. On `c727e97`, where the issue was written, that fixture reports whitespace at 1:29 that no run of `--fix` clears, exactly as the issue has it. What is left reachable is a comment inside a call rather than a call inside a comment, and there the two readings agree.

So this is a reading made honest rather than a fix, in the shape #286 had, and it carries **no changelog entry**. It is worth having where it stands: three of the branches the plan still holds open — #320, #329 and #333 — widen the very walk whose stopping point makes the misreading invisible, and each of them would inherit code counted as whitespace.

## Why the guard the issue proposes is not the one written

The issue asks for the overrun to be counted where it is whitespace and dropped otherwise. That takes the break away along with the code, and the break is the very one an `always` option asks for: the call above would be reported under `always` and a second break written in front of a comment that already ends on one.

The six cases added here are what pins that. All six pass on the reading as it stood and on the narrowed one, and all six fail on the all-or-nothing one.

## The runs

- A corpus of **70 980 rows** — 11 830 values, each an inline comment inside a call, over 13 prefixes, 14 comment texts and 13 tails in 5 wrappers, under both custom syntaxes, all three options and both fix modes — comes back byte for byte, warnings and fixed output alike.
- A differential fuzzer over **400 000 values** of the shape the branch is about, comparing the two readings at the level of the measurement itself: **9 626** values where the whitespace read differs, and **none** where any of the three questions above does.
- All five oracles are byte-identical to their run on the base: `converge`, `comments` and `nodes` silent, `control` at 96 rows, `twins` at 413.
- `make verify` passes: 8 550 tests and one skipped, plus `tsc`, oxlint, the prose check and `check-break-readings.js`. The branch spells no line break of its own, so that script's debt list is untouched.

The branch is rebased on `f3a3783` (#312), which rewrote half of this file. Neither of the two facts above is touched by it, and every run here was repeated on that base.

## What the review turned up

- **Nothing else moved.** Three rounds of review swept their own corpora on top of the ones above — 53 460 rows, then 97 632, then 895 584 lint units over 110 880 values, the last of them shaped to enter the remapped-span path of #288, which it did 150 504 times. Not one row moved between the base and the branch, and over 75 546 firings of the branch every overrun opened on a line break and no dropped code held one. The fixability claim was instrumented directly: over 25 182 firings that reached `getNeverFixability`, `isOpeningFixable` was true zero times.
- **The issue's own repair is the one thing the cases are written against.** They pass against the `f3a3783` copy of the rule and fail — all six, and nothing else — when the guard the issue proposes replaces the reading.
- **Three prose defects came out of the review, and one of them was a real gap in the reading's own account.** The enumeration of what can overrun a comment's end named two node kinds where there are three, and then named one of the three by a condition that is neither necessary nor sufficient. The `url()` word had stood in the comment this branch rewrote, and dropping it is what let the gap in; a case for it is added, and the two ways a word reaches that far are written out above.
- **Noted and left alone:** the same overstatement about a comment's span ending on a break stands in `getNeverFixability`, at the line saying "no such whitespace can hold the break that closes that comment — the span ends at that break". That sentence came with #312 and this branch does not touch it. It changes no output either, for the same reason.
