### PR TITLE
Stop counting the rules in prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ CI (`.github/workflows/test.yaml`) runs `make setup` and then `make verify` �
 
 ## Architecture
 
-A Stylelint plugin (`@stylistic/stylelint-plugin`) that restores the 76 stylistic rules Stylelint removed in v16. Pure ESM, no build step — `lib/` is published as-is (minus `*.test.js`).
+A Stylelint plugin (`@stylistic/stylelint-plugin`) that restores the stylistic rules Stylelint removed in v16 and adds rules of its own. How many there are is `lib/rules/index.js`, and no number is written here, since a written one falls behind. Pure ESM, no build step — `lib/` is published as-is (minus `*.test.js`).
 
 - `lib/index.js` — maps every entry of the rule registry through `stylelint.createPlugin(addNamespace(name), rule)` and exports the array. `addNamespace` prefixes `@stylistic/`, so users write `"@stylistic/color-hex-case"`.
 - `lib/rules/index.js` — the registry: static imports of every rule plus a default-exported object keyed by kebab-case rule name. **A new rule is not active until it is added here.**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An updatable collection of stylistic rules for [Stylelint](https://github.com
 
 ## About and purpose
 
-[Stylelint has removed 76 rules](https://stylelint.io/migration-guide/to-16#removed-deprecated-stylistic-rules) that enforce stylistic conventions. This project returns these rules to keep styles consistent with your codeguide. In addition, new rules may be added in the future.
+[Stylelint has removed 76 rules](https://stylelint.io/migration-guide/to-16#removed-deprecated-stylistic-rules) that enforce stylistic conventions. This project brought them back to keep styles consistent with your codeguide, and it has not stopped there: the list grows with rules of its own, so it is a collection rather than a fixed set.
 
 ## Installation and usage
 


### PR DESCRIPTION
`AGENTS.md` said the plugin "restores the 76 stylistic rules Stylelint removed in v16". The registry holds **79** — `Object.keys` of `lib/rules/index.js` and of `scripts/oracles/options.mjs` both answer 79, and the two agree by construction. Three rules of the plugin's own have joined the 76 since that sentence was written.

The number is dropped rather than corrected, and `lib/rules/index.js` is named in its place as the count that cannot go stale. A written one falls behind the moment one more rule lands, and it had already misled: the review of the branch closing [#325](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/325) reported a sweep as covering "all 76 rules" on the strength of that sentence, over a run that had covered 79.

The README's own opening — "Stylelint has removed 76 rules" — stays as it is. It is about Stylelint rather than about this package, and it is right. What follows it is rewritten: the emphasis belonged on the growing rather than on the restoring, and the sentence promising that new rules "may be added in the future" was written before three of them were.

```
- This project returns these rules to keep styles consistent with your codeguide. In addition, new rules may be added in the future.
+ This project brought them back to keep styles consistent with your codeguide, and it has not stopped there: the list grows with rules of its own, so it is a collection rather than a fixed set.
```

Documentation alone, so there is no changelog entry: no rule changes what it says about a stylesheet, and an entry would force a release.

Closes #361
