### PR TITLE
Ask before an oracle or a sweep is run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ make test TEST_FLAGS="-t 'lower'"                            # filter by test na
 make lint FILE=lib/rules/color-hex-case
 ```
 
+Two targets collect results rather than check them, and are the slowest things the repository does: `make oracles` and `make sweep FILE=…`. Neither starts without `RUN=1`, and that spelling is what the user approves — a permission rule of theirs makes it prompt, in every mode. So a session runs the bare target first, which says what it would have run and stops, and then asks the user for the run rather than adding the flag on its own; a subagent never adds it at all, and hands the plan back to the session that spawned it. The scripts under `scripts/oracles/` refuse to start unless the Makefile has set `HARNESS_RUN`, so a direct `node` of one of them, or a script of the session's own importing them, stops at the same wall.
+
 CI (`.github/workflows/test.yaml`) runs `make setup` and then `make verify` — run `make verify` locally before pushing. The release workflow (`.github/workflows/release.yaml`) runs `make setup` and then `make release` on pushes to `release` and `release-*`. The `pre-commit` hook lints the staged `.js`/`.ts` files and runs, in one pass of `vitest related`, whatever test imports one of them — so a util is answered for by the rules that use it rather than by the directory it sits in.
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,21 @@ prose-check: ## 🔤 Check that markdown prose is bound
 	./scripts/bind-prose.js --check
 .PHONY: prose-check
 
-oracles: ## 🔮 Run every oracle over every rule and option [OUT=]
+oracles: ## 🔮 Run every oracle over every rule and option [RUN=1] [OUT=]
+	$(call require_run,every oracle — about 350 000 lints and four to five minutes on an idle machine)
 	@mkdir -p $(OUT)
 	for oracle in converge control comments twins nodes pairs ; do
 		printf "\t🔮 $$oracle\n"
-		./scripts/oracles/$$oracle.mjs > $(OUT)/$$oracle.json
+		HARNESS_RUN=1 ./scripts/oracles/$$oracle.mjs > $(OUT)/$$oracle.json
 	done
 	@printf "\t✅ Written to $(ANSI_BOLD)$(OUT)$(ANSI_RESET). Run once before a branch and once after, and read the diff.\n\n"
 .PHONY: oracles
+
+sweep: ## 🧹 Run one sweep script, base and branch alike [RUN=1] FILE=
+	@test -n "$(FILE)" || { printf "\t❌ $(ANSI_BOLD)FILE= names the sweep to run$(ANSI_RESET)\n\n"; exit 2; }
+	$(call require_run,the sweep $(FILE))
+	HARNESS_RUN=1 node $(FILE)
+.PHONY: sweep
 
 breaks-check: ## ↩️  Check that every line spelling a line break in lib/ is classified
 	./scripts/check-break-readings.js
@@ -60,6 +67,15 @@ verify: check lint test prose-check breaks-check ## ✅ Run every check the CI r
 release: verify ## 🚀 Release a new version
 	pnx @firefoxic/release-it
 .PHONY: release
+
+# A run of the oracles or of a sweep is the slowest thing this repository does, and it is asked for far more often than it is needed: what it compares is two states of the tree, and the state of a commit does not change with the commit's date or its message. So nothing here collects results without RUN=1, and a permission rule of the user's own makes that spelling prompt. Without it the target says what it would have run and stops — the recipe exits with the code below, and make reports it — which a session reads as "ask first" rather than as a failure of the build. A comma cannot stand in the argument, since `call` would read it as a second one.
+define require_run
+	@if [ "$(RUN)" != "1" ] ; then
+		printf "\n\t⏸  $(ANSI_BOLD)Not running$(ANSI_RESET) $(1).\n"
+		printf "\tA run collects new results, so it is asked for rather than started: the user approves it by adding $(ANSI_BOLD)RUN=1$(ANSI_RESET) to this very command.\n\n"
+		exit 3
+	fi
+endef
 
 define pnpm_alert
 	(

--- a/scripts/oracles/runs.mjs
+++ b/scripts/oracles/runs.mjs
@@ -1,5 +1,15 @@
+import { env, exit, stderr } from "node:process"
+
 import { FIXTURES, INLINE_FIXTURES } from "./fixtures.mjs"
 import { RULE_OPTIONS } from "./options.mjs"
+
+/** The code a run stops with where it was started without approval, and the one thing every oracle shares apart from its list of runs: a run collects results rather than reading them, it is the slowest thing the repository does, and it is asked for far more often than it is needed. So a script of this directory refuses to start unless the Makefile has set this variable, which `make oracles RUN=1` does and nothing else should — a session that wants a run asks for that spelling, and a permission rule of the user's own makes that spelling prompt. */
+const EXIT_CODE_NOT_APPROVED = 3
+
+if (env.HARNESS_RUN !== `1`) {
+	stderr.write(`Not running: an oracle collects new results, so it is started through \`make oracles RUN=1\` after the user has approved the run, never directly.\n`)
+	exit(EXIT_CODE_NOT_APPROVED)
+}
 
 /** The plugin is loaded by its place on disk, so that an oracle runs the same from any directory. */
 const PLUGIN = new URL(`../../lib/index.js`, import.meta.url).pathname


### PR DESCRIPTION
A run of the oracles or of a sweep is the slowest thing this repository does, and it was started far more often than it was needed: every rebase and every amend brought a fresh run of both sides, while what a run compares is two states of the tree, and neither a commit's date nor its message is a state of the tree.

```shell
make oracles          # ⏸ Not running every oracle — about 350 000 lints … the user approves it by adding RUN=1 to this very command
./scripts/oracles/nodes.mjs   # Not running: an oracle collects new results, so it is started through `make oracles RUN=1` … never directly
```

Nothing collects results without `RUN=1` any more. The bare `make oracles` and the new `make sweep FILE=…` say what they would have run and stop with exit code 3; the scripts under `scripts/oracles/` refuse to start unless the Makefile has set `HARNESS_RUN`, so a direct `node` of one of them, or a script importing them, stops at the same wall. The flag is what the user approves: a `permissions.ask` rule in their own settings makes that spelling prompt in every mode, and a `deny` rule refuses the direct spellings. `AGENTS.md` says that a subagent never adds the flag and hands the plan back instead.

## What the review turned up

- **The gate holds in a session.** A direct `./scripts/oracles/nodes.mjs` from Claude Code was refused by the `deny` rule before it ran; the `RUN=1` spellings went through the prompt.
- **Nothing in `lib/` moves.** The branch touches the Makefile, one shared oracle module and the docs.

Part of the plan in `.claude/plans/2026-08-28-dev-performance.md`; the four pull requests stacked above it are the rest of it.
