### PR TITLE
Lint a snippet without the linter around the rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ sweep: ## 🧹 Run one sweep script, base and branch alike [RUN=1] FILE=
 	HARNESS_RUN=1 node $(FILE)
 .PHONY: sweep
 
+harness-check: ## 🧫 Check that the direct runner agrees with Stylelint over every run of the oracles [RUN=1]
+	$(call require_run,the runner check — about 60 000 lints)
+	HARNESS_RUN=1 ./scripts/harness/verify-lint.mjs
+.PHONY: harness-check
+
 breaks-check: ## ↩️  Check that every line spelling a line break in lib/ is classified
 	./scripts/check-break-readings.js
 .PHONY: breaks-check

--- a/scripts/harness/lint.mjs
+++ b/scripts/harness/lint.mjs
@@ -1,0 +1,128 @@
+/**
+ * Lints one text under one or more rules of this plugin the way Stylelint would, without Stylelint.
+ *
+ * A call of `stylelint.lint` over a snippet costs about 0.8 ms on this machine, and 0.7 of them are the linter around the rule — a linter created for the call, a configuration searched for and augmented, an ignore file looked up, reference roots loaded, disable comments walked. The parse and the rule cost 0.05 ms together. An oracle or a sweep makes hundreds of thousands of such calls over snippets that carry no configuration comment and no ignore file, so the runner here does what `lintPostcssResult.mjs` does for one rule and nothing of the rest: it parses, hangs the `stylelint` object `report()` reads on the result, calls the rule, and hands back what the rule said and what it wrote. `verify-lint.mjs` is the proof that the two agree, run over every run the oracles make.
+ *
+ * What is not reproduced, since no corpus of this repository carries it: disable comments and their ranges, `ignoreDisables`, `quiet`, `computeEditInfo`, the lexer and the reference roots. A rule reaching for one of them would show up in the verification as a disagreement rather than as a wrong answer.
+ */
+
+import { EOL } from "node:os"
+
+import postcss from "postcss"
+
+import { BREAK_AS_STYLELINT_READS_IT } from "./regexps.mjs"
+
+/** The comment word Stylelint reads its configuration comments by, which no fixture carries and which a rule may still ask about. */
+const CONFIGURATION_COMMENT = `stylelint`
+
+/** The severity every rule is given, since a run here has no configuration to set another. */
+const SEVERITY = `error`
+
+/** The syntaxes a run can name, each loaded once on first use. */
+let syntaxes = new Map()
+
+/**
+ * Loads a syntax by the name a configuration spells it with, or hands back the one given.
+ * @param {string | { parse: Function, stringify: Function } | undefined} syntax - A package name such as `postcss-scss`, a syntax object, or nothing for plain CSS.
+ * @returns {Promise<{ parse: Function, stringify: Function }>} The syntax to parse and print with.
+ */
+async function loadSyntax (syntax) {
+	if (!syntax) return postcss
+	if (typeof syntax !== `string`) return syntax
+
+	if (!syntaxes.has(syntax)) {
+		let module = await import(syntax)
+
+		syntaxes.set(syntax, module.default ?? module)
+	}
+
+	return syntaxes.get(syntax)
+}
+
+/**
+ * Loads the rule registry of a checkout, so that a base and a branch can be asked in one process.
+ * @param {string} lib - The path of the checkout's `lib/` directory.
+ * @returns {Promise<Record<string, Function>>} The registry, keyed by the rule's short name.
+ */
+async function loadRules (lib) {
+	let module = await import(`${lib}/rules/index.js`)
+
+	return module.default
+}
+
+/**
+ * Names a rule the way a configuration does.
+ * @param {string} name - The short name.
+ * @returns {string} The namespaced one.
+ */
+function namespaced (name) {
+	return name.startsWith(`@stylistic/`) ? name : `@stylistic/${name}`
+}
+
+/**
+ * Lints a text under the rules given, in the order given.
+ * @param {object} options - What to lint and how.
+ * @param {string} options.code - The text.
+ * @param {Array<[string, unknown, object?]>} options.rules - Each rule by its short name, with its primary option and, where there is one, its secondary options; the order is the order the rules run in, which is the order a configuration would have listed them in.
+ * @param {Record<string, Function>} options.registry - The rule registry to take the rules from, as `loadRules` returns it.
+ * @param {string | object} [options.syntax] - The syntax to read the text with; plain CSS where none is given.
+ * @param {boolean} [options.fix] - Whether the rules are let write.
+ * @returns {Promise<{ unparsable: true, detail: string } | { unparsable: false, usable: boolean, warnings: object[], code: string }>} What the rules said and wrote, or why the text could not be read at all. A run is `usable` where no rule objected to its options, as `isUsable` of the oracles has it.
+ */
+async function lintDirect ({ code, rules, registry, syntax, fix = false }) {
+	let parser = await loadSyntax(syntax)
+	let result
+
+	try {
+		result = postcss().process(code, { from: undefined, syntax: parser }).sync()
+	}
+	catch (error) {
+		return { unparsable: true, detail: error.reason ?? error.message }
+	}
+
+	let config = { fix, rules: {} }
+	let stylelint = { ruleSeverities: {}, customMessages: {}, customUrls: {}, ruleMetadata: {}, fixersData: {}, rangesOfComputedEditInfos: [], disabledRanges: {}, config }
+
+	result.stylelint = stylelint
+
+	let context = { configurationComment: CONFIGURATION_COMMENT, newline: code.match(BREAK_AS_STYLELINT_READS_IT)?.[0] ?? EOL }
+	let roots = result.root.type === `document` ? result.root.nodes : [result.root]
+
+	for (let [name, primary, secondary] of rules) {
+		let rule = registry[name]
+
+		if (!rule) throw new Error(`No rule named "${name}" in the registry`)
+
+		let fullName = namespaced(name)
+
+		config.rules[fullName] = [primary, secondary]
+		stylelint.ruleSeverities[fullName] = SEVERITY
+		stylelint.ruleMetadata[fullName] = rule.meta ?? {}
+
+		let check = rule(primary, secondary, context)
+
+		for (let root of roots) {
+			// A rule may return a promise, and Stylelint awaits every rule before reading the result
+			// eslint-disable-next-line no-await-in-loop
+			await check(root, result)
+		}
+	}
+
+	let warnings = []
+	let usable = true
+
+	for (let warning of result.warnings()) {
+		if (warning.stylelintType === `invalidOption`) {
+			usable = false
+			continue
+		}
+
+		if (warning.stylelintType) continue
+
+		warnings.push({ rule: warning.rule, text: warning.text, line: warning.line, column: warning.column, endLine: warning.endLine, endColumn: warning.endColumn })
+	}
+
+	return { unparsable: false, usable, warnings, code: result.root.toString(parser.stringify) }
+}
+
+export { lintDirect, loadRules, loadSyntax }

--- a/scripts/harness/regexps.mjs
+++ b/scripts/harness/regexps.mjs
@@ -1,0 +1,6 @@
+/** The expressions the harness reads a text with, named the way `lib/regexps.js` names its own. */
+
+/** The first line break of a text as Stylelint reads one to fill `context.newline`: a line feed or a Windows pair, and nothing else — `lintPostcssResult.mjs` matches exactly this. */
+const BREAK_AS_STYLELINT_READS_IT = /\r?\n/u
+
+export { BREAK_AS_STYLELINT_READS_IT }

--- a/scripts/harness/verify-lint.mjs
+++ b/scripts/harness/verify-lint.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+/**
+ * Proves that `lintDirect` says and writes what `stylelint.lint` says and writes, over every run the oracles make.
+ *
+ * Every rule under every primary option over every fixture of the shared corpus, under each syntax, is linted twice by each of the two — once for its warnings and once for its fix — and the four answers are compared field by field: whether the syntax read the text at all, whether the rule accepted its options, every warning's rule, text and four positions, and the text the fix left. Then every fixture is linted under pairs of rules in both orders, since a run of several rules is where the runner has to reproduce the order Stylelint gives a plugin's rules. A disagreement is printed and fails the script; the count of runs compared is printed either way, so that a pull request can quote it.
+ */
+
+import { exit, stdout } from "node:process"
+
+import stylelint from "stylelint"
+
+import { RULE_OPTIONS } from "../oracles/options.mjs"
+import { buildRuns, isUsable } from "../oracles/runs.mjs"
+
+import { lintDirect, loadRules } from "./lint.mjs"
+
+/** The registry of this checkout, which is the one every oracle reads too. */
+const REGISTRY = await loadRules(new URL(`../../lib`, import.meta.url).pathname)
+
+/** How many neighbouring rules of the option list are paired for the two-rule runs. */
+const PAIRS_PER_FIXTURE = 24
+
+/**
+ * Asks Stylelint, and shapes its answer like the runner's.
+ * @param {string} code - The text.
+ * @param {object} config - The configuration, as the oracles build one.
+ * @param {boolean} fix - Whether the rules are let write.
+ * @returns {Promise<object>} The answer in the runner's shape.
+ */
+async function askStylelint (code, config, fix) {
+	let result
+
+	try {
+		result = await stylelint.lint({ code, config, fix })
+	}
+	catch (error) {
+		return { unparsable: true, detail: error.message }
+	}
+
+	let [first] = result.results
+	let parseError = first.warnings.find((warning) => warning.rule === `CssSyntaxError`)
+
+	if (parseError) return { unparsable: true, detail: parseError.text }
+
+	return {
+		unparsable: false,
+		usable: isUsable(first),
+		warnings: first.warnings.map(({ rule, text, line, column, endLine, endColumn }) => ({ rule, text, line, column, endLine, endColumn })),
+		code: result.code ?? code,
+	}
+}
+
+/**
+ * Asks the runner under the same configuration.
+ * @param {string} code - The text.
+ * @param {object} config - The configuration, as the oracles build one.
+ * @param {boolean} fix - Whether the rules are let write.
+ * @returns {Promise<object>} The answer.
+ */
+function askRunner (code, config, fix) {
+	let rules = Object.entries(config.rules).map(([name, setting]) => {
+		let [primary, secondary] = Array.isArray(setting) ? setting : [setting]
+
+		return [name.replace(`@stylistic/`, ``), primary, secondary]
+	})
+
+	return lintDirect({ code, rules, registry: REGISTRY, syntax: config.customSyntax, fix })
+}
+
+/**
+ * Compares the two answers, and names the first field they differ in.
+ * @param {object} expected - What Stylelint said.
+ * @param {object} actual - What the runner said.
+ * @returns {string | null} The field, or null where the two agree.
+ */
+function disagreement (expected, actual) {
+	if (expected.unparsable !== actual.unparsable) return `unparsable`
+	if (expected.unparsable) return null
+	if (expected.usable !== actual.usable) return `usable`
+	if (!expected.usable) return null
+	if (expected.code !== actual.code) return `code`
+	if (JSON.stringify(expected.warnings) !== JSON.stringify(actual.warnings)) return `warnings`
+
+	return null
+}
+
+let compared = 0
+let failures = []
+
+/**
+ * Compares one configuration over one text, checking and fixing.
+ * @param {string} label - What to print where the two disagree.
+ * @param {string} code - The text.
+ * @param {object} config - The configuration.
+ * @returns {Promise<void>} Nothing; a disagreement is recorded.
+ */
+async function compare (label, code, config) {
+	for (let fix of [false, true]) {
+		// The two are asked in turn so that a run of this script stays as light on the machine as the oracle it stands in for
+		// eslint-disable-next-line no-await-in-loop
+		let [expected, actual] = [await askStylelint(code, config, fix), await askRunner(code, config, fix)]
+		let field = disagreement(expected, actual)
+
+		compared += 1
+
+		if (field) failures.push({ label, fix, field, expected, actual })
+	}
+}
+
+let runs = buildRuns()
+
+for (let run of runs) {
+	// eslint-disable-next-line no-await-in-loop
+	await compare(`${run.rule} ${JSON.stringify(run.primary)} ${run.syntaxName} ${run.name}`, run.code, run.config)
+}
+
+let configs = Object.entries(RULE_OPTIONS).map(([rule, [primary]]) => [`@stylistic/${rule}`, primary])
+let fixtures = new Map(runs.filter((run) => run.syntaxName === `css`).map((run) => [run.name, run]))
+
+for (let [name, run] of fixtures) {
+	for (let index = 0; index < PAIRS_PER_FIXTURE; index += 1) {
+		let a = configs[(index * 3) % configs.length]
+		let b = configs[((index * 3) + 1) % configs.length]
+
+		for (let [first, second] of [[a, b], [b, a]]) {
+			// eslint-disable-next-line no-await-in-loop
+			await compare(`${first[0]} then ${second[0]} css ${name}`, run.code, { plugins: run.config.plugins, rules: { [first[0]]: first[1], [second[0]]: second[1] } })
+		}
+	}
+}
+
+stdout.write(`${compared} runs compared, ${failures.length} disagreements\n`)
+
+for (let failure of failures.slice(0, 20)) stdout.write(`${JSON.stringify(failure, null, `\t`)}\n`)
+
+exit(failures.length === 0 ? 0 : 1)


### PR DESCRIPTION
A call of `stylelint.lint` over a snippet costs about 0.8 ms on this machine, and 0.7 of them are the linter around the rule — a linter created for the call, a configuration searched for and augmented, an ignore file looked up, reference roots loaded, disable comments walked. The parse and the rule cost 0.05 ms together, and an oracle makes some 350 000 such calls.

```text
stylelint.lint, one rule       0.83 ms
stylelint.lint, rules: {}      0.68 ms   ← the linter around the rule
postcss.parse                  0.004 ms
rule called on the parsed root 0.04 ms
```

`scripts/harness/lint.mjs` does what `lintPostcssResult.mjs` does for one rule and nothing of the rest: it parses, hangs the `stylelint` object `report()` reads on the result, calls each rule in the order given — the order Stylelint gives a plugin's rules — and hands back what the rules said and what they wrote. It answers in the shape the oracles read as well, so the next pull request changes one import in each of them.

## What the review turned up

- **The two agree, field by field.** `make harness-check RUN=1` runs every run the oracles make, checked and fixed, and every fixture under 24 pairs of rules in both orders, through both: 52 160 runs compared, no disagreement in whether the text parsed, whether the options were accepted, any warning's rule, text or four positions, or the text the fix left.
- **What is not reproduced no fixture carries.** Disable comments, `ignoreDisables`, `quiet` and `computeEditInfo` are not modelled; a rule reaching for one of them would show up in the check above as a disagreement rather than as a wrong answer.

Stacked on #429.
