### PR TITLE
Run the oracles and the sweeps on the runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ oracles: ## 🔮 Run every oracle over every rule and option [RUN=1] [OUT=]
 	@printf "\t✅ Written to $(ANSI_BOLD)$(OUT)$(ANSI_RESET). Run once before a branch and once after, and read the diff.\n\n"
 .PHONY: oracles
 
-sweep: ## 🧹 Run one sweep script, base and branch alike [RUN=1] FILE=
+sweep: ## 🧹 Run one sweep on the base and on the working tree, and write the diff [RUN=1] FILE= [BASE=]
 	@test -n "$(FILE)" || { printf "\t❌ $(ANSI_BOLD)FILE= names the sweep to run$(ANSI_RESET)\n\n"; exit 2; }
 	$(call require_run,the sweep $(FILE))
-	HARNESS_RUN=1 node $(FILE)
+	HARNESS_RUN=1 ./scripts/sweeps/run.mjs $(FILE) $(BASE)
 .PHONY: sweep
 
 harness-check: ## 🧫 Check that the direct runner agrees with Stylelint over every run of the oracles [RUN=1]

--- a/scripts/harness/checkout.mjs
+++ b/scripts/harness/checkout.mjs
@@ -1,0 +1,41 @@
+/**
+ * Puts the `lib/` of another revision on disk, so that a run can ask a base and a branch in one process.
+ *
+ * The working tree is never moved for the sake of a run. The directory is extracted once per content — it is named by the hash of the `lib` tree, which a rebase or an amend that touched no file of it leaves as it was — under `tmp/checkouts/`, which the repository ignores.
+ */
+
+import { execFileSync } from "node:child_process"
+import { existsSync, mkdirSync } from "node:fs"
+import path from "node:path"
+
+/** The root of the repository, whatever directory the run was started from. */
+const ROOT = execFileSync(`git`, [`rev-parse`, `--show-toplevel`], { encoding: `utf8` }).trim()
+
+/**
+ * Hands back the path of a revision's `lib/`, extracting it where it is not on disk yet.
+ * @param {string} revision - Anything `git rev-parse` reads, or `worktree` for the working tree as it stands.
+ * @returns {string} The absolute path of that `lib/`.
+ */
+function libAt (revision) {
+	if (revision === `worktree`) return path.join(ROOT, `lib`)
+
+	let tree = execFileSync(`git`, [`rev-parse`, `${revision}:lib`], { cwd: ROOT, encoding: `utf8` }).trim()
+	let directory = path.join(ROOT, `tmp`, `checkouts`, tree)
+
+	if (!existsSync(path.join(directory, `lib`))) {
+		mkdirSync(directory, { recursive: true })
+		execFileSync(`sh`, [`-c`, `git archive ${revision} lib | tar -x -C ${directory}`], { cwd: ROOT })
+	}
+
+	return path.join(directory, `lib`)
+}
+
+/**
+ * Names the revision a branch is measured against: where it left `origin/main`.
+ * @returns {string} The commit.
+ */
+function defaultBase () {
+	return execFileSync(`git`, [`merge-base`, `HEAD`, `origin/main`], { cwd: ROOT, encoding: `utf8` }).trim()
+}
+
+export { defaultBase, libAt, ROOT }

--- a/scripts/harness/diff.mjs
+++ b/scripts/harness/diff.mjs
@@ -1,0 +1,62 @@
+/**
+ * Compares two results of one run, row by row and never by count.
+ *
+ * A row can change shape without leaving and leave while another arrives, and a count stands still through both. So the two sides are read as maps from a row's key to what the row holds, and the finding is three lists: the keys one side holds and the other does not, either way round, and the keys both hold under a different value.
+ */
+
+/**
+ * Diffs two results keyed alike.
+ * @param {Record<string, unknown>} base - The rows of the base, by key.
+ * @param {Record<string, unknown>} head - The rows of the branch, by key.
+ * @returns {{ added: string[], removed: string[], changed: string[], same: number }} The keys the branch added, the keys it removed, the keys it changed, and how many it left as they were.
+ */
+function diff (base, head) {
+	let added = []
+	let removed = []
+	let changed = []
+	let same = 0
+
+	for (let key of Object.keys(head)) {
+		if (!(key in base)) {
+			added.push(key)
+			continue
+		}
+
+		if (JSON.stringify(base[key]) === JSON.stringify(head[key])) same += 1
+		else changed.push(key)
+	}
+
+	for (let key of Object.keys(base)) if (!(key in head)) removed.push(key)
+
+	return { added, removed, changed, same }
+}
+
+/**
+ * Writes a diff as Markdown a reader can go through row by row.
+ * @param {ReturnType<typeof diff>} result - The diff.
+ * @param {Record<string, unknown>} base - The rows of the base, by key.
+ * @param {Record<string, unknown>} head - The rows of the branch, by key.
+ * @param {number} [limit] - How many rows of each list to spell out.
+ * @returns {string} The Markdown.
+ */
+function render (result, base, head, limit = 200) {
+	let lines = [`| | rows |`, `| --- | --- |`, `| same | ${result.same} |`, `| changed | ${result.changed.length} |`, `| added | ${result.added.length} |`, `| removed | ${result.removed.length} |`, ``]
+
+	for (let [title, keys, sides] of [[`Changed`, result.changed, [base, head]], [`Added`, result.added, [head]], [`Removed`, result.removed, [base]]]) {
+		if (keys.length === 0) continue
+
+		lines.push(`## ${title}`, ``)
+
+		for (let key of keys.slice(0, limit)) {
+			lines.push(`### \`${key}\``, ``)
+
+			for (let side of sides) lines.push(`\`\`\`json`, JSON.stringify(side[key], null, `\t`), `\`\`\``, ``)
+		}
+
+		if (keys.length > limit) lines.push(`… and ${keys.length - limit} more`, ``)
+	}
+
+	return `${lines.join(`\n`)}\n`
+}
+
+export { diff, render }

--- a/scripts/harness/lint.mjs
+++ b/scripts/harness/lint.mjs
@@ -7,6 +7,7 @@
  */
 
 import { EOL } from "node:os"
+import path from "node:path"
 
 import postcss from "postcss"
 
@@ -125,4 +126,37 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }) {
 	return { unparsable: false, usable, warnings, code: result.root.toString(parser.stringify) }
 }
 
-export { lintDirect, loadRules, loadSyntax }
+/** The registries already loaded, by the plugin path a configuration names. */
+let registries = new Map()
+
+/**
+ * Lints the way `stylelint.lint` is called by the oracles, and answers in the shape they read.
+ *
+ * The configuration is the one `runs.mjs` builds — a plugin named by its path, a syntax named by its package, and one rule or several under their namespaced names — and the answer carries `results[0].warnings`, `results[0].invalidOptionWarnings` and `code`, which is all an oracle reads of Stylelint's. A text the syntax cannot read answers with a warning whose rule is `CssSyntaxError`, as Stylelint's does.
+ * @param {object} options - The options `stylelint.lint` would have taken.
+ * @param {string} options.code - The text.
+ * @param {object} options.config - The configuration.
+ * @param {boolean} [options.fix] - Whether the rules are let write.
+ * @returns {Promise<{ results: [{ warnings: object[], invalidOptionWarnings: object[] }], code: string | undefined }>} The answer, shaped like Stylelint's.
+ */
+async function lint ({ code, config, fix = false }) {
+	let [plugin] = config.plugins
+
+	if (!registries.has(plugin)) registries.set(plugin, await loadRules(path.dirname(plugin)))
+
+	let rules = Object.entries(config.rules).map(([name, setting]) => {
+		let [primary, secondary] = Array.isArray(setting) ? setting : [setting]
+
+		return [name.replace(`@stylistic/`, ``), primary, secondary]
+	})
+	let answer = await lintDirect({ code, rules, registry: registries.get(plugin), syntax: config.customSyntax, fix })
+
+	if (answer.unparsable) return { results: [{ warnings: [{ rule: `CssSyntaxError`, text: `${answer.detail} (CssSyntaxError)`, severity: SEVERITY }], invalidOptionWarnings: [] }], code: undefined }
+
+	return {
+		results: [{ warnings: answer.warnings, invalidOptionWarnings: answer.usable ? [] : [{ text: `invalid option` }] }],
+		code: fix ? answer.code : undefined,
+	}
+}
+
+export { lint, lintDirect, loadRules, loadSyntax }

--- a/scripts/harness/matrix.mjs
+++ b/scripts/harness/matrix.mjs
@@ -1,0 +1,34 @@
+/**
+ * Builds the corpus of a sweep by multiplying axes.
+ *
+ * A sweep answers as well as its corpus is full, and every sweep so far spelled the same product of axes by hand — a comment, a break, another break, a tail — and forgot an axis each time review found the class it was blind to. So the product is written once here, and a corpus is a list of named axes plus a template that places one value of each. Every value carries a name, and a row's key is the names of the values that made it joined by a bar, so that a row can be read without the text and diffed across two sides.
+ */
+
+/**
+ * Multiplies the axes and places each combination in the template.
+ * @param {Record<string, Record<string, string>>} axes - Each axis under its name, and under each axis every value under its own name.
+ * @param {(values: Record<string, string>) => string} template - Places one value of every axis, given by the axis names.
+ * @returns {[string, string][]} Every combination, as the key made of the value names and the text the template gave.
+ */
+function multiply (axes, template) {
+	let entries = Object.entries(axes)
+	let rows = [[[], {}]]
+
+	for (let [axis, values] of entries) {
+		rows = rows.flatMap(([names, chosen]) => Object.entries(values).map(([name, value]) => [[...names, name], { ...chosen, [axis]: value }]))
+	}
+
+	return rows.map(([names, chosen]) => [names.join(`|`), template(chosen)])
+}
+
+/**
+ * Places every value of a corpus in every environment, so that a shape is asked about wherever it can stand.
+ * @param {[string, string][]} values - The values, keyed.
+ * @param {Record<string, (value: string) => string>} environments - Each environment under its name, taking a value and giving the stylesheet it stands in.
+ * @returns {[string, string][]} Every value in every environment, the environment's name in front of the value's key.
+ */
+function place (values, environments) {
+	return Object.entries(environments).flatMap(([name, wrap]) => values.map(([key, value]) => [`${name}|${key}`, wrap(value)]))
+}
+
+export { multiply, place }

--- a/scripts/oracles/README.md
+++ b/scripts/oracles/README.md
@@ -3,11 +3,11 @@
 Probes over a corpus of the shapes that have gone wrong before. All but one run every rule of the plugin against every primary option it accepts; `pairs.mjs` runs every pair of those instead. Each asks a question no test case in this repository can ask, and the table below is the list of them — a count of them written into this prose would fall behind the next one written.
 
 ```shell
-make oracles                        # writes tmp/oracles/{converge,control,comments,twins,nodes,pairs}.json
-make oracles OUT=tmp/oracles-before # anywhere else
+make oracles RUN=1                        # writes tmp/oracles/{converge,control,comments,twins,nodes,pairs}.json
+make oracles RUN=1 OUT=tmp/oracles-before # anywhere else
 ```
 
-They take a few minutes together, and each writes JSON: a list of rows, one per rule, option, syntax and fixture that answered wrongly — or, in `pairs.mjs`, one per pair of configurations and fixture. They can also be run one at a time — every script is executable and writes to standard output.
+Nothing runs without `RUN=1`: a run collects results rather than reading them, and it is the user who says when one is worth the machine — the bare target says what it would have run and stops, and the scripts refuse to start unless the Makefile has set `HARNESS_RUN`. They take about twenty seconds together, and each writes JSON: a list of rows, one per rule, option, syntax and fixture that answered wrongly — or, in `pairs.mjs`, one per pair of configurations and fixture. They can also be run one at a time — every script is executable and writes to standard output.
 
 | Oracle | Asks |
 | --- | --- |
@@ -45,6 +45,12 @@ Seven issues came out of the first run of them, [#231](https://github.com/st
 - it lints under one configuration, spelled one way round. A case naming a second rule through `extraRules` asserts the order it happened to write them in, and never the other, which is what `pairs.mjs` is for.
 
 An oracle is worth what it can be shown to catch, and a probe that has never been seen to fire says nothing about the code. `nodes.mjs` reported nothing when it was written, because no fixture stood where a fixer takes a break away from an inline comment; `inline-after-brace` and `inline-after-semicolon` were written with it, and it then reported [#248](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/248) four times over. `grid-empty-row` was written the same way for [#368](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/368), a row of the grid holding no cell at all, which no fixture carried: `converge.mjs` reports that shape three times over the code as it stood before that fix — once per syntax — and comes back clean from the fix itself.
+
+## The runner
+
+None of them calls `stylelint.lint`. A call of it over a snippet costs about 0.8 ms, and 0.7 of them are the linter around the rule — a linter created for the call, a configuration searched for and augmented, an ignore file looked up, reference roots loaded, disable comments walked — while the parse and the rule cost 0.05 ms together; over the 350 000 calls a run of the six makes, that is the difference between five minutes and twenty seconds. So [scripts/harness/lint.mjs](../harness/lint.mjs) does what `lintPostcssResult.mjs` does for one rule and nothing of the rest, and answers in the shape the oracles read. `make harness-check RUN=1` is the proof that the two agree: every run the oracles make, checked and fixed, and every fixture under pairs of rules in both orders, compared with Stylelint field by field. What the runner does not reproduce — disable comments, `ignoreDisables`, `quiet`, `computeEditInfo` — no fixture carries, and a rule reaching for one of them would show up there as a disagreement.
+
+The same runner drives the sweeps of [scripts/sweeps/](../sweeps/): a sweep is a module exporting a corpus, most often built by multiplying axes with [scripts/harness/matrix.mjs](../harness/matrix.mjs), and the configurations to read it under; `make sweep FILE=scripts/sweeps/<name>.mjs RUN=1 [BASE=<rev>]` lints it on the base and on the working tree in one process — the base's `lib/` is extracted under `tmp/checkouts/` by the hash of its tree, so the working tree is never moved for a run — and writes the rows that moved to `tmp/sweeps/<name>.md`, row by row and never by count. A sweep is kept once it has measured a branch, the way a fixture is kept once it has caught a defect.
 
 ## The files
 

--- a/scripts/oracles/comments.mjs
+++ b/scripts/oracles/comments.mjs
@@ -8,7 +8,7 @@
 
 import { stdout } from "node:process"
 
-import stylelint from "stylelint"
+import { lint } from "../harness/lint.mjs"
 
 import { buildRuns, isUsable } from "./runs.mjs"
 
@@ -38,7 +38,7 @@ async function probe (run) {
 	let result
 
 	try {
-		result = await stylelint.lint({ code: run.code, config: run.config, fix: true })
+		result = await lint({ code: run.code, config: run.config, fix: true })
 	}
 	catch {
 		return null

--- a/scripts/oracles/control.mjs
+++ b/scripts/oracles/control.mjs
@@ -10,7 +10,7 @@
 
 import { stdout } from "node:process"
 
-import stylelint from "stylelint"
+import { lint } from "../harness/lint.mjs"
 
 import { buildRuns } from "./runs.mjs"
 
@@ -43,7 +43,7 @@ const CORPUS = [
  * @returns {Promise<string[]>} The warnings, each with its position.
  */
 async function warningsOf (code, config) {
-	let result = await stylelint.lint({ code, config, fix: false })
+	let result = await lint({ code, config, fix: false })
 
 	return result.results[0].warnings.map((warning) => `${warning.line}:${warning.column} ${warning.text}`)
 }

--- a/scripts/oracles/converge.mjs
+++ b/scripts/oracles/converge.mjs
@@ -14,7 +14,7 @@
 
 import { stdout } from "node:process"
 
-import stylelint from "stylelint"
+import { lint } from "../harness/lint.mjs"
 
 import { buildRuns, isUsable } from "./runs.mjs"
 
@@ -42,7 +42,7 @@ async function probe (run) {
 		try {
 			// Each run reads what the one before it wrote, so the three cannot be made at once
 			// eslint-disable-next-line no-await-in-loop
-			result = await stylelint.lint({ code: current, config: run.config, fix: true })
+			result = await lint({ code: current, config: run.config, fix: true })
 		}
 		catch (error) {
 			return { kind: `broke`, ...label(run), detail: `threw: ${error.message}`, history }

--- a/scripts/oracles/nodes.mjs
+++ b/scripts/oracles/nodes.mjs
@@ -13,7 +13,8 @@ import { stdout } from "node:process"
 import postcss from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
-import stylelint from "stylelint"
+
+import { lint } from "../harness/lint.mjs"
 
 import { buildRuns, isUsable } from "./runs.mjs"
 
@@ -55,7 +56,7 @@ async function probe (run) {
 	let result
 
 	try {
-		result = await stylelint.lint({ code: run.code, config: run.config, fix: true })
+		result = await lint({ code: run.code, config: run.config, fix: true })
 	}
 	catch {
 		return null

--- a/scripts/oracles/pairs.mjs
+++ b/scripts/oracles/pairs.mjs
@@ -15,7 +15,7 @@
 
 import { stdout } from "node:process"
 
-import stylelint from "stylelint"
+import { lint as lintDirectly } from "../harness/lint.mjs"
 
 import { RULE_OPTIONS } from "./options.mjs"
 import { isUsable, PLUGIN } from "./runs.mjs"
@@ -52,7 +52,7 @@ async function lint (code, rules, fix) {
 	let result
 
 	try {
-		result = await stylelint.lint({ code, fix, config: { plugins: [PLUGIN], rules } })
+		result = await lintDirectly({ code, fix, config: { plugins: [PLUGIN], rules } })
 	}
 	catch {
 		return { code, warnings: 0, usable: false }

--- a/scripts/oracles/twins.mjs
+++ b/scripts/oracles/twins.mjs
@@ -25,7 +25,7 @@
 
 import { stdout } from "node:process"
 
-import stylelint from "stylelint"
+import { lint } from "../harness/lint.mjs"
 
 import { buildRuns, isUsable } from "./runs.mjs"
 
@@ -76,8 +76,8 @@ async function ask (code, config) {
 	let fixed
 
 	try {
-		checked = await stylelint.lint({ code, config })
-		fixed = await stylelint.lint({ code, config, fix: true })
+		checked = await lint({ code, config })
+		fixed = await lint({ code, config, fix: true })
 	}
 	catch (error) {
 		return { read: false, unparsable: true, detail: `threw: ${error.message}` }

--- a/scripts/sweeps/function-parentheses-breaks.mjs
+++ b/scripts/sweeps/function-parentheses-breaks.mjs
@@ -1,0 +1,36 @@
+/**
+ * A comment of every kind in front of a break of every kind, inside the parentheses of a call, under the seven configurations of the two rules about the whitespace inside those parentheses.
+ *
+ * Written for #282 and #321 and carried since, so that no later fix can move a break or a comment there without a row saying so. Ten comments, since a `//` comment closed by the parser, one left open, one holding a block comment's opener and one standing in a string or an address are all different things to a fixer; ten breaks, since a line feed, a carriage return, a Windows pair, a form feed, the two Unicode separators and a plain space are all different things to the syntaxes; and six tails, since what stands behind the break decides whether the parser has closed the call at all. A second prefix puts the same call on two lines, so that the `-multi-line` options are reached.
+ */
+
+import { multiply, place } from "../harness/matrix.mjs"
+
+const LINE_SEPARATOR = String.fromCodePoint(0x2028)
+const PARAGRAPH_SEPARATOR = String.fromCodePoint(0x2029)
+const NO_BREAK_SPACE = String.fromCodePoint(0x00a0)
+
+const BREAKS = { lf: `\n`, cr: `\r`, crlf: `\r\n`, ff: `\f`, ls: LINE_SEPARATOR, ps: PARAGRAPH_SEPARATOR, nbsp: NO_BREAK_SPACE, space: ` `, tab: `\t`, none: `` }
+
+const COMMENTS = { inline: `//c`, inlineThenBlockOpener: `//c/*x`, block: `/*b*/`, inlineThenBlockCloser: `//c*/`, none: ``, bareSlashes: `//`, url: `url(//x)`, string: `"//s"`, inlineThenSlash: `//c/`, slash: `/` }
+
+const TAILS = { none: ``, block: `/*t*/`, blockOverLs: `/*t${LINE_SEPARATOR}u*/`, blockOverLf: `/*t\nu*/`, blockOpen: `/*t*`, word: `d` }
+
+const name = `function-parentheses-breaks`
+
+const corpus = place(
+	multiply({ comment: COMMENTS, first: BREAKS, second: BREAKS, tail: TAILS }, ({ comment, first, second, tail }) => `translate(1px, 2px ${comment}${first}${tail}${second})`),
+	{ singleLine: (value) => `a { transform: ${value}; }`, multiLine: (value) => `a { transform: 1px,\n${value}; }` },
+)
+
+const configs = [
+	{ rule: `function-parentheses-space-inside`, primary: `always` },
+	{ rule: `function-parentheses-space-inside`, primary: `never` },
+	{ rule: `function-parentheses-space-inside`, primary: `always-single-line` },
+	{ rule: `function-parentheses-space-inside`, primary: `never-single-line` },
+	{ rule: `function-parentheses-newline-inside`, primary: `always` },
+	{ rule: `function-parentheses-newline-inside`, primary: `always-multi-line` },
+	{ rule: `function-parentheses-newline-inside`, primary: `never-multi-line` },
+]
+
+export { configs, corpus, name }

--- a/scripts/sweeps/interpolation-case.mjs
+++ b/scripts/sweeps/interpolation-case.mjs
@@ -1,0 +1,61 @@
+/**
+ * An interpolation of every spelling, holding every kind of text, welded to every head and every tail a value word can carry, in every environment a value stands in, under the two rules that recase what they read.
+ *
+ * Written for #298, where `unit-case` recased the name inside `10px#{$a != $b}` because the parser had cut the interpolation into words and no word held the whole of it; the corpus of that branch is rebuilt here from the axes `.claude/docs/method-sweep.md` records, and the numbers of that branch are not to be read off it. The twelve controls open no interpolation in plain CSS, since a corpus that puts an interpolation into every form is blind to what a branch does where there is none — the second draft of that fix stopped checking a value whose braces stand in two comments, and no row could say so.
+ */
+
+import { multiply, place } from "../harness/matrix.mjs"
+
+const OPENERS = { sass: `#{`, less: `@{`, postcssSimpleVars: `$(` }
+const CLOSERS = { sass: `}`, less: `}`, postcssSimpleVars: `)` }
+
+const TEXTS = { name: `$a`, comparison: `$a != $b`, product: `$m * 2px`, productEndingInDigit: `$n * 2`, twoDimensions: `2px 3rem`, upper: `$A`, upperUnit: `10PX`, unitAlone: `px`, upperUnitAlone: `PX`, sum: `$a + 1`, call: `f($a)`, quoted: `"PX"`, spacedName: ` $a `, hex: `#FFF`, empty: `` }
+
+const HEADS = { none: ``, unit: `10px`, upperUnit: `10PX`, product: `1px*2rem`, bang: `10px!important`, hack: `10px\\9` }
+
+const TAILS = { none: ``, unit: `10px`, upperUnit: `10PX`, unitAlone: `px`, upperUnitAlone: `PX`, spacedUnit: ` 10px` }
+
+/** Values whose braces open no interpolation in plain CSS: a pair in a comment, in a string, and a bare one. */
+const CONTROLS = [
+	[`control|comment-pair`, `1px /* { */ 10PX /* } */`],
+	[`control|string-pair`, `"{" 10PX "}"`],
+	[`control|bare-pair`, `{ 10PX }`],
+	[`control|bare-open`, `{ 10PX`],
+	[`control|bare-close`, `10PX }`],
+	[`control|comment-open`, `1px /* #{ */ 10PX`],
+	[`control|comment-close`, `10PX /* } */`],
+	[`control|string-open`, `"#{" 10PX`],
+	[`control|string-close`, `10PX "}"`],
+	[`control|dollar-paren-string`, `"$(" 10PX ")"`],
+	[`control|at-brace-comment`, `/* @{ */ 10PX /* } */`],
+	[`control|parens`, `(10PX)`],
+]
+
+const name = `interpolation-case`
+
+const corpus = place(
+	[
+		...multiply({ spelling: OPENERS, text: TEXTS, head: HEADS, tail: TAILS }, ({ spelling, text, head, tail }) => {
+			let closer = CLOSERS[Object.keys(OPENERS).find((key) => OPENERS[key] === spelling)]
+
+			return `${head}${spelling}${text}${closer}${tail}`
+		}),
+		...CONTROLS,
+	],
+	{
+		declaration: (value) => `a { width: ${value}; }`,
+		calc: (value) => `a { width: calc(${value} + 1px); }`,
+		neighbours: (value) => `a { margin: 1PX ${value} 2PX; }`,
+		media: (value) => `@media (min-width: ${value}) { a { b: c; } }`,
+		customProperty: (value) => `a { --x: ${value}; }`,
+	},
+)
+
+const configs = [
+	{ rule: `unit-case`, primary: `lower` },
+	{ rule: `unit-case`, primary: `upper` },
+	{ rule: `color-hex-case`, primary: `lower` },
+	{ rule: `color-hex-case`, primary: `upper` },
+]
+
+export { configs, corpus, name }

--- a/scripts/sweeps/run.mjs
+++ b/scripts/sweeps/run.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * Runs one sweep on both sides and writes the diff.
+ *
+ * A sweep is a module exporting its `name`, its `corpus` — a list of keyed texts, most often built with `scripts/harness/matrix.mjs` — its `configs`, each a rule under a primary option and, where there are any, secondary ones, and the `syntaxes` it is read under. Every text is linted under every configuration and syntax twice, checked and fixed, on the base and on the branch, and the finding is what moved between the two: `tmp/sweeps/<name>.md` holds it row by row, and the two sides stand beside it as JSON.
+ *
+ * Started through `make sweep FILE=… RUN=1` and nothing else: a run collects results, and the user approves one by that spelling.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { argv, env, exit, stderr, stdout } from "node:process"
+
+import { defaultBase, libAt, ROOT } from "../harness/checkout.mjs"
+import { diff, render } from "../harness/diff.mjs"
+import { lintDirect, loadRules } from "../harness/lint.mjs"
+
+/** The code a run stops with where it was started without approval. */
+const EXIT_CODE_NOT_APPROVED = 3
+
+/** The syntax each name is read under, plain CSS under none. */
+const SYNTAXES = { css: undefined, scss: `postcss-scss`, less: `postcss-less` }
+
+if (env.HARNESS_RUN !== `1`) {
+	stderr.write(`Not running: a sweep collects new results, so it is started through \`make sweep FILE=… RUN=1\` after the user has approved the run, never directly.\n`)
+	exit(EXIT_CODE_NOT_APPROVED)
+}
+
+/**
+ * Lints one text under one configuration, checking and fixing, and reads the fix back.
+ * @param {object} options - What `lintDirect` takes, without `fix`.
+ * @returns {Promise<object>} The row: the warnings the check drew, the text the fix left and whether the syntax reads it — or why the run says nothing.
+ */
+async function measureOne (options) {
+	let checked = await lintDirect(options)
+
+	if (checked.unparsable) return { unparsable: true }
+	if (!checked.usable) return { usable: false }
+
+	let fixed = await lintDirect({ ...options, fix: true })
+	let reparse = await lintDirect({ ...options, code: fixed.code, rules: [] })
+
+	return { warnings: checked.warnings.map((warning) => warning.text), fixed: fixed.code, reparses: !reparse.unparsable }
+}
+
+/**
+ * Lints every text of the corpus under every configuration and syntax, with one registry.
+ * @param {object} sweep - The sweep module.
+ * @param {Record<string, Function>} registry - The rules of one side.
+ * @returns {Promise<Record<string, object>>} Every row by its key.
+ */
+async function measure (sweep, registry) {
+	let rows = {}
+
+	for (let syntaxName of sweep.syntaxes ?? Object.keys(SYNTAXES)) {
+		for (let config of sweep.configs) {
+			let rules = [[config.rule, config.primary, config.secondary]]
+
+			for (let [key, code] of sweep.corpus) {
+				// The rows are measured in turn so that a run stays as light on the machine as the one it replaces
+				// eslint-disable-next-line no-await-in-loop
+				rows[`${syntaxName}|${config.rule}|${JSON.stringify(config.primary)}|${key}`] = await measureOne({ code, rules, registry, syntax: SYNTAXES[syntaxName] })
+			}
+		}
+	}
+
+	return rows
+}
+
+let [file, base = defaultBase()] = argv.slice(2)
+
+if (!file) {
+	stderr.write(`Usage: run.mjs <sweep module> [base revision]\n`)
+	exit(2)
+}
+
+let sweep = await import(path.resolve(file))
+let sides = { base: await loadRules(libAt(base)), head: await loadRules(libAt(`worktree`)) }
+let results = {}
+
+for (let [side, registry] of Object.entries(sides)) {
+	// The two sides are measured in turn, base first, so that the branch is never read before what it is compared with
+	// eslint-disable-next-line no-await-in-loop
+	results[side] = await measure(sweep, registry)
+}
+
+let out = path.join(ROOT, `tmp`, `sweeps`)
+
+mkdirSync(out, { recursive: true })
+
+let result = diff(results.base, results.head)
+
+for (let side of Object.keys(sides)) writeFileSync(path.join(out, `${sweep.name}-${side}.json`), `${JSON.stringify(results[side], null, `\t`)}\n`)
+
+writeFileSync(path.join(out, `${sweep.name}.md`), `# ${sweep.name}: ${base} → worktree\n\n${render(result, results.base, results.head)}`)
+stdout.write(`${Object.keys(results.head).length} rows: ${result.same} same, ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed — tmp/sweeps/${sweep.name}.md\n`)


### PR DESCRIPTION
Every oracle called `stylelint.lint`, and a sweep was a script written from scratch in `tmp/` for each issue, dying with its worktree and spelling the same product of axes by hand every time — and forgetting an axis each time review found the class it was blind to.

```text
make oracles RUN=1 on the old scripts   ≈ 5 min
make oracles RUN=1 on the runner        22.5 s   — the six JSON files byte for byte the same
make sweep FILE=scripts/sweeps/function-parentheses-breaks.mjs RUN=1   252 000 rows, both sides, 37 s
```

The oracles change one import each. A sweep is now a module under `scripts/sweeps/` exporting a corpus, most often built by multiplying named axes with `scripts/harness/matrix.mjs`, and the configurations to read it under; `scripts/sweeps/run.mjs` lints it on the base and on the working tree in one process — the base's `lib/` is extracted under `tmp/checkouts/` by the hash of its tree, so the working tree is never moved for a run — and `scripts/harness/diff.mjs` writes what moved to `tmp/sweeps/<name>.md`, row by row and never by count. Two corpora come with it: the one #282 and #321 were measured with, and the one of #298 rebuilt from the axes `method-sweep.md` records.

## What the review turned up

- **Nothing moved in any oracle.** Each of the six was run by the old script and by the new one over the same checkout, and `cmp` found the six pairs of files identical.
- **The sweep sees nothing between a base and an unchanged tree.** 252 000 rows of the first corpus, `origin/main` against a working tree whose `lib/` is the same: 0 changed, 0 added, 0 removed.

Stacked on #430.
