### PR TITLE
Say how long an oracle took, and compare a sweep by digest

### DIFF
--- a/scripts/harness/cache.mjs
+++ b/scripts/harness/cache.mjs
@@ -91,6 +91,32 @@ function fileOf (kind, name, key) {
 }
 
 /**
+ * Digests a result down to one short hash per row, so that two results can be compared without either being read whole.
+ *
+ * A result of the largest sweep is half a million rows and a hundred megabytes of JSON, and a comparison that reads both sides whole spends its seconds parsing text it will find unchanged. The digest is what a comparison reads instead; the rows themselves are read only for the keys the digest says have moved, which is most often none.
+ * @param {Record<string, unknown>} rows - The rows by key.
+ * @returns {Record<string, string>} A hash of each row by the same key.
+ */
+function digestOf (rows) {
+	let digest = {}
+
+	for (let [key, row] of Object.entries(rows)) digest[key] = createHash(`sha1`).update(JSON.stringify(row)).digest(`hex`).slice(0, 16)
+
+	return digest
+}
+
+/**
+ * Names the digest file of a result.
+ * @param {string} kind - `oracles` or `sweeps`.
+ * @param {string} name - The oracle's or the sweep's.
+ * @param {string} key - The key.
+ * @returns {string} The path.
+ */
+function digestFileOf (kind, name, key) {
+	return path.join(CACHE_DIR, kind, name, `${key}.digest.json`)
+}
+
+/**
  * Reads a kept result.
  * @param {string} kind - `oracles` or `sweeps`.
  * @param {string} name - The oracle's or the sweep's.
@@ -105,24 +131,48 @@ function read (kind, name, key) {
 	return JSON.parse(readFileSync(file, `utf8`))
 }
 
+/** The digests read in this process, by file. */
+let digests = new Map()
+
 /**
- * Keeps a result, once.
+ * Reads the digest of a kept result, which is all a comparison needs until a row has moved.
+ * @param {string} kind - `oracles` or `sweeps`.
+ * @param {string} name - The oracle's or the sweep's.
+ * @param {string} key - The key.
+ * @returns {Record<string, string> | undefined} The hash of each row by key, or nothing where no result was kept.
+ */
+function readDigest (kind, name, key) {
+	let file = digestFileOf(kind, name, key)
+
+	if (!existsSync(file)) return
+
+	// Two sides standing on one tree ask for one digest, and a file of half a million keys is parsed once for both
+	if (!digests.has(file)) digests.set(file, JSON.parse(readFileSync(file, `utf8`)))
+
+	return digests.get(file)
+}
+
+/**
+ * Keeps a result, once, with its digest beside it.
  * @param {string} kind - `oracles` or `sweeps`.
  * @param {string} name - The oracle's or the sweep's.
  * @param {string} key - The key.
  * @param {unknown} rows - The result.
  * @param {object} meta - What the key was made of, and where and when the run was made, kept beside the rows for a reader and for the collector.
+ * @param {Record<string, string>} [digest] - The digest of the rows, where the caller has it already.
  * @returns {void}
  */
-function write (kind, name, key, rows, meta) {
+function write (kind, name, key, rows, meta, digest) {
 	let file = fileOf(kind, name, key)
 
 	if (existsSync(file)) throw new Error(`${file} is already written; a result is written once, and a second answer to the same question is a finding rather than an update`)
 
 	mkdirSync(path.dirname(file), { recursive: true })
-	writeFileSync(file, `${JSON.stringify(rows, null, `\t`)}\n`)
+	writeFileSync(file, JSON.stringify(rows))
+	writeFileSync(digestFileOf(kind, name, key), JSON.stringify(digest ?? digestOf(/** @type {Record<string, unknown>} */ (rows))))
 	writeFileSync(`${file.slice(0, -5)}.meta.json`, `${JSON.stringify({ ...meta, writtenAt: new Date().toISOString() }, null, `\t`)}\n`)
 	chmodSync(file, READ_ONLY)
+	chmodSync(digestFileOf(kind, name, key), READ_ONLY)
 }
 
-export { CACHE_DIR, fileOf, hashAt, keyOf, read, treeOf, write }
+export { CACHE_DIR, digestOf, fileOf, hashAt, keyOf, read, readDigest, treeOf, write }

--- a/scripts/oracles/compare.mjs
+++ b/scripts/oracles/compare.mjs
@@ -112,9 +112,10 @@ if (plan.length > 0 && env.HARNESS_RUN !== `1`) {
 }
 
 for (let item of plan) {
-	stdout.write(`\t🔮 ${item.oracle} over ${item.side} (${item.revision})\n`)
-
+	let started = performance.now()
 	let rows = run(item.oracle, item.revision)
+
+	stdout.write(`\t🔮 ${item.oracle} over ${item.side} (${item.revision}) — ${((performance.now() - started) / 1000).toFixed(1)} s, ${rows.length} rows\n`)
 
 	write(`oracles`, item.oracle, item.key, rows, { ...item.inputs, revision: item.revision, root: ROOT })
 	results[item.side][item.oracle] = rows

--- a/scripts/sweeps/run.mjs
+++ b/scripts/sweeps/run.mjs
@@ -3,16 +3,16 @@
 /**
  * Runs one sweep on both sides and writes the diff.
  *
- * A sweep is a module exporting its `name`, its `corpus` — a list of keyed texts, most often built with `scripts/harness/matrix.mjs` — its `configs`, each a rule under a primary option and, where there are any, secondary ones, and the `syntaxes` it is read under. Every text is linted under every configuration and syntax twice, checked and fixed, on the base and on the branch, and the finding is what moved between the two: `tmp/sweeps/<name>.md` holds it row by row, and the two sides stand beside it as JSON.
+ * A sweep is a module exporting its `name`, its `corpus` — a list of keyed texts, most often built with `scripts/harness/matrix.mjs` — its `configs`, each a rule under a primary option and, where there are any, secondary ones, and the `syntaxes` it is read under. Every text is linted under every configuration and syntax twice, checked and fixed, on the base and on the branch, and the finding is what moved between the two: `tmp/sweeps/<name>.md` holds it row by row; the two sides themselves stand in the store.
  *
- * Started through `make sweep FILE=… RUN=1` and nothing else: a run collects results, and the user approves one by that spelling.
+ * Each side is kept in the store with a digest beside it — one short hash per row — and a run compares the digests, reading the rows themselves only for the keys that moved. Started through `make sweep FILE=… RUN=1` and nothing else: a run collects results, and the user approves one by that spelling.
  */
 
 import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { argv, env, exit, stderr, stdout } from "node:process"
 
-import { hashAt, keyOf, read, write } from "../harness/cache.mjs"
+import { digestOf, hashAt, keyOf, read, readDigest, write } from "../harness/cache.mjs"
 import { defaultBase, libAt, ROOT } from "../harness/checkout.mjs"
 import { diff, render } from "../harness/diff.mjs"
 import { lintDirect, loadRules } from "../harness/lint.mjs"
@@ -78,31 +78,39 @@ if (!file) {
 
 let sweep = await import(path.resolve(file))
 let sides = { base, head: `worktree` }
+
+/** @type {Record<string, { digest: Record<string, string>, rows: () => Record<string, object> }>} Each side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
 let results = {}
 
 for (let [side, revision] of Object.entries(sides)) {
 	// A side is measured once by what it depends on — the rules, the sweep and the runner — and read back on every later run; the two are taken in turn, base first
 	let inputs = { sweep: hashAt(`worktree`, path.relative(ROOT, path.resolve(file))), lib: hashAt(revision, `lib`), harness: hashAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
 	let key = keyOf(inputs)
-	let rows = read(`sweeps`, sweep.name, key)
+	let digest = readDigest(`sweeps`, sweep.name, key)
 
-	if (!rows) {
-		stdout.write(`\t🧹 ${sweep.name} over ${side} (${revision})\n`)
-		// eslint-disable-next-line no-await-in-loop
-		rows = await measure(sweep, await loadRules(libAt(revision)))
-		write(`sweeps`, sweep.name, key, rows, { ...inputs, revision, root: ROOT })
+	if (digest) {
+		let rows
+
+		results[side] = { digest, rows: () => (rows ??= read(`sweeps`, sweep.name, key)) }
+		continue
 	}
 
-	results[side] = rows
+	stdout.write(`\t🧹 ${sweep.name} over ${side} (${revision})\n`)
+	// eslint-disable-next-line no-await-in-loop
+	let rows = await measure(sweep, await loadRules(libAt(revision)))
+
+	digest = digestOf(rows)
+	write(`sweeps`, sweep.name, key, rows, { ...inputs, revision, root: ROOT }, digest)
+	results[side] = { digest, rows: () => rows }
 }
 
 let out = path.join(ROOT, `tmp`, `sweeps`)
 
 mkdirSync(out, { recursive: true })
 
-let result = diff(results.base, results.head)
+let result = diff(results.base.digest, results.head.digest)
+let moved = result.changed.length + result.added.length + result.removed.length > 0
+let report = moved ? render(result, results.base.rows(), results.head.rows()) : render(result, {}, {})
 
-for (let side of Object.keys(sides)) writeFileSync(path.join(out, `${sweep.name}-${side}.json`), `${JSON.stringify(results[side], null, `\t`)}\n`)
-
-writeFileSync(path.join(out, `${sweep.name}.md`), `# ${sweep.name}: ${base} → worktree\n\n${render(result, results.base, results.head)}`)
-stdout.write(`${Object.keys(results.head).length} rows: ${result.same} same, ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed — tmp/sweeps/${sweep.name}.md\n`)
+writeFileSync(path.join(out, `${sweep.name}.md`), `# ${sweep.name}: ${base} → worktree\n\n${report}`)
+stdout.write(`${Object.keys(results.head.digest).length} rows: ${result.same} same, ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed — tmp/sweeps/${sweep.name}.md\n`)


### PR DESCRIPTION
A run of the six oracles was measured as a whole and never by part, and a sweep whose two sides were both kept spent six seconds parsing eighty megabytes of JSON it then found unchanged, and two more writing both sides to `tmp/` again, pretty-printed.

```text
make oracles RUN=1, cold          11.7 s   converge 2.7 · control 1.0 · comments 1.1 · twins 3.5 · nodes 2.0 · pairs 1.1
make sweep eol RUN=1, cold        36.8 s → 33.1 s
make sweep eol RUN=1, warm         6.1 s →  1.6 s   (21 449 rows moved: 4.5 s)
```

The line an oracle prints when it is measured now carries its seconds and its row count. A kept result gets a digest beside it — one short hash per row under the row's key — and a sweep compares the digests, reading the rows themselves only for the keys that moved, once per file where the two sides stand on one tree. The copies under `tmp/` go; the store holds the sides, and the report holds what moved.

## What the review turned up

- **The cold run is unchanged within noise.** Hashing half a million rows costs less than the pretty-printed copies did.
- **The moved path was exercised**, against the `lib/` of `184a3b3`: 21 449 rows changed, both sides read whole, the first 200 rendered.

Nothing in `lib/` moves.
