### PR TITLE
Import a type by name and write an object type over several lines

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,4 +1,4 @@
-import stylelint from "stylelint"
+import stylelint, { type Config } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import plugins from "./index.ts"
@@ -11,7 +11,7 @@ describe(`the plugin in the wrong field of a config`, () => {
 			config: {
 				plugins: [plugins],
 				rules: { "@stylistic/color-hex-case": `lower` },
-			} as unknown as import("stylelint").Config,
+			} as unknown as Config,
 		})
 
 		expect(results[0].warnings).toHaveLength(1)
@@ -25,7 +25,7 @@ describe(`the plugin in the wrong field of a config`, () => {
 			config: {
 				"extends": [plugins],
 				"rules": { "@stylistic/color-hex-case": `lower` },
-			} as unknown as import("stylelint").Config,
+			} as unknown as Config,
 		})
 
 		await expect(lint).rejects.toThrow(/is a plugin, not a shareable config/u)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import stylelint from "stylelint"
 
 import rules from "./rules/index.ts"
 import { addNamespace } from "./utils/addNamespace/index.ts"
+import type { ConfigurationError } from "./utils/configurationError/index.ts"
 
 /** The code Stylelint exits with when its configuration is invalid. */
 const EXIT_CODE_INVALID_CONFIG = 78
@@ -11,7 +12,7 @@ let rulesPlugins = Object.keys(rules).map((name) => stylelint.createPlugin(addNa
 /** Stylelint reads `extends` on every config it is told to extend, and never on a plugin, so this getter runs only where the package has been listed in the wrong field. Without it Stylelint loads the package as a config, finds no rules in it, and reports every `@stylistic/` rule as unknown — an error about the rules, whose cause is the field they were never reached from. */
 Object.defineProperty(rulesPlugins, `extends`, {
 	get () {
-		let error = new Error(`"@stylistic/stylelint-plugin" is a plugin, not a shareable config, so it cannot be used in "extends". List it in "plugins" instead, and put the rules you need, each namespaced with "@stylistic/", in "rules".`) as import("./utils/configurationError/index.ts").ConfigurationError
+		let error = new Error(`"@stylistic/stylelint-plugin" is a plugin, not a shareable config, so it cannot be used in "extends". List it in "plugins" instead, and put the rules you need, each namespaced with "@stylistic/", in "rules".`) as ConfigurationError
 
 		error.name = `ConfigurationError`
 		error.code = EXIT_CODE_INVALID_CONFIG

--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -1,4 +1,5 @@
-import valueParser from "postcss-value-parser"
+import type { Node } from "postcss"
+import valueParser, { type Node as ValueParserNode } from "postcss-value-parser"
 import stylelint from "stylelint"
 
 import { ASPECT_RATIO_PROPERTY, NUMBER_WITHOUT_SIGN_OR_EXPONENT } from "../../regexps.ts"
@@ -75,7 +76,7 @@ function rule (primary: `ratio` | `number-where-possible` | `as-written`, second
 		 * @param textIndex - The offset from the start of the node to the first character of that text.
 		 * @param write - Writes the fixed text back to the node.
 		 */
-		function check (node: import("postcss").Node, text: string, textIndex: number, write: (fixed: string) => void): void {
+		function check (node: Node, text: string, textIndex: number, write: (fixed: string) => void): void {
 			let comments = findCommentSpans(text, readsInlineComments(node, result))
 			// The value parser has a node for a block comment and none for a comment opened by a double slash, whose text comes back as ordinary words and divs. Blanking every comment out answers both at once: the copy spells the text character for character everywhere else, so every position below counts in the text itself, and what the parse holds is code the file spells and nothing else.
 			let ratio = findRatio(valueParser(blankComments(text, comments)).nodes)
@@ -121,7 +122,7 @@ function rule (primary: `ratio` | `number-where-possible` | `as-written`, second
 }
 
 /** The two numbers a `<ratio>` is written with, as the value parser read them. */
-type Ratio = { width: import("postcss-value-parser").Node, height?: import("postcss-value-parser").Node }
+type Ratio = { width: ValueParserNode, height?: ValueParserNode }
 
 /**
  * Finds the numbers of the `<ratio>` a value holds, where the value spells `auto || <ratio>` and nothing else.
@@ -130,7 +131,7 @@ type Ratio = { width: import("postcss-value-parser").Node, height?: import("post
  * @param nodes - The nodes of the parsed value, comments already blanked out of it.
  * @returns The numbers, or nothing where the value is no bare ratio.
  */
-function findRatio (nodes: import("postcss-value-parser").Node[]): Ratio | undefined {
+function findRatio (nodes: ValueParserNode[]): Ratio | undefined {
 	let numbers = []
 	let hasAuto = false
 	let hasAutoBehindNumber = false

--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -122,7 +122,10 @@ function rule (primary: `ratio` | `number-where-possible` | `as-written`, second
 }
 
 /** The two numbers a `<ratio>` is written with, as the value parser read them. */
-type Ratio = { width: ValueParserNode, height?: ValueParserNode }
+type Ratio = {
+	width: ValueParserNode,
+	height?: ValueParserNode,
+}
 
 /**
  * Finds the numbers of the `<ratio>` a value holds, where the value spells `auto || <ratio>` and nothing else.
@@ -282,7 +285,13 @@ function greatestCommonDivisor (one: bigint, other: bigint): bigint {
  * @param comments - The spans the comments of that text occupy in it.
  * @returns True where a comment stands in what the edit writes over.
  */
-function holdsComment (edit: { start: number, end: number }, comments: { start: number, end: number }[]): boolean {
+function holdsComment (edit: {
+	start: number,
+	end: number,
+}, comments: {
+	start: number,
+	end: number,
+}[]): boolean {
 	return comments.some(({ start, end }) => start < edit.end && end > edit.start)
 }
 

--- a/lib/rules/block-closing-brace-empty-line-before/index.ts
+++ b/lib/rules/block-closing-brace-empty-line-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { SEMICOLON_RUN } from "../../regexps.ts"
@@ -65,7 +66,7 @@ function rule (primary: `always-multi-line` | `never`, secondaryOptions: { excep
 		 * Checks a statement for closing brace empty line violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/block-closing-brace-newline-after/index.ts
+++ b/lib/rules/block-closing-brace-newline-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { LINE_BREAK, NON_SPACE } from "../../regexps.ts"
@@ -74,7 +75,7 @@ function rule (primary: `always` | `always-single-line` | `never-single-line` | 
 		 * Checks a statement for closing brace newline after violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			if (!hasBlock(statement)) return
 
 			if (statement.type === `atrule` && optionsMatches(secondaryOptions, `ignoreAtRules`, statement.name)) return

--- a/lib/rules/block-closing-brace-newline-before/index.ts
+++ b/lib/rules/block-closing-brace-newline-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { EVERY_WHITESPACE, LEADING_LINE_BREAK, LINE_BREAK, SEMICOLON_RUN, WHITESPACE } from "../../regexps.ts"
@@ -55,7 +56,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 		 * Checks a statement for closing brace newline violations.
 		 * @param statement - The rule or at-rule node to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/block-closing-brace-space-after/index.ts
+++ b/lib/rules/block-closing-brace-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -59,7 +60,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 		 * Checks a statement for closing brace space after violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			let nextNode = statement.next()
 
 			if (!nextNode) return

--- a/lib/rules/block-closing-brace-space-before/index.ts
+++ b/lib/rules/block-closing-brace-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -65,7 +66,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 		 * Checks a statement for closing brace space before violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/block-opening-brace-newline-after/index.test.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.test.ts
@@ -855,7 +855,10 @@ describe(`${ruleName} on a run of comments longer than the stack is deep`, () =>
  * @param option - The primary option to run under.
  * @returns What the fix wrote and how many warnings a run without it raised.
  */
-async function fixQuietly (code: string, option: string): Promise<{ code: string | undefined, warnings: number }> {
+async function fixQuietly (code: string, option: string): Promise<{
+	code: string | undefined,
+	warnings: number,
+}> {
 	let fixed = await stylelint.lint({
 		code,
 		config: { plugins, rules: { [ruleName]: option } },

--- a/lib/rules/block-opening-brace-newline-after/index.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.ts
@@ -1,4 +1,5 @@
-import stylelint from "stylelint"
+import type { AtRule, Node, Rule } from "postcss"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { EVERY_LINE_BREAK, LINE_BREAK } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -43,7 +44,7 @@ export let meta = {
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where any node of that run leaves an inline comment open behind it.
  */
-function fixWouldCommentOutTheBlock (statement: import("postcss").Rule | import("postcss").AtRule, nodeToCheck: import("postcss").Node, result: import("stylelint").PostcssResult): boolean {
+function fixWouldCommentOutTheBlock (statement: Rule | AtRule, nodeToCheck: Node, result: PostcssResult): boolean {
 	for (let node = statement.first; node && node !== nodeToCheck; node = node.next()) {
 		if (writesIntoInlineComment(node, result)) return true
 	}
@@ -88,7 +89,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, sec
 		 * Checks a statement for opening brace newline violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 
@@ -103,7 +104,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, sec
 			 * @param comment - The comment the walk stepped over.
 			 * @param nextNode - The node standing behind that comment.
 			 */
-			function carryBreakPastComment (comment: import("postcss").Node, nextNode: import("postcss").Node | undefined): void {
+			function carryBreakPastComment (comment: Node, nextNode: Node | undefined): void {
 				if (!nextNode) return
 
 				// A line break is what PostCSS reads as one: a line feed, with or without the carriage return of a Windows pair in front of it

--- a/lib/rules/block-opening-brace-newline-before/index.ts
+++ b/lib/rules/block-opening-brace-newline-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_SPACES_AND_TABS, TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -63,7 +64,7 @@ function rule (primary: `always` | `always-single-line` | `never-single-line` | 
 		 * Checks a statement for opening brace newline before violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/block-opening-brace-space-after/index.ts
+++ b/lib/rules/block-opening-brace-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -74,7 +75,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 		 * Checks a statement for opening brace space after violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/block-opening-brace-space-before/index.ts
+++ b/lib/rules/block-opening-brace-space-before/index.ts
@@ -41,7 +41,10 @@ export let meta = {
  * @param secondaryOptions - The secondary options: `ignoreAtRules` and `ignoreSelectors`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule (primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreAtRules?: string | RegExp | (string | RegExp)[], ignoreSelectors?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule (primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: {
+	ignoreAtRules?: string | RegExp | (string | RegExp)[],
+	ignoreSelectors?: string | RegExp | (string | RegExp)[],
+}): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {

--- a/lib/rules/block-opening-brace-space-before/index.ts
+++ b/lib/rules/block-opening-brace-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -78,7 +79,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 		 * Checks a statement for opening brace space before violations.
 		 * @param statement - The rule or at-rule to check.
 		 */
-		function check (statement: import("postcss").Rule | import("postcss").AtRule): void {
+		function check (statement: Rule | AtRule): void {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) return
 

--- a/lib/rules/color-hex-case/index.ts
+++ b/lib/rules/color-hex-case/index.ts
@@ -1,9 +1,9 @@
-import valueParser from "postcss-value-parser"
+import valueParser, { type Node } from "postcss-value-parser"
 import stylelint from "stylelint"
 
 import { CONTAINS_HEX_COLOR, HEX_COLOR } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
-import { applyEditsFromEnd } from "../../utils/applyEditsFromEnd/index.ts"
+import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
@@ -27,8 +27,6 @@ export let meta = {
 	url: getRuleDocUrl(shortName),
 	fixable: true,
 }
-
-type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
 
 /**
  * Enforces lowercase or uppercase case for hex color values.
@@ -96,7 +94,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
  * @param node - The value parser node to check.
  * @returns True if the node is a hex color, false otherwise.
  */
-function isHexColor (node: import("postcss-value-parser").Node): boolean {
+function isHexColor (node: Node): boolean {
 	let { type, value } = node
 
 	return type === `word` && HEX_COLOR.test(value)

--- a/lib/rules/declaration-block-semicolon-newline-after/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.ts
@@ -1,3 +1,4 @@
+import type { ChildNode } from "postcss"
 import stylelint from "stylelint"
 
 import { LINE_BREAK } from "../../regexps.ts"
@@ -68,7 +69,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 			if (!nodeToCheck) return
 
 			let problemIndex = nodeString(decl, result).length + 1
-			let previousNode = nodeToCheck.prev() as import("postcss").ChildNode
+			let previousNode = nodeToCheck.prev() as ChildNode
 			// Under `never-multi-line` the fix takes away the whitespace standing in front of the node it checks, and where an inline comment stands in front of that whitespace, the line break the whitespace opens with is what closes the comment: taking it away would put the node inside the comment's text, and the declaration it holds out of the stylesheet altogether. Nothing can be written there, so the block is left alone and the warning stands. The `always` options are in no such danger, since the break they keep or write is what closes such a comment anyway
 			//
 			// The semicolon stands between the declaration and that whitespace, so it is handed in with the declaration: a value ending in the break that closes its own comment is asked about with the semicolon behind it, which is where the write lands. Where a comment node stands between the two instead, the semicolon is in front of that comment rather than behind it, and there is nothing to hand in

--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -68,12 +68,23 @@ function semicolonOutlivesTheFlag (node: Node): boolean {
 	return (isAtRule(node) && !hasBlock(node)) || (isDeclaration(node) && isCustomProperty(node.prop))
 }
 
+/** A raw standing behind the node closing a block: the node holding it, the key it is held under, where it opens in the file and what it holds. */
+type HeldRaw = {
+	owner: Node,
+	key: string,
+	start: number,
+	text: string,
+}
+
 /**
  * Reads where a node opens and closes in the file, which every node the parser built says of itself.
  * @param node - The node.
  * @returns The two offsets.
  */
-function offsetsOf (node: Node): { start: number, end: number } {
+function offsetsOf (node: Node): {
+	start: number,
+	end: number,
+} {
 	let { source } = node
 
 	if (!source?.start || !source.end) throw new Error(`The node must carry a source with both of its ends`)
@@ -109,12 +120,12 @@ function blockEnd (container: Container): number {
  * @param node - The node closing the block.
  * @returns The raws, each named by the node holding it and the key it is held under.
  */
-function rawsBehind (node: ChildNode): { owner: Node, key: string, start: number, text: string }[] {
+function rawsBehind (node: ChildNode): HeldRaw[] {
 	let container = node.parent
 
 	if (!container?.nodes) throw new Error(`The node must stand in a block`)
 
-	let raws: { owner: Node, key: string, start: number, text: string }[] = []
+	let raws: HeldRaw[] = []
 
 	for (let sibling of container.nodes.slice(container.index(node) + 1)) {
 		let text = sibling.raws.before

--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -1,4 +1,5 @@
-import stylelint from "stylelint"
+import type { ChildNode, Container, Node } from "postcss"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -42,7 +43,7 @@ export let meta = {
  * @param node - The node the semicolon would stand behind.
  * @returns True where the node stands in a declaration block.
  */
-function standsInADeclarationBlock (node: import("postcss").Node): boolean {
+function standsInADeclarationBlock (node: Node): boolean {
 	let container = node.parent
 
 	// The two walks throw on a node with no parent before they ask, so this stands for whoever asks next rather than for them
@@ -61,7 +62,7 @@ function standsInADeclarationBlock (node: import("postcss").Node): boolean {
  * @param node - The node the semicolon stands behind.
  * @returns True where clearing the block's flag would leave the semicolon where it is.
  */
-function semicolonOutlivesTheFlag (node: import("postcss").Node): boolean {
+function semicolonOutlivesTheFlag (node: Node): boolean {
 	if (!node.next()) return false
 
 	return (isAtRule(node) && !hasBlock(node)) || (isDeclaration(node) && isCustomProperty(node.prop))
@@ -72,7 +73,7 @@ function semicolonOutlivesTheFlag (node: import("postcss").Node): boolean {
  * @param node - The node.
  * @returns The two offsets.
  */
-function offsetsOf (node: import("postcss").Node): { start: number, end: number } {
+function offsetsOf (node: Node): { start: number, end: number } {
 	let { source } = node
 
 	if (!source?.start || !source.end) throw new Error(`The node must carry a source with both of its ends`)
@@ -89,7 +90,7 @@ function offsetsOf (node: import("postcss").Node): { start: number, end: number 
  * @param container - The container the block belongs to.
  * @returns The offset in the file the block ends at.
  */
-function blockEnd (container: import("postcss").Container): number {
+function blockEnd (container: Container): number {
 	let { end } = offsetsOf(container)
 
 	if (isRoot(container)) return end
@@ -108,12 +109,12 @@ function blockEnd (container: import("postcss").Container): number {
  * @param node - The node closing the block.
  * @returns The raws, each named by the node holding it and the key it is held under.
  */
-function rawsBehind (node: import("postcss").ChildNode): { owner: import("postcss").Node, key: string, start: number, text: string }[] {
+function rawsBehind (node: ChildNode): { owner: Node, key: string, start: number, text: string }[] {
 	let container = node.parent
 
 	if (!container?.nodes) throw new Error(`The node must stand in a block`)
 
-	let raws: { owner: import("postcss").Node, key: string, start: number, text: string }[] = []
+	let raws: { owner: Node, key: string, start: number, text: string }[] = []
 
 	for (let sibling of container.nodes.slice(container.index(node) + 1)) {
 		let text = sibling.raws.before
@@ -139,7 +140,7 @@ function rawsBehind (node: import("postcss").ChildNode): { owner: import("postcs
  * @param node - The node closing the block.
  * @returns The index, counted from the node's own start, or undefined where the block ends on no semicolon.
  */
-function trailingSemicolonIndex (node: import("postcss").ChildNode): number | undefined {
+function trailingSemicolonIndex (node: ChildNode): number | undefined {
 	let { start, end } = offsetsOf(node)
 	let holder = rawsBehind(node).findLast((raw) => raw.text.includes(`;`))
 
@@ -155,7 +156,7 @@ function trailingSemicolonIndex (node: import("postcss").ChildNode): number | un
  * Taking one of them alone away would leave the block ending on a semicolon still, and that is what used to happen: the flag's own semicolon went, the raws kept theirs, and the next parse read the first of those as the flag's in its turn. So one run of `--fix` ended clean over a file the rule still had something to say about, and the work needed a second.
  * @param node - The node closing the block.
  */
-function takeTheTrailingSemicolonsAway (node: import("postcss").ChildNode): void {
+function takeTheTrailingSemicolonsAway (node: ChildNode): void {
 	let { parent } = node
 
 	if (!parent) throw new Error(`The node must stand in a block`)
@@ -181,7 +182,7 @@ function takeTheTrailingSemicolonsAway (node: import("postcss").ChildNode): void
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where the fix may be written.
  */
-function isFixable (node: import("postcss").ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: import("stylelint").PostcssResult): boolean {
+function isFixable (node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult): boolean {
 	if (primary === `never`) return !semicolonOutlivesTheFlag(node) && !requiresTrailingSemicolon(node, result)
 
 	return !hasBlock(node) && !writesIntoInlineComment(node, result, spelledBetween)
@@ -229,7 +230,7 @@ function rule (primary: `always` | `never`, secondaryOptions: { ignore?: `single
 		 * Checks the last node for trailing semicolon violations.
 		 * @param node - The node to check.
 		 */
-		function checkLastNode (node: import("postcss").ChildNode): void {
+		function checkLastNode (node: ChildNode): void {
 			let { parent } = node
 
 			if (!parent) throw new Error(`A parent node must be present`)

--- a/lib/rules/declaration-colon-space-before/index.ts
+++ b/lib/rules/declaration-colon-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -33,7 +34,7 @@ export let meta = {
  * @param index - The index of the colon within the checked string.
  * @returns The part of `between` in front of the colon.
  */
-function beforeColonString (decl: import("postcss").Declaration, index: number): string {
+function beforeColonString (decl: Declaration, index: number): string {
 	let between = decl.raws.between
 
 	assertString(between)

--- a/lib/rules/function-max-empty-lines/index.ts
+++ b/lib/rules/function-max-empty-lines/index.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "postcss"
 import valueParser from "postcss-value-parser"
 import stylelint from "stylelint"
 
@@ -30,7 +31,7 @@ export let meta = {
  * @param decl - The CSS declaration node.
  * @returns The index of the start of the declaration's value.
  */
-function placeIndexOnValueStart (decl: import("postcss").Declaration): number {
+function placeIndexOnValueStart (decl: Declaration): number {
 	assertString(decl.raws.between)
 
 	return decl.prop.length + decl.raws.between.length - 1

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -1,18 +1,18 @@
-import valueParser from "postcss-value-parser"
-import stylelint from "stylelint"
+import valueParser, { type FunctionNode } from "postcss-value-parser"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { LEADING_WHITESPACE, LINE_BREAK } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
-import { addEdit, applyEditsFromEnd, toIndexBeforeEdits } from "../../utils/applyEditsFromEnd/index.ts"
+import { addEdit, applyEditsFromEnd, type Edit, toIndexBeforeEdits } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
-import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
 import { isStandardSyntaxFunction } from "../../utils/isStandardSyntaxFunction/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
+import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
@@ -36,8 +36,6 @@ export let meta = {
 	fixable: true,
 }
 
-type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
-
 /**
  * Finds the spans the inline comments of a value occupy once the fixes collected so far are written into it, counted in the value as the file spells it.
  *
@@ -49,7 +47,7 @@ type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
  * @param spellsInlineComments - False where the syntax the value was spelled in writes no comment with a double slash.
  * @returns The spans, in the coordinates of the value the file spells.
  */
-function findInlineCommentSpansAfterEdits (declValue: string, edits: Edit[], spellsInlineComments: boolean): import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan[] {
+function findInlineCommentSpansAfterEdits (declValue: string, edits: Edit[], spellsInlineComments: boolean): InlineCommentSpan[] {
 	return findInlineCommentSpans(applyEditsFromEnd(declValue, edits), spellsInlineComments)
 		.map(({ start, end }) => ({ start: toIndexBeforeEdits(start, edits), end: toIndexBeforeEdits(end, edits) }))
 }
@@ -70,7 +68,7 @@ function findInlineCommentSpansAfterEdits (declValue: string, edits: Edit[], spe
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns True where the rule may read the function's parentheses and write between them.
  */
-function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan[]): boolean {
+function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
 	if (!isStandardSyntaxFunction(valueNode)) return false
 
 	if (valueNode.unclosed) return false
@@ -129,7 +127,7 @@ function mergeRanges (lists: number[][][]): number[][] {
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the character move into a comment.
  */
-function movesIntoComment (declValue: string, characterIndex: number, emptied: number[][], reading: import("../../utils/readsInlineComments/index.ts").InlineCommentReading): boolean {
+function movesIntoComment (declValue: string, characterIndex: number, emptied: number[][], reading: InlineCommentReading): boolean {
 	let standingText = declValue.slice(0, characterIndex + 1)
 
 	return movesEndIntoInlineComment(standingText, withoutRanges(standingText, emptied), reading)
@@ -217,7 +215,7 @@ function getFixEmptiedAfter (valueNode: FunctionNode): number[][] {
  * @param read - What the walk has read of the function, and the value it was read from.
  * @returns Whether each of the two fixes may be written.
  */
-function getNeverFixability (read: { declValue: string, valueNode: FunctionNode, openingIndex: number, checkBefore: string, checkAfter: string, firstIndex: number, measured: number[][], reading: import("../../utils/readsInlineComments/index.ts").InlineCommentReading }): { isOpeningFixable: boolean, isClosingFixable: boolean } {
+function getNeverFixability (read: { declValue: string, valueNode: FunctionNode, openingIndex: number, checkBefore: string, checkAfter: string, firstIndex: number, measured: number[][], reading: InlineCommentReading }): { isOpeningFixable: boolean, isClosingFixable: boolean } {
 	let { declValue, valueNode, openingIndex, checkBefore, checkAfter, firstIndex, measured, reading } = read
 
 	let firstCharacterIndex = findFirstCharacterIndex(declValue, firstIndex)
@@ -260,7 +258,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 		root.walkDecls((decl) => {
 			if (!decl.value.includes(`(`)) return
 
-			let fix: import("stylelint").FixCallback | undefined
+			let fix: FixCallback | undefined
 			// What a fix changed, and nothing else: the value is edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a value would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
 			let declValue = getDeclarationValue(decl)
@@ -369,8 +367,6 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 	}
 }
 
-type FunctionNode = import("postcss-value-parser").FunctionNode
-
 /**
  * Gets the whitespace before the first non-comment, non-space node in a function, and says where that node begins.
  *
@@ -385,7 +381,7 @@ type FunctionNode = import("postcss-value-parser").FunctionNode
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns The whitespace, the index the first significant thing behind it begins at — the node the parser hands back where one stands, the code a node of a comment's text reaches past that comment's end with where the parser filed one under such a node, and the function's own closing parenthesis where it holds neither — and the stretches the whitespace was gathered from.
  */
-function getCheckBefore (valueNode: FunctionNode, openingIndex: number, declValue: string, inlineComments: import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan[]): { before: string, firstIndex: number, measured: number[][] } {
+function getCheckBefore (valueNode: FunctionNode, openingIndex: number, declValue: string, inlineComments: InlineCommentSpan[]): { before: string, firstIndex: number, measured: number[][] } {
 	let before = valueNode.before
 	let measured = [[openingIndex, openingIndex + valueNode.before.length]]
 	let firstIndex = valueNode.sourceEndIndex - 1

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -153,7 +153,10 @@ function findFirstCharacterIndex (declValue: string, firstIndex: number): number
  * @param valueNode - The function being fixed.
  * @returns The span, counted in the value the file spells.
  */
-function getAfterSpan (valueNode: FunctionNode): { start: number, end: number } {
+function getAfterSpan (valueNode: FunctionNode): {
+	start: number,
+	end: number,
+} {
 	let end = valueNode.sourceEndIndex - 1
 
 	return { start: end - valueNode.after.length, end }
@@ -215,7 +218,19 @@ function getFixEmptiedAfter (valueNode: FunctionNode): number[][] {
  * @param read - What the walk has read of the function, and the value it was read from.
  * @returns Whether each of the two fixes may be written.
  */
-function getNeverFixability (read: { declValue: string, valueNode: FunctionNode, openingIndex: number, checkBefore: string, checkAfter: string, firstIndex: number, measured: number[][], reading: InlineCommentReading }): { isOpeningFixable: boolean, isClosingFixable: boolean } {
+function getNeverFixability (read: {
+	declValue: string,
+	valueNode: FunctionNode,
+	openingIndex: number,
+	checkBefore: string,
+	checkAfter: string,
+	firstIndex: number,
+	measured: number[][],
+	reading: InlineCommentReading,
+}): {
+	isOpeningFixable: boolean,
+	isClosingFixable: boolean,
+} {
 	let { declValue, valueNode, openingIndex, checkBefore, checkAfter, firstIndex, measured, reading } = read
 
 	let firstCharacterIndex = findFirstCharacterIndex(declValue, firstIndex)
@@ -381,7 +396,11 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns The whitespace, the index the first significant thing behind it begins at — the node the parser hands back where one stands, the code a node of a comment's text reaches past that comment's end with where the parser filed one under such a node, and the function's own closing parenthesis where it holds neither — and the stretches the whitespace was gathered from.
  */
-function getCheckBefore (valueNode: FunctionNode, openingIndex: number, declValue: string, inlineComments: InlineCommentSpan[]): { before: string, firstIndex: number, measured: number[][] } {
+function getCheckBefore (valueNode: FunctionNode, openingIndex: number, declValue: string, inlineComments: InlineCommentSpan[]): {
+	before: string,
+	firstIndex: number,
+	measured: number[][],
+} {
 	let before = valueNode.before
 	let measured = [[openingIndex, openingIndex + valueNode.before.length]]
 	let firstIndex = valueNode.sourceEndIndex - 1

--- a/lib/rules/function-parentheses-space-inside/index.ts
+++ b/lib/rules/function-parentheses-space-inside/index.ts
@@ -1,16 +1,16 @@
-import valueParser from "postcss-value-parser"
-import stylelint from "stylelint"
+import valueParser, { type FunctionNode } from "postcss-value-parser"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.ts"
-import { applyEditsFromEnd } from "../../utils/applyEditsFromEnd/index.ts"
+import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
-import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
 import { isStandardSyntaxFunction } from "../../utils/isStandardSyntaxFunction/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
+import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
@@ -36,9 +36,6 @@ export let meta = {
 	fixable: true,
 }
 
-type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
-type FunctionNode = import("postcss-value-parser").FunctionNode
-
 /** A character put where the first argument of a function begins, so that the guard reading the text in front of it is answered about that position and not about the whitespace the fix would write over. Any character that opens nothing and that `String.prototype.trimEnd` leaves standing answers the same, and the argument's own first character is not one of those: the value parser counts as space only what stands below the blank, so a separator of Unicode standing there is a character of the argument, and the scan behind the guard would trim it away together with the line break in front of it and read the comment as still open. */
 const ARGUMENT_STAND_IN = `x`
 
@@ -58,7 +55,7 @@ const ARGUMENT_STAND_IN = `x`
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns True where the rule may read the function's parentheses and write between them.
  */
-function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan[]): boolean {
+function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
 	if (!isStandardSyntaxFunction(valueNode)) return false
 
 	if (valueNode.unclosed) return false
@@ -78,7 +75,7 @@ function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: imp
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the argument move into a comment.
  */
-function movesOpeningIntoComment (declValue: string, valueNode: FunctionNode, reading: import("../../utils/readsInlineComments/index.ts").InlineCommentReading): boolean {
+function movesOpeningIntoComment (declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
 	let openingIndex = valueNode.sourceIndex + valueNode.value.length + 1
 	let firstIndex = openingIndex + valueNode.before.length
 	let standingText = declValue.slice(0, firstIndex)
@@ -97,7 +94,7 @@ function movesOpeningIntoComment (declValue: string, valueNode: FunctionNode, re
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the parenthesis move into a comment.
  */
-function movesClosingIntoComment (declValue: string, valueNode: FunctionNode, reading: import("../../utils/readsInlineComments/index.ts").InlineCommentReading): boolean {
+function movesClosingIntoComment (declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
 	let closingIndex = valueNode.sourceEndIndex - 1
 	let standingText = declValue.slice(0, closingIndex)
 	// The fix writes the whitespace the function keeps in front of the parenthesis and nothing else, so everything behind that whitespace stays on the line it is written on, and only the parenthesis moves. A single space is all the `always` options put there, and a space closes no comment, so both options leave the parenthesis standing behind the same text.
@@ -152,7 +149,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 		root.walkDecls((decl) => {
 			if (!decl.value.includes(`(`)) return
 
-			let fix: import("stylelint").FixCallback | undefined
+			let fix: FixCallback | undefined
 			// What a fix changed, and nothing else: the value is edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a value would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
 			let declValue = getDeclarationValue(decl)

--- a/lib/rules/function-whitespace-after/index.ts
+++ b/lib/rules/function-whitespace-after/index.ts
@@ -1,3 +1,4 @@
+import type { Node } from "postcss"
 import stylelint from "stylelint"
 
 import { IMPORT_AT_RULE, LEADING_SPACED_SIGN, LEADING_SPACED_SUM_OPERATOR } from "../../regexps.ts"
@@ -58,7 +59,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param node - The node whose text is being read.
 		 * @returns True where the syntax that spelled that node spells arithmetic of its own.
 		 */
-		function readsOwnArithmetic (node: import("postcss").Node): boolean {
+		function readsOwnArithmetic (node: Node): boolean {
 			return readsInlineComments(node, result)
 		}
 
@@ -70,7 +71,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param nodeIndex - The index of the node.
 		 * @param fix - The fix function.
 		 */
-		function check (node: import("postcss").Node, value: string, searchString: string, nodeIndex: number, fix: (index: number) => void): void {
+		function check (node: Node, value: string, searchString: string, nodeIndex: number, fix: (index: number) => void): void {
 			// The parenthesis a call closes is the one this rule is about, and it is looked for rather than come across: the parentheses of `(@a * 2)px` group an arithmetic expression, and the unit standing behind them belongs to it, so neither option may touch that spelling. A call the text never closes ends at the end of it, where no parenthesis stands and nothing follows to space from. The spans come in the order the text closes them, so the fixer is handed its positions front to back, as it reads them
 			for (let { end } of findFunctionArgumentSpans(searchString)) {
 				if (searchString.charAt(end) !== `)`) continue
@@ -88,7 +89,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param nodeIndex - The index of the node.
 		 * @param fix - The fix function.
 		 */
-		function checkClosingParen (source: string, searchString: string, index: number, node: import("postcss").Node, nodeIndex: number, fix: (index: number) => void): void {
+		function checkClosingParen (source: string, searchString: string, index: number, node: Node, nodeIndex: number, fix: (index: number) => void): void {
 			let nextChar = source.charAt(index)
 
 			if (!nextChar) return

--- a/lib/rules/function-whitespace-after/index.ts
+++ b/lib/rules/function-whitespace-after/index.ts
@@ -141,7 +141,11 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param value - The value to fix.
 		 * @returns The fixer object.
 		 */
-		function createFixer (value: string): { applyFix: (index: number) => void, hasFixed: boolean, fixed: string } {
+		function createFixer (value: string): {
+			applyFix: (index: number) => void,
+			hasFixed: boolean,
+			fixed: string,
+		} {
 			let fixed = ``
 			let lastIndex = 0
 

--- a/lib/rules/indentation/document-with-roots.test.ts
+++ b/lib/rules/indentation/document-with-roots.test.ts
@@ -1,4 +1,4 @@
-import { Document, Input, parse as postcssParse, stringify } from "postcss"
+import { Document, Input, parse as postcssParse, type ProcessOptions, type Root, stringify } from "postcss"
 
 import { ruleName } from "./index.ts"
 
@@ -10,11 +10,11 @@ let testRule = createTestRule({ ruleName })
  * @param opts - The options of the parse.
  * @returns The document holding that one root.
  */
-function parse (source: string, opts?: import("postcss").ProcessOptions): import("postcss").Document {
+function parse (source: string, opts?: ProcessOptions): Document {
 	let doc = (new Document())
 	let root = postcssParse(source, opts)
 
-	let held = root as import("postcss").Root & { document?: import("postcss").Document }
+	let held = root as Root & { document?: Document }
 
 	held.parent = doc
 	held.document = doc

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -37,13 +37,22 @@ export let meta = {
 	fixable: true,
 }
 
+/** The secondary options: the level the file opens at, the constructs excepted or ignored, how far a parenthesised value indents, and whether a closing brace does. */
+type SecondaryOptions = {
+	baseIndentLevel?: number | `auto`,
+	except?: (`block` | `value` | `param`)[],
+	ignore?: (`value` | `param` | `inside-parens`)[],
+	indentInsideParens?: `twice` | `once-at-root-twice-in-block`,
+	indentClosingBrace?: boolean,
+}
+
 /**
  * Specifies indentation.
  * @param primary - The primary option: a number of spaces, or `tab`.
  * @param secondaryOptions - The secondary options: `baseIndentLevel`, `except`, `ignore`, `indentInsideParens` and `indentClosingBrace`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: number | `auto`, except?: (`block` | `value` | `param`)[], ignore?: (`value` | `param` | `inside-parens`)[], indentInsideParens?: `twice` | `once-at-root-twice-in-block`, indentClosingBrace?: boolean } = {}): RuleCheck {
+function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {}): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -269,7 +278,11 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 			let { searchString } = searchCopy(source, node, result)
 
 			// Data for current node fixing
-			let fixPositions: Array<{ expectedIndentation: string, currentIndentation: string, startIndex: number }> = []
+			let fixPositions: Array<{
+				expectedIndentation: string,
+				currentIndentation: string,
+				startIndex: number,
+			}> = []
 
 			// Every break the search finds is handed over, and the ones standing inside parentheses are turned away in the callback below, so that the arguments of a function, and the non-standard things written in parentheses beside them — a Sass map among them — may be indented however their author likes.
 			// Only a bracket opened at the end of a line raises the lines standing behind it, so a bracket opening a line unwinds one only while such a one is open. One opened in the middle of a line raised nothing, and unwinding it took the count a step past the outermost level of the text being measured — at the root, to an indentation of minus one tab, which is no level and nothing a file can be written with. These are counts rather than a stack: a closing bracket is not matched to the one it closes, so where a bracket opened in the middle of a line closes while another opened at a line's end is still open, the count spends the wrong one. The two kinds are counted apart, since a brace closes on the line it lowers and a parenthesis on the line after it.

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Declaration, Document, Node, Root, Rule, Source } from "postcss"
 import styleSearch from "style-search"
 import stylelint from "stylelint"
 
@@ -162,7 +163,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param node - The node to calculate level for.
 		 * @returns The calculated indentation level.
 		 */
-		function getStyledDeclarationLevel (node: import("postcss").Node): number {
+		function getStyledDeclarationLevel (node: Node): number {
 			let { parent } = node
 
 			if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
@@ -181,7 +182,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param level - The current level.
 		 * @returns The calculated indentation level.
 		 */
-		function indentationLevel (node: import("postcss").Node, level: number = 0): number {
+		function indentationLevel (node: Node, level: number = 0): number {
 			if (!node.parent) throw new Error(`A parent node must be present`)
 
 			let calculatedLevel = level
@@ -210,7 +211,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param decl - The declaration to check.
 		 * @param declLevel - The indentation level of the declaration.
 		 */
-		function checkValue (decl: import("postcss").Declaration, declLevel: number): void {
+		function checkValue (decl: Declaration, declLevel: number): void {
 			if (!LINE_BREAK.test(decl.value)) return
 
 			if (isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`)) return
@@ -228,7 +229,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param ruleNode - The rule node to check.
 		 * @param ruleLevel - The indentation level of the rule.
 		 */
-		function checkSelector (ruleNode: import("postcss").Rule, ruleLevel: number): void {
+		function checkSelector (ruleNode: Rule, ruleLevel: number): void {
 			let level = ruleLevel
 
 			// Less mixins have params, and they should be indented extra
@@ -243,7 +244,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param atRule - The at-rule to check.
 		 * @param ruleLevel - The indentation level of the rule.
 		 */
-		function checkAtRuleParams (atRule: import("postcss").AtRule, ruleLevel: number): void {
+		function checkAtRuleParams (atRule: AtRule, ruleLevel: number): void {
 			if (optionsMatches(secondaryOptions, `ignore`, `param`)) return
 
 			// @nest and SCSS's @at-root rules should be treated like regular rules, not expected to have their params (selectors) indented
@@ -259,7 +260,7 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
 		 * @param node - The node being checked.
 		 * @param nodeLevel - The indentation level of that node, which the level above is measured against.
 		 */
-		function checkMultilineBit (source: string, newlineIndentLevel: number, node: import("postcss").Node, nodeLevel: number): void {
+		function checkMultilineBit (source: string, newlineIndentLevel: number, node: Node, nodeLevel: number): void {
 			if (!LINE_BREAK.test(source)) return
 
 			// The search is handed a copy with every comment blanked out of it rather than the text itself, since `style-search` reads the line break that closes an inline comment as part of that comment and never hands the position over — so every line standing behind such a comment went unmeasured, which is #236. The copy is as long as the text and spells it character for character everywhere else, so the positions of the search are the positions of the file, which is the text a warning is counted in and the text a fix is written to.
@@ -461,14 +462,14 @@ function rule (primary: number | `tab`, secondaryOptions: { baseIndentLevel?: nu
  * @param space - The primary option: the number of spaces of one level, or `tab`.
  * @returns The calculated base indentation level.
  */
-function getRootBaseIndentLevel (root: import("postcss").Root, baseIndentLevel: number | `auto` | undefined, space: number | `tab`): number {
+function getRootBaseIndentLevel (root: Root, baseIndentLevel: number | `auto` | undefined, space: number | `tab`): number {
 	let document = getDocument(root)
 
 	if (!document) return 0
 
 	if (!root.source) throw new Error(`The root node must have a source`)
 
-	let source: import("postcss").Source & { baseIndentLevel?: number } = root.source
+	let source: Source & { baseIndentLevel?: number } = root.source
 
 	let indentLevel = source.baseIndentLevel
 
@@ -486,12 +487,12 @@ function getRootBaseIndentLevel (root: import("postcss").Root, baseIndentLevel: 
  * @param node - The node to get document from.
  * @returns The document node or undefined.
  */
-function getDocument (node: import("postcss").Node): import("postcss").Document | undefined {
+function getDocument (node: Node): Document | undefined {
 	let holder = `document` in node ? node : node.root()
 
 	if (!(`document` in holder)) return
 
-	return holder.document as import("postcss").Document | undefined
+	return holder.document as Document | undefined
 }
 
 /**
@@ -500,10 +501,10 @@ function getDocument (node: import("postcss").Node): import("postcss").Document 
  * @param space - The primary option: the number of spaces of one level, or `tab`.
  * @returns The inferred indent size.
  */
-function inferDocIndentSize (document: import("postcss").Document, space: number | `tab`): number {
+function inferDocIndentSize (document: Document, space: number | `tab`): number {
 	if (!document.source) throw new Error(`The document node must have a source`)
 
-	let docSource: import("postcss").Source & { indentSize?: number } = document.source
+	let docSource: Source & { indentSize?: number } = document.source
 
 	let indentSize = docSource.indentSize
 
@@ -566,7 +567,7 @@ function inferDocIndentSize (document: import("postcss").Document, space: number
  * @param indentSize - Function to get the indent size.
  * @returns The inferred root indentation level.
  */
-function inferRootIndentLevel (root: import("postcss").Root, baseIndentLevel: number | `auto` | undefined, indentSize: () => number): number {
+function inferRootIndentLevel (root: Root, baseIndentLevel: number | `auto` | undefined, indentSize: () => number): number {
 	/**
 	 * Gets the indentation level from a string.
 	 *
@@ -634,7 +635,7 @@ function inferRootIndentLevel (root: import("postcss").Root, baseIndentLevel: nu
 		let afterEnd
 
 		if (TRAILING_LINE_BREAK.test(after)) {
-			let document = (`document` in root ? root.document : undefined) as import("postcss").Document | undefined
+			let document = (`document` in root ? root.document : undefined) as Document | undefined
 
 			if (document) {
 				let nextRoot = document.nodes[document.nodes.indexOf(root) + 1]

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -1,3 +1,5 @@
+import type { Rule } from "stylelint"
+
 import aspectRatioNotation from "./aspect-ratio-notation/index.ts"
 import atRuleNameCase from "./at-rule-name-case/index.ts"
 import atRuleNameNewlineAfter from "./at-rule-name-newline-after/index.ts"
@@ -77,8 +79,6 @@ import valueListCommaNewlineBefore from "./value-list-comma-newline-before/index
 import valueListCommaSpaceAfter from "./value-list-comma-space-after/index.ts"
 import valueListCommaSpaceBefore from "./value-list-comma-space-before/index.ts"
 import valueListMaxEmptyLines from "./value-list-max-empty-lines/index.ts"
-
-type Rule = import("stylelint").Rule
 
 let rules: { readonly [name: string]: Rule } = {
 	"aspect-ratio-notation": aspectRatioNotation,

--- a/lib/rules/linebreaks/index.ts
+++ b/lib/rules/linebreaks/index.ts
@@ -1,4 +1,4 @@
-import { Input, rule as _rule } from "postcss"
+import { Input, rule as _rule, type RuleProps } from "postcss"
 import stylelint from "stylelint"
 
 import { CRLF, EVERY_LINE_BREAK, EVERY_LINE_WITH_BREAK, LINE_BREAK } from "../../regexps.ts"
@@ -140,7 +140,7 @@ function rule (primary: `unix` | `windows`): RuleCheck {
 					start: { line, column, offset: 0 },
 					input: new Input(``),
 				},
-			} as import("postcss").RuleProps)
+			} as RuleProps)
 
 			report({
 				message: messages.expected,

--- a/lib/rules/max-empty-lines/index.ts
+++ b/lib/rules/max-empty-lines/index.ts
@@ -1,5 +1,6 @@
+import type { Document, Root } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { CRLF, CRLF_RUN, EVERY_CRLF_RUN, EVERY_LF_RUN, TRAILING_SPACES_AND_TABS } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -71,7 +72,7 @@ function rule (primary: number, secondaryOptions: { ignore?: `comments` | `comme
 			})
 
 			let { first } = root
-			let { document } = root as { document?: import("postcss").Document }
+			let { document } = root as { document?: Document }
 			let firstNodeRawsBefore = first && first.raws.before
 			let rootRawsAfter = root.raws.after
 
@@ -115,7 +116,7 @@ function rule (primary: number, secondaryOptions: { ignore?: `comments` | `comme
 		 * @param matchEndIndex - The end index of the match.
 		 * @param node - The root node.
 		 */
-		function checkMatch (matchStartIndex: number, matchEndIndex: number, node: import("postcss").Root): void {
+		function checkMatch (matchStartIndex: number, matchEndIndex: number, node: Root): void {
 			let eof = matchEndIndex >= endOfFile
 			let problem = false
 
@@ -197,7 +198,7 @@ function replaceEmptyLines (maxLines: number, str: unknown, isSpecialCase: boole
  * @param root - The root node of CSS.
  * @returns True if the node is the last node of file, false otherwise.
  */
-function isEofNode (document: import("stylelint").PostcssResult[`root`], root: import("postcss").Root): boolean {
+function isEofNode (document: PostcssResult[`root`], root: Root): boolean {
 	if (!document || document.constructor.name !== `Document` || !(`type` in document)) return true
 
 	// In the `postcss-html` and `postcss-jsx` syntax, checks that there is text after the given node.

--- a/lib/rules/max-line-length/index.ts
+++ b/lib/rules/max-line-length/index.ts
@@ -34,7 +34,11 @@ const EXCLUDED_PATTERNS = [
  * @param secondaryOptions - The secondary options: `ignore`, `ignorePattern` and `tabSize`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule (primary: number, secondaryOptions: { ignore?: (`non-comments` | `comments`) | (`non-comments` | `comments`)[], ignorePattern?: string | RegExp | (string | RegExp)[], tabSize?: number }): RuleCheck {
+function rule (primary: number, secondaryOptions: {
+	ignore?: (`non-comments` | `comments`) | (`non-comments` | `comments`)[],
+	ignorePattern?: string | RegExp | (string | RegExp)[],
+	tabSize?: number,
+}): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,

--- a/lib/rules/max-line-length/index.ts
+++ b/lib/rules/max-line-length/index.ts
@@ -1,4 +1,4 @@
-import styleSearch from "style-search"
+import styleSearch, { type StyleSearchMatch } from "style-search"
 import stylelint from "stylelint"
 
 import { EVERY_IMPORT_ADDRESS, EVERY_URL_CONTENT, LEADING_WHITESPACE_RUN } from "../../regexps.ts"
@@ -144,7 +144,7 @@ function rule (primary: number, secondaryOptions: { ignore?: (`non-comments` | `
 		 * @param match - The style search match.
 		 * @returns Nothing; a line over the limit is reported, and one within it is left alone.
 		 */
-		function checkNewline (match: import("style-search").StyleSearchMatch | { endIndex: number }): void {
+		function checkNewline (match: StyleSearchMatch | { endIndex: number }): void {
 			let nextNewlineIndex = rootString.indexOf(`\n`, match.endIndex)
 
 			if (rootString[nextNewlineIndex - 1] === `\r`) nextNewlineIndex -= 1

--- a/lib/rules/media-feature-colon-space-after/index.ts
+++ b/lib/rules/media-feature-colon-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE } from "../../regexps.ts"
@@ -42,7 +43,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").AtRule, number[]> | undefined
+		let fixData: Map<AtRule, number[]> | undefined
 
 		mediaFeatureColonSpaceChecker({
 			root,

--- a/lib/rules/media-feature-colon-space-before/index.ts
+++ b/lib/rules/media-feature-colon-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -42,7 +43,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").AtRule, number[]> | undefined
+		let fixData: Map<AtRule, number[]> | undefined
 
 		mediaFeatureColonSpaceChecker({
 			root,

--- a/lib/rules/media-feature-parentheses-space-inside/index.ts
+++ b/lib/rules/media-feature-parentheses-space-inside/index.ts
@@ -1,9 +1,9 @@
-import valueParser from "postcss-value-parser"
+import valueParser, { type FunctionNode } from "postcss-value-parser"
 import stylelint from "stylelint"
 
 import { MEDIA_AT_RULE, SPACE_OR_TAB } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
-import { addEdit, applyEditsFromEnd } from "../../utils/applyEditsFromEnd/index.ts"
+import { addEdit, applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
@@ -30,9 +30,6 @@ export let meta = {
 	url: getRuleDocUrl(shortName),
 	fixable: true,
 }
-
-type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
-type FunctionNode = import("postcss-value-parser").FunctionNode
 
 /**
  * Names the span the whitespace behind a media feature's opening parenthesis stands in, and what goes there.

--- a/lib/rules/media-feature-parentheses-space-inside/index.ts
+++ b/lib/rules/media-feature-parentheses-space-inside/index.ts
@@ -84,7 +84,11 @@ function rule (primary: `always` | `never`): RuleCheck {
 			// A double slash opens a comment that runs to the end of its line, and `postcss-value-parser` knows nothing of the kind: a parenthesis standing in the text of one opens a media feature as far as that parser is concerned, and the fix then writes inside the comment
 			let inlineComments = findInlineCommentSpans(params, reading.spells)
 
-			let problems: Array<{ message: string, index: number, fix?: () => void }> = []
+			let problems: Array<{
+				message: string,
+				index: number,
+				fix?: () => void,
+			}> = []
 
 			// What a fix changed, and nothing else: the parameters are edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a query would rewrite a comment standing elsewhere in it
 			//

--- a/lib/rules/media-query-list-comma-newline-after/index.ts
+++ b/lib/rules/media-query-list-comma-newline-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE, LEADING_WHITESPACE_WITHOUT_BREAK, OPENS_WITH_LINE_BREAK } from "../../regexps.ts"
@@ -46,7 +47,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 		if (!validOptions) return
 
 		// Only check for the newline after the comma, while allowing arbitrary indentation after the newline
-		let fixData: Map<import("postcss").AtRule, number[]> | undefined
+		let fixData: Map<AtRule, number[]> | undefined
 
 		mediaQueryListCommaWhitespaceChecker({
 			root,

--- a/lib/rules/media-query-list-comma-space-after/index.ts
+++ b/lib/rules/media-query-list-comma-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE } from "../../regexps.ts"
@@ -44,7 +45,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").AtRule, number[]> | undefined
+		let fixData: Map<AtRule, number[]> | undefined
 
 		mediaQueryListCommaWhitespaceChecker({
 			root,

--- a/lib/rules/media-query-list-comma-space-before/index.ts
+++ b/lib/rules/media-query-list-comma-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -46,7 +47,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").AtRule, number[]> | undefined
+		let fixData: Map<AtRule, number[]> | undefined
 
 		mediaQueryListCommaWhitespaceChecker({
 			root,

--- a/lib/rules/named-grid-areas-alignment/index.ts
+++ b/lib/rules/named-grid-areas-alignment/index.ts
@@ -45,7 +45,10 @@ function isGridRow (node: Node, inlineComments: InlineCommentSpan[]): node is St
  * @param secondaryOptions - The secondary options: `gap` and `alignQuotes`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule (primary: true, secondaryOptions: { gap?: number, alignQuotes?: boolean } = {}): RuleCheck {
+function rule (primary: true, secondaryOptions: {
+	gap?: number,
+	alignQuotes?: boolean,
+} = {}): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,

--- a/lib/rules/named-grid-areas-alignment/index.ts
+++ b/lib/rules/named-grid-areas-alignment/index.ts
@@ -1,10 +1,10 @@
-import valueParser from "postcss-value-parser"
+import valueParser, { type Node, type StringNode } from "postcss-value-parser"
 import stylelint from "stylelint"
 
 import { EVERY_LINE_BREAK_RUN, EVERY_WHITESPACE_RUN, LAST_LINE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
-import { findInlineCommentSpans, findInlineCommentSpanTouching } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpans, findInlineCommentSpanTouching, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
@@ -35,7 +35,7 @@ export let meta = {
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns True where the node is a row of the grid.
  */
-function isGridRow (node: import("postcss-value-parser").Node, inlineComments: import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan[]): node is import("postcss-value-parser").StringNode {
+function isGridRow (node: Node, inlineComments: InlineCommentSpan[]): node is StringNode {
 	return node.type === `string` && !findInlineCommentSpanTouching(node, inlineComments)
 }
 

--- a/lib/rules/no-empty-first-line/index.ts
+++ b/lib/rules/no-empty-first-line/index.ts
@@ -4,6 +4,7 @@ import { OPENS_WITH_LINE_BREAK } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
+import type { EmbeddedSource } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -29,7 +30,7 @@ function rule (primary: true): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, { actual: primary })
 
-		let source: import("../../utils/typeGuards/index.ts").EmbeddedSource | undefined = root.source
+		let source: EmbeddedSource | undefined = root.source
 
 		if (!validOptions || source?.inline || source?.lang === `object-literal`) return
 

--- a/lib/rules/no-eol-whitespace/index.ts
+++ b/lib/rules/no-eol-whitespace/index.ts
@@ -64,7 +64,10 @@ function lastLineBreakIndex (string: string, from: number = string.length - 1): 
  * @param options - The options object.
  * @returns The error start index, or -1 if no error.
  */
-function findErrorStartIndex (lastEOLIndex: number, string: string, options: { ignoreEmptyLines: boolean, isRootFirst: boolean }): number {
+function findErrorStartIndex (lastEOLIndex: number, string: string, options: {
+	ignoreEmptyLines: boolean,
+	isRootFirst: boolean,
+}): number {
 	let { ignoreEmptyLines, isRootFirst } = options
 
 	let eolWhitespaceIndex = lastEOLIndex - 1
@@ -149,7 +152,10 @@ function rule (primary: true, secondaryOptions: { ignore?: `empty-lines` | `empt
 		 * @param callback - callback the whitespace index at the end of each line.
 		 * @param options - `isRootFirst` marks the given string as the first token of the root, `isPlainText` marks it as text that is not CSS.
 		 */
-		function eachEolWhitespace (string: string, callback: (index: number) => void, options: { isRootFirst?: boolean, isPlainText?: boolean } = {}): void {
+		function eachEolWhitespace (string: string, callback: (index: number) => void, options: {
+			isRootFirst?: boolean,
+			isPlainText?: boolean,
+		} = {}): void {
 			let { isRootFirst = false, isPlainText = false } = options
 
 			/**
@@ -287,7 +293,10 @@ function rule (primary: true, secondaryOptions: { ignore?: `empty-lines` | `empt
 		 * @param fixFn - The function to apply the fix.
 		 * @param options - The scanning options, forwarded to `eachEolWhitespace`.
 		 */
-		function fixText (value: string | undefined, fixFn: (text: string) => void, options?: { isRootFirst?: boolean, isPlainText?: boolean }): void {
+		function fixText (value: string | undefined, fixFn: (text: string) => void, options?: {
+			isRootFirst?: boolean,
+			isPlainText?: boolean,
+		}): void {
 			if (!value) return
 
 			let fixed = ``

--- a/lib/rules/no-extra-semicolons/index.ts
+++ b/lib/rules/no-extra-semicolons/index.ts
@@ -1,5 +1,6 @@
+import type { Node } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
@@ -29,7 +30,7 @@ export let meta = {
  * @param node - The PostCSS node.
  * @returns The offset index.
  */
-function getOffsetByNode (node: import("postcss").Node): number {
+function getOffsetByNode (node: Node): number {
 	if (node.parent && `document` in node.parent && node.parent.document) return 0
 
 	let root = node.root()
@@ -74,7 +75,7 @@ function rule (primary: true): RuleCheck {
 
 		if (!validOptions) return
 
-		let fix: import("stylelint").FixCallback | undefined
+		let fix: FixCallback | undefined
 
 		if (root.raws.after && root.raws.after.trim().length > 0) {
 			let rawAfterRoot = root.raws.after

--- a/lib/rules/no-missing-end-of-source-newline/index.ts
+++ b/lib/rules/no-missing-end-of-source-newline/index.ts
@@ -5,6 +5,7 @@ import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
+import type { EmbeddedSource } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -35,7 +36,7 @@ function rule (primary: true, _secondaryOptions: unknown): RuleCheck {
 
 		if (root.source === undefined) throw new Error(`The root node must have a source property`)
 
-		let source: import("../../utils/typeGuards/index.ts").EmbeddedSource = root.source
+		let source: EmbeddedSource = root.source
 
 		if (source.inline || source.lang === `object-literal`) return
 

--- a/lib/rules/no-missing-end-of-source-newline/integration.test.ts
+++ b/lib/rules/no-missing-end-of-source-newline/integration.test.ts
@@ -11,7 +11,10 @@ import plugins from "../../index.ts"
  * @param rules - The two rules, in the order the configuration is to spell them.
  * @returns What the run left behind and how much of it the pair still has to say about.
  */
-async function fix (code: string, rules: object): Promise<{ code: string, warnings: number }> {
+async function fix (code: string, rules: object): Promise<{
+	code: string,
+	warnings: number,
+}> {
 	let fixed = await stylelint.lint({ code, config: { plugins, rules }, fix: true })
 	let read = await stylelint.lint({ code: fixed.code ?? code, config: { plugins, rules } })
 

--- a/lib/rules/no-multiple-whitespaces/index.ts
+++ b/lib/rules/no-multiple-whitespaces/index.ts
@@ -66,7 +66,11 @@ function isEscapedQuote (value: string, pos: number): boolean {
  * @param pos - The position of the character.
  * @returns Updated string state.
  */
-function handleStringChar (char: string, inString: boolean, stringChar: string, value: string, pos: number): { inString: boolean, stringChar: string, skip: boolean } {
+function handleStringChar (char: string, inString: boolean, stringChar: string, value: string, pos: number): {
+	inString: boolean,
+	stringChar: string,
+	skip: boolean,
+} {
 	if (!inString && (char === `"` || char === `'`)) {
 		return { inString: true, stringChar: char, skip: true }
 	}
@@ -90,7 +94,10 @@ function handleStringChar (char: string, inString: boolean, stringChar: string, 
  * @param errors - Array of error positions.
  * @returns The fixed value.
  */
-function fixWhitespaceErrors (value: string, errors: { start: number, count: number }[]): string {
+function fixWhitespaceErrors (value: string, errors: {
+	start: number,
+	count: number,
+}[]): string {
 	let newValue = value
 
 	for (let j = errors.length - 1; j >= 0; j -= 1) {
@@ -121,7 +128,10 @@ function rule (primary: true): RuleCheck {
 			let stringChar = ``
 			let afterNewline = true
 
-			let errors: { start: number, count: number }[] = []
+			let errors: {
+				start: number,
+				count: number,
+			}[] = []
 
 			// Main character iteration to find multiple whitespace errors
 			for (let i = 0; i < value.length; i += 1) {

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -63,7 +63,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param value - The value to check.
 		 */
 		function check (node: AtRule | Declaration, value: string): void {
-			let neverFixPositions: Array<{ startIndex: number, endIndex: number }> = []
+			let neverFixPositions: Array<{
+				startIndex: number,
+				endIndex: number,
+			}> = []
 
 			let alwaysFixPositions: Array<{ index: number }> = []
 

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -1,5 +1,6 @@
+import type { AtRule, Declaration, Node } from "postcss"
 import valueParser from "postcss-value-parser"
-import stylelint from "stylelint"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { FRACTION_WITH_LEADING_ZEROS, FRACTION_WITHOUT_LEADING_ZERO } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -46,7 +47,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 
 		if (!validOptions) return
 
-		let fix: import("stylelint").FixCallback | undefined
+		let fix: FixCallback | undefined
 
 		root.walkAtRules((atRule) => {
 			if (atRule.name.toLowerCase() === `import`) return
@@ -61,7 +62,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param node - The node to check.
 		 * @param value - The value to check.
 		 */
-		function check (node: import("postcss").AtRule | import("postcss").Declaration, value: string): void {
+		function check (node: AtRule | Declaration, value: string): void {
 			let neverFixPositions: Array<{ startIndex: number, endIndex: number }> = []
 
 			let alwaysFixPositions: Array<{ index: number }> = []
@@ -154,7 +155,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		 * @param node - The node with the violation.
 		 * @param index - The index of the violation.
 		 */
-		function complain (message: string, node: import("postcss").Node, index: number): void {
+		function complain (message: string, node: Node, index: number): void {
 			report({
 				result,
 				ruleName,

--- a/lib/rules/number-no-trailing-zeros/index.ts
+++ b/lib/rules/number-no-trailing-zeros/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Declaration } from "postcss"
 import valueParser from "postcss-value-parser"
 import stylelint from "stylelint"
 
@@ -55,7 +56,7 @@ function rule (primary: true): RuleCheck {
 		 * @param node - The node to check.
 		 * @param value - The value to check.
 		 */
-		function check (node: import("postcss").AtRule | import("postcss").Declaration, value: string): void {
+		function check (node: AtRule | Declaration, value: string): void {
 			let fixPositions: Array<{ startIndex: number, endIndex: number }> = []
 
 			// Get out quickly if there are no periods

--- a/lib/rules/number-no-trailing-zeros/index.ts
+++ b/lib/rules/number-no-trailing-zeros/index.ts
@@ -57,7 +57,10 @@ function rule (primary: true): RuleCheck {
 		 * @param value - The value to check.
 		 */
 		function check (node: AtRule | Declaration, value: string): void {
-			let fixPositions: Array<{ startIndex: number, endIndex: number }> = []
+			let fixPositions: Array<{
+				startIndex: number,
+				endIndex: number,
+			}> = []
 
 			// Get out quickly if there are no periods
 			if (!value.includes(`.`)) return

--- a/lib/rules/selector-attribute-brackets-space-inside/index.ts
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.ts
@@ -154,7 +154,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 		let spacesAttribute = attributeNode.raws.spaces && attributeNode.raws.spaces.attribute
 		let rawAttrBefore = spacesAttribute && spacesAttribute.before
 
-		let { attrBefore, setAttrBefore }: { attrBefore: string, setAttrBefore: (fixed: string) => void } = spacesAttribute && rawAttrBefore
+		let { attrBefore, setAttrBefore }: {
+			attrBefore: string,
+			setAttrBefore: (fixed: string) => void,
+		} = spacesAttribute && rawAttrBefore
 			? {
 				attrBefore: rawAttrBefore,
 				setAttrBefore (fixed) {
@@ -186,7 +189,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 
 		let spaces = attributeNode.spaces[key]
 
-		let { after, setAfter }: { after: string, setAfter: (fixed: string) => void } = rawSpaces && rawAfter
+		let { after, setAfter }: {
+			after: string,
+			setAfter: (fixed: string) => void,
+		} = rawSpaces && rawAfter
 			? {
 				after: rawAfter,
 				setAfter (fixed) {

--- a/lib/rules/selector-attribute-brackets-space-inside/index.ts
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.ts
@@ -1,5 +1,6 @@
+import type { Attribute } from "postcss-selector-parser"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { LEADING_WHITESPACE, TRAILING_WHITESPACE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -10,6 +11,7 @@ import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -46,7 +48,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return
 
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
@@ -55,7 +57,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
 			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 
-			let fix: import("stylelint").FixCallback | undefined
+			let fix: FixCallback | undefined
 			let hasFixed
 			let selectorTree = parseSelector(selector, result, ruleNode)
 
@@ -148,7 +150,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 	 * Fixes the space before an attribute selector.
 	 * @param attributeNode - The attribute node to fix.
 	 */
-	function fixBefore (attributeNode: import("postcss-selector-parser").Attribute): void {
+	function fixBefore (attributeNode: Attribute): void {
 		let spacesAttribute = attributeNode.raws.spaces && attributeNode.raws.spaces.attribute
 		let rawAttrBefore = spacesAttribute && spacesAttribute.before
 
@@ -176,7 +178,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 	 * Fixes the space after an attribute selector.
 	 * @param attributeNode - The attribute node to fix.
 	 */
-	function fixAfter (attributeNode: import("postcss-selector-parser").Attribute): void {
+	function fixAfter (attributeNode: Attribute): void {
 		let key: `insensitive` | `value` | `attribute` = attributeNode.operator ? (attributeNode.insensitive ? `insensitive` : `value`) : `attribute`
 
 		let rawSpaces = attributeNode.raws.spaces && attributeNode.raws.spaces[key]

--- a/lib/rules/selector-attribute-operator-space-after/index.ts
+++ b/lib/rules/selector-attribute-operator-space-after/index.ts
@@ -45,7 +45,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 			checkedRuleName: ruleName,
 			checkBeforeOperator: false,
 			fix: (attributeNode) => {
-				let { operatorAfter, setOperatorAfter }: { operatorAfter: string, setOperatorAfter: (fixed: string) => void } = (() => {
+				let { operatorAfter, setOperatorAfter }: {
+					operatorAfter: string,
+					setOperatorAfter: (fixed: string) => void,
+				} = (() => {
 					let rawOperator = attributeNode.raws.operator
 
 					if (rawOperator) {

--- a/lib/rules/selector-attribute-operator-space-before/index.ts
+++ b/lib/rules/selector-attribute-operator-space-before/index.ts
@@ -49,7 +49,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 				let rawAttr = attributeNode.raws.spaces && attributeNode.raws.spaces.attribute
 				let rawAttrAfter = rawAttr && rawAttr.after
 
-				let { attrAfter, setAttrAfter }: { attrAfter: string, setAttrAfter: (fixed: string) => void } = rawAttr && rawAttrAfter
+				let { attrAfter, setAttrAfter }: {
+					attrAfter: string,
+					setAttrAfter: (fixed: string) => void,
+				} = rawAttr && rawAttrAfter
 					? {
 						attrAfter: rawAttrAfter,
 						setAttrAfter (fixed) {

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.ts
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.ts
@@ -1,15 +1,17 @@
+import type { Combinator, Root } from "postcss-selector-parser"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE_AND_REST, WHITESPACE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { findSelectorBlockComments } from "../../utils/findSelectorBlockComments/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
+import { findSelectorInlineComments, type InlineComment } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -44,7 +46,7 @@ function rule (primary: true): RuleCheck {
 
 			let hasFixed = false
 
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
@@ -164,7 +166,7 @@ function rule (primary: true): RuleCheck {
  * @param selector - The selector the tree was parsed from.
  * @returns True if the tree gives the selector back the way the source spells it.
  */
-function standsForSource (selectorTree: import("postcss-selector-parser").Root, selector: string): boolean {
+function standsForSource (selectorTree: Root, selector: string): boolean {
 	if (String(selectorTree) === selector) return true
 
 	selectorTree.walkCombinators((combinatorNode) => {
@@ -194,7 +196,7 @@ function standsForSource (selectorTree: import("postcss-selector-parser").Root, 
  * @param node - The combinator to look back from.
  * @returns True if a comment separates this node from a combinator in front of it.
  */
-function isLeftOverOfCombinator (node: import("postcss-selector-parser").Combinator): boolean {
+function isLeftOverOfCombinator (node: Combinator): boolean {
 	let previous = node.prev()
 
 	if (!previous || previous.type !== `comment`) return false
@@ -215,7 +217,7 @@ function isLeftOverOfCombinator (node: import("postcss-selector-parser").Combina
  * @param inlineComments - The inline comments of the selector.
  * @returns The segments, in the order they stand in.
  */
-function splitAtComments (text: string, offset: number, inlineComments: import("../../utils/findSelectorInlineComments/index.ts").InlineComment[]): Array<{ value: string, index: number, isComment: boolean, closesInlineComment: boolean }> {
+function splitAtComments (text: string, offset: number, inlineComments: InlineComment[]): Array<{ value: string, index: number, isComment: boolean, closesInlineComment: boolean }> {
 	let comments = inlineComments
 		.filter((inlineComment) => inlineComment.startIndex < offset + text.length && offset < inlineComment.endIndex)
 		.map((inlineComment) => ({ start: Math.max(inlineComment.startIndex - offset, 0), end: Math.min(inlineComment.endIndex - offset, text.length), isInline: true }))

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.ts
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.ts
@@ -113,7 +113,12 @@ function rule (primary: true): RuleCheck {
 				 * Reports a run of whitespace that is not the single space the rule asks for.
 				 * @param segment - The run, as {@link splitAtComments} cut it.
 				 */
-				function reportRun (segment: { value: string, index: number, isComment: boolean, closesInlineComment: boolean }): void {
+				function reportRun (segment: {
+					value: string,
+					index: number,
+					isComment: boolean,
+					closesInlineComment: boolean,
+				}): void {
 					// A run already a single space is what the rule asks for, and an empty one — a comment abutting the selector beside it — has no whitespace to complain of.
 					if (segment.isComment || segment.value === ` ` || segment.value === ``) return
 
@@ -217,7 +222,12 @@ function isLeftOverOfCombinator (node: Combinator): boolean {
  * @param inlineComments - The inline comments of the selector.
  * @returns The segments, in the order they stand in.
  */
-function splitAtComments (text: string, offset: number, inlineComments: InlineComment[]): Array<{ value: string, index: number, isComment: boolean, closesInlineComment: boolean }> {
+function splitAtComments (text: string, offset: number, inlineComments: InlineComment[]): Array<{
+	value: string,
+	index: number,
+	isComment: boolean,
+	closesInlineComment: boolean,
+}> {
 	let comments = inlineComments
 		.filter((inlineComment) => inlineComment.startIndex < offset + text.length && offset < inlineComment.endIndex)
 		.map((inlineComment) => ({ start: Math.max(inlineComment.startIndex - offset, 0), end: Math.min(inlineComment.endIndex - offset, text.length), isInline: true }))

--- a/lib/rules/selector-list-comma-newline-after/index.ts
+++ b/lib/rules/selector-list-comma-newline-after/index.ts
@@ -10,6 +10,7 @@ import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -52,7 +53,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 			// The raw selector is what is read, so that an end-of-line comment is allowed, e.g.
 			//   a, /* comment */
 			//   b {}
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.

--- a/lib/rules/selector-list-comma-newline-before/index.ts
+++ b/lib/rules/selector-list-comma-newline-before/index.ts
@@ -1,3 +1,4 @@
+import type { Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_SPACES_AND_TABS, TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -8,6 +9,7 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -44,7 +46,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Rule, number[]> | undefined
+		let fixData: Map<Rule, number[]> | undefined
 
 		selectorListCommaWhitespaceChecker({
 			root,
@@ -73,7 +75,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.

--- a/lib/rules/selector-list-comma-space-after/index.ts
+++ b/lib/rules/selector-list-comma-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE } from "../../regexps.ts"
@@ -7,6 +8,7 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -43,7 +45,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Rule, number[]> | undefined
+		let fixData: Map<Rule, number[]> | undefined
 
 		selectorListCommaWhitespaceChecker({
 			root,
@@ -64,7 +66,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.

--- a/lib/rules/selector-list-comma-space-before/index.ts
+++ b/lib/rules/selector-list-comma-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { Rule } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -7,6 +8,7 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { ruleMessages, validateOptions } } = stylelint
@@ -43,7 +45,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Rule, number[]> | undefined
+		let fixData: Map<Rule, number[]> | undefined
 
 		selectorListCommaWhitespaceChecker({
 			root,
@@ -70,7 +72,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.

--- a/lib/rules/selector-max-empty-lines/index.ts
+++ b/lib/rules/selector-max-empty-lines/index.ts
@@ -6,6 +6,7 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { isNumber } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -45,7 +46,7 @@ function rule (primary: number): RuleCheck {
 		let allowedCRLFNewLinesString = `\r\n`.repeat(maxAdjacentNewlines)
 
 		root.walkRules((ruleNode) => {
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. The positions are reported in the file's own coordinates, and a fix is written to both copies. The line break that closes each comment stands outside it and survives the fix, since collapsing the empty lines always leaves the first break standing.

--- a/lib/rules/selector-pseudo-class-case/index.ts
+++ b/lib/rules/selector-pseudo-class-case/index.ts
@@ -10,6 +10,7 @@ import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -43,7 +44,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return
 
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
 			if (!selector.includes(`:`)) return

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
@@ -1,4 +1,5 @@
-import stylelint from "stylelint"
+import type { Container, Node, Root, Spaces } from "postcss-selector-parser"
+import stylelint, { type FixCallback } from "stylelint"
 
 import { LEADING_WHITESPACE_OR_BLOCK_COMMENT, LEADING_WHITESPACE_RUN, LINE_BREAK, TRAILING_WHITESPACE_RUN, WHITESPACE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
@@ -9,11 +10,12 @@ import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
 /** A node of the selector with the raws the parser hangs on one it found a comment beside: the run of whitespace and comment it prints in place of `spaces`, and the value it prints in place of the node's own. */
-type NodeWithRaws = import("postcss-selector-parser").Node & { raws?: { spaces?: Partial<import("postcss-selector-parser").Spaces>, value?: string } }
+type NodeWithRaws = Node & { raws?: { spaces?: Partial<Spaces>, value?: string } }
 
 let shortName = `selector-pseudo-class-parentheses-space-inside`
 
@@ -50,10 +52,10 @@ function rule (primary: `always` | `never`): RuleCheck {
 
 			if (!ruleNode.selector.includes(`(`)) return
 
-			let fix: import("stylelint").FixCallback | undefined
+			let fix: FixCallback | undefined
 			let hasFixed = false
 
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
 
@@ -167,7 +169,7 @@ function rule (primary: `always` | `never`): RuleCheck {
  * @param selector - The selector the tree was parsed from.
  * @returns True if the tree gives the selector back the way the source spells it.
  */
-function standsForSource (selectorTree: import("postcss-selector-parser").Root, selector: string): boolean {
+function standsForSource (selectorTree: Root, selector: string): boolean {
 	if (String(selectorTree) === selector) return true
 
 	selectorTree.walk((node) => {
@@ -197,8 +199,8 @@ function standsForSource (selectorTree: import("postcss-selector-parser").Root, 
  * @param node - The node to look ahead from.
  * @returns The node, or nothing where it closes the selector.
  */
-function nodeAfter (node: import("postcss-selector-parser").Node | import("postcss-selector-parser").Container | undefined): import("postcss-selector-parser").Node | undefined {
-	let current: import("postcss-selector-parser").Node | import("postcss-selector-parser").Container | undefined = node
+function nodeAfter (node: Node | Container | undefined): Node | undefined {
+	let current: Node | Container | undefined = node
 
 	while (current && current.parent) {
 		let next = current.next()
@@ -221,7 +223,7 @@ function nodeAfter (node: import("postcss-selector-parser").Node | import("postc
  * @param node - The node to give the whitespace to.
  * @param selector - The selector the tree was parsed from.
  */
-function restoreSpaceBefore (node: import("postcss-selector-parser").Node, selector: string): void {
+function restoreSpaceBefore (node: Node, selector: string): void {
 	if (node.type === `combinator` && WHITESPACE.test(node.value)) {
 		node.spaces.before = ``
 		node.spaces.after = ``
@@ -282,7 +284,7 @@ function trailingWhitespace (text: string, index: number): string {
  * @param node - The container node.
  * @returns The node, or nothing where the container holds none.
  */
-function firstNodeInside (node: import("postcss-selector-parser").Container): import("postcss-selector-parser").Node | undefined {
+function firstNodeInside (node: Container): Node | undefined {
 	let target = node.first
 
 	while (target && target.type === `selector`) target = target.first
@@ -295,7 +297,7 @@ function firstNodeInside (node: import("postcss-selector-parser").Container): im
  * @param node - The container node.
  * @returns The node, or nothing where the container holds none.
  */
-function lastNodeInside (node: import("postcss-selector-parser").Container): import("postcss-selector-parser").Node | undefined {
+function lastNodeInside (node: Container): Node | undefined {
 	let target = node.last
 
 	while (target && target.type === `selector`) target = target.last
@@ -310,7 +312,7 @@ function lastNodeInside (node: import("postcss-selector-parser").Container): imp
  * @param target - The node to set the space of.
  * @param value - The space value to set.
  */
-function setSpaceBefore (target: import("postcss-selector-parser").Node, value: string): void {
+function setSpaceBefore (target: Node, value: string): void {
 	target.spaces.before = value
 
 	let spaces = (target as NodeWithRaws).raws?.spaces
@@ -325,7 +327,7 @@ function setSpaceBefore (target: import("postcss-selector-parser").Node, value: 
  * @param target - The node to set the space of.
  * @param value - The space value to set.
  */
-function setSpaceAfter (target: import("postcss-selector-parser").Node, value: string): void {
+function setSpaceAfter (target: Node, value: string): void {
 	target.spaces.after = value
 
 	let spaces = (target as NodeWithRaws).raws?.spaces

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
@@ -15,7 +15,12 @@ import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
 /** A node of the selector with the raws the parser hangs on one it found a comment beside: the run of whitespace and comment it prints in place of `spaces`, and the value it prints in place of the node's own. */
-type NodeWithRaws = Node & { raws?: { spaces?: Partial<Spaces>, value?: string } }
+type NodeWithRaws = Node & {
+	raws?: {
+		spaces?: Partial<Spaces>,
+		value?: string,
+	},
+}
 
 let shortName = `selector-pseudo-class-parentheses-space-inside`
 

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -285,7 +285,7 @@ function rule (primary: `single` | `double`, secondaryOptions: { avoidEscape?: b
 		 * @param value - The value, as the file spells it.
 		 * @returns The spans, in the coordinates of the value.
 		 */
-		function scanCommentSpans (raws: { raw: string, scss?: string } | undefined, value: string): InlineCommentSpan[] {
+		function scanCommentSpans (raws: SyntaxRaw | undefined, value: string): InlineCommentSpan[] {
 			if (!value.includes(`//`)) return []
 
 			// A double slash of a syntax that marks its comments in a copy of its own is code — part of an address, most often. Unless that copy has gone out of step with the value and left the scan to answer after all, and then the comments are the ones the text spells.

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -1,3 +1,4 @@
+import type { AtRule, Declaration, Rule } from "postcss"
 import valueParser from "postcss-value-parser"
 import stylelint from "stylelint"
 
@@ -5,7 +6,7 @@ import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
-import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
@@ -20,7 +21,7 @@ import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import { isAtRule } from "../../utils/typeGuards/index.ts"
+import { isAtRule, type SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
@@ -40,8 +41,6 @@ export let meta = {
 
 const SINGLE_QUOTE = `'`
 const DOUBLE_QUOTE = `"`
-
-type InlineCommentSpan = import("../../utils/findInlineCommentSpans/index.ts").InlineCommentSpan
 
 /**
  * Specifies single or double quotes around strings.
@@ -99,10 +98,10 @@ function rule (primary: `single` | `double`, secondaryOptions: { avoidEscape?: b
 		 * Checks a rule node for quote violations.
 		 * @param ruleNode - The rule node to check.
 		 */
-		function checkRule (ruleNode: import("postcss").Rule): void {
+		function checkRule (ruleNode: Rule): void {
 			if (!isStandardSyntaxRule(ruleNode)) return
 
-			let selectorRaws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = ruleNode.raws.selector
+			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 
 			// `ruleNode.selector` is a copy with every comment taken out, so a position counted in it stands short of the file wherever a comment goes before, and a fix written to it prints without the comments. The raw is the text the file holds — except under `postcss-scss`, which spells every inline comment of the raw as a block one and keeps the file's spelling beside it, two characters shorter per comment. The raw is what is parsed here, every position is translated back into the file's coordinates, and a fix is written to both copies.
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
@@ -209,10 +208,10 @@ function rule (primary: `single` | `double`, secondaryOptions: { avoidEscape?: b
 		 * @param rawValue - The value to check, as the raws of the node record it.
 		 * @param getIndex - Function to get the index of the node.
 		 */
-		function checkDeclOrAtRule<T extends import("postcss").AtRule | import("postcss").Declaration> (node: T, rawValue: string, getIndex: (node: T) => number): void {
+		function checkDeclOrAtRule<T extends AtRule | Declaration> (node: T, rawValue: string, getIndex: (node: T) => number): void {
 			let fixPositions: number[] = []
 
-			let raws: import("../../utils/typeGuards/index.ts").SyntaxRaw | undefined = isAtRule(node) ? node.raws.params : node.raws.value
+			let raws: SyntaxRaw | undefined = isAtRule(node) ? node.raws.params : node.raws.value
 
 			// `postcss-scss` rewrites every `//` comment inside the raw into a block comment, keeps the spelling of the file in a copy of its own and prints that copy. The rule works in that copy, since it is the file it reports positions in and the text a fix has to reach.
 			let value = (raws && raws.scss) || rawValue

--- a/lib/rules/unicode-bom/index.ts
+++ b/lib/rules/unicode-bom/index.ts
@@ -1,8 +1,10 @@
+import type { Document } from "postcss"
 import stylelint from "stylelint"
 
 import { addNamespace } from "../../utils/addNamespace/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
+import type { EmbeddedSource } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, ruleMessages, validateOptions } } = stylelint
 
@@ -32,8 +34,8 @@ function rule (primary: `always` | `never`): RuleCheck {
 		})
 
 		// A `document` root is an HTML file holding stylesheets, and a byte order mark stands at the head of the file rather than of any block in it
-		let source: import("../../utils/typeGuards/index.ts").EmbeddedSource | undefined = root.source
-		let { document } = root as { document?: import("postcss").Document }
+		let source: EmbeddedSource | undefined = root.source
+		let { document } = root as { document?: Document }
 
 		if (!validOptions || !source || source.inline || source.lang === `object-literal` || document !== undefined) return
 

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -1,9 +1,10 @@
-import valueParser from "postcss-value-parser"
-import stylelint from "stylelint"
+import type { AtRule, Declaration } from "postcss"
+import valueParser, { type Node } from "postcss-value-parser"
+import stylelint, { type RuleMessage } from "stylelint"
 
 import { MEDIA_AT_RULE } from "../../regexps.ts"
 import { addNamespace } from "../../utils/addNamespace/index.ts"
-import { applyEditsFromEnd } from "../../utils/applyEditsFromEnd/index.ts"
+import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
@@ -36,8 +37,6 @@ export let meta = {
 	fixable: true,
 }
 
-type Edit = import("../../utils/applyEditsFromEnd/index.ts").Edit
-
 /**
  * Specifies lowercase or uppercase for units.
  * @param primary - The primary option, one of `lower` and `upper`.
@@ -58,8 +57,8 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 		 * @param checkedValue - The value to check.
 		 * @param getIndex - Function to get the index of the node.
 		 */
-		function check<T extends import("postcss").AtRule | import("postcss").Declaration> (node: T, checkedValue: string, getIndex: (node: T) => number): void {
-			let problems: Array<{ index: number, endIndex: number, message: import("stylelint").RuleMessage, messageArgs: string[] }> = []
+		function check<T extends AtRule | Declaration> (node: T, checkedValue: string, getIndex: (node: T) => number): void {
+			let problems: Array<{ index: number, endIndex: number, message: RuleMessage, messageArgs: string[] }> = []
 
 			// What the walk changed, and nothing else: the text is edited at the positions the changed words stand at rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a text would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
@@ -77,7 +76,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 			 * @param valueNode - The value parser node to read.
 			 * @returns What to report about the unit, or `null` where the node carries no miscased one.
 			 */
-			function readMiscasedUnit (valueNode: import("postcss-value-parser").Node): { index: number, endIndex: number, message: import("stylelint").RuleMessage, messageArgs: string[] } | null {
+			function readMiscasedUnit (valueNode: Node): { index: number, endIndex: number, message: RuleMessage, messageArgs: string[] } | null {
 				let dimension = getDimension(valueNode)
 
 				if (!dimension.number || !dimension.unit) return null

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -37,6 +37,14 @@ export let meta = {
 	fixable: true,
 }
 
+/** What one miscased unit is reported as: where the warning stands, counted in the node, and what it says. */
+type Problem = {
+	index: number,
+	endIndex: number,
+	message: RuleMessage,
+	messageArgs: string[],
+}
+
 /**
  * Specifies lowercase or uppercase for units.
  * @param primary - The primary option, one of `lower` and `upper`.
@@ -58,7 +66,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 		 * @param getIndex - Function to get the index of the node.
 		 */
 		function check<T extends AtRule | Declaration> (node: T, checkedValue: string, getIndex: (node: T) => number): void {
-			let problems: Array<{ index: number, endIndex: number, message: RuleMessage, messageArgs: string[] }> = []
+			let problems: Problem[] = []
 
 			// What the walk changed, and nothing else: the text is edited at the positions the changed words stand at rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a text would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
@@ -76,7 +84,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 			 * @param valueNode - The value parser node to read.
 			 * @returns What to report about the unit, or `null` where the node carries no miscased one.
 			 */
-			function readMiscasedUnit (valueNode: Node): { index: number, endIndex: number, message: RuleMessage, messageArgs: string[] } | null {
+			function readMiscasedUnit (valueNode: Node): Problem | null {
 				let dimension = getDimension(valueNode)
 
 				if (!dimension.number || !dimension.unit) return null

--- a/lib/rules/value-list-comma-newline-after/index.ts
+++ b/lib/rules/value-list-comma-newline-after/index.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE, SPACES_THEN_BLOCK_COMMENT, SPACES_THEN_INLINE_COMMENT } from "../../regexps.ts"
@@ -45,7 +46,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Declaration, number[]> | undefined
+		let fixData: Map<Declaration, number[]> | undefined
 
 		valueListCommaWhitespaceChecker({
 			root,

--- a/lib/rules/value-list-comma-space-after/index.ts
+++ b/lib/rules/value-list-comma-space-after/index.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "postcss"
 import stylelint from "stylelint"
 
 import { LEADING_WHITESPACE } from "../../regexps.ts"
@@ -44,7 +45,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Declaration, number[]> | undefined
+		let fixData: Map<Declaration, number[]> | undefined
 
 		valueListCommaWhitespaceChecker({
 			root,

--- a/lib/rules/value-list-comma-space-before/index.ts
+++ b/lib/rules/value-list-comma-space-before/index.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "postcss"
 import stylelint from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
@@ -46,7 +47,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 
 		if (!validOptions) return
 
-		let fixData: Map<import("postcss").Declaration, number[]> | undefined
+		let fixData: Map<Declaration, number[]> | undefined
 
 		valueListCommaWhitespaceChecker({
 			root,

--- a/lib/utils/addEmptyLineAfter/index.test.ts
+++ b/lib/utils/addEmptyLineAfter/index.test.ts
@@ -1,4 +1,5 @@
-import { parse } from "postcss"
+import { parse, type Rule } from "postcss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { addEmptyLineAfter } from "./index.ts"
@@ -96,7 +97,7 @@ describe(`addEmptyLineAfter`, () => {
 function run (css: string, index: number = 0, rules: Record<string, unknown> = {}): string {
 	let root = parse(css)
 
-	addEmptyLineAfter(root.nodes[index] as import("postcss").Rule, { stylelint: { config: { rules } } } as unknown as import("stylelint").PostcssResult)
+	addEmptyLineAfter(root.nodes[index] as Rule, { stylelint: { config: { rules } } } as unknown as PostcssResult)
 
 	return root.toString()
 }

--- a/lib/utils/addEmptyLineAfter/index.ts
+++ b/lib/utils/addEmptyLineAfter/index.ts
@@ -1,3 +1,6 @@
+import type { AtRule, Rule } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { CAPTURED_LINE_BREAK, LINE_BREAK } from "../../regexps.ts"
 import { getBlockAfter } from "../getBlockAfter/index.ts"
 import { getLineBreak } from "../getLineBreak/index.ts"
@@ -11,7 +14,7 @@ import { setBlockAfter } from "../setBlockAfter/index.ts"
  * @param result - The Stylelint result, which holds the configuration the break to write is read from.
  * @returns The modified node.
  */
-export function addEmptyLineAfter<T extends import("postcss").Rule | import("postcss").AtRule> (node: T, result: import("stylelint").PostcssResult): T {
+export function addEmptyLineAfter<T extends Rule | AtRule> (node: T, result: PostcssResult): T {
 	let blockAfter = getBlockAfter(node)
 
 	if (typeof blockAfter !== `string`) return node

--- a/lib/utils/applyEditsFromEnd/index.test.ts
+++ b/lib/utils/applyEditsFromEnd/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { addEdit, applyEditsFromEnd, toIndexBeforeEdits } from "./index.ts"
+import { addEdit, applyEditsFromEnd, type Edit, toIndexBeforeEdits } from "./index.ts"
 
 describe(`applyEditsFromEnd`, () => {
 	it(`no edit at all`, () => {
@@ -123,7 +123,7 @@ describe(`addEdit`, () => {
 	})
 
 	it(`an edit added to an empty list`, () => {
-		let edits: import("./index.ts").Edit[] = []
+		let edits: Edit[] = []
 
 		addEdit(edits, { start: 0, end: 1, text: `x` })
 

--- a/lib/utils/applyEditsFromEnd/index.ts
+++ b/lib/utils/applyEditsFromEnd/index.ts
@@ -1,5 +1,9 @@
 /** A replacement for one span of a text, addressed in that text as it stood before any edit was applied. */
-export type Edit = { start: number, end: number, text: string }
+export type Edit = {
+	start: number,
+	end: number,
+	text: string,
+}
 
 /**
  * Applies a list of edits to a text.

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -1,4 +1,5 @@
-import stylelint from "stylelint"
+import type { AtRule, Root } from "postcss"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { isStandardSyntaxAtRule } from "../isStandardSyntaxAtRule/index.ts"
 
@@ -9,11 +10,11 @@ let { utils: { report } } = stylelint
  * @param options - The options object.
  */
 export function atRuleNameSpaceChecker (options: {
-	root: import("postcss").Root,
+	root: Root,
 	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void, errTarget: string }) => void,
-	result: import("stylelint").PostcssResult,
+	result: PostcssResult,
 	checkedRuleName: string,
-	fix?: ((atRule: import("postcss").AtRule) => void) | null,
+	fix?: ((atRule: AtRule) => void) | null,
 }): void {
 	options.root.walkAtRules((atRule) => {
 		if (!isStandardSyntaxAtRule(atRule)) return
@@ -31,7 +32,7 @@ export function atRuleNameSpaceChecker (options: {
 	 * @param index - The index to check.
 	 * @param node - The at-rule node.
 	 */
-	function checkColon (source: string, index: number, node: import("postcss").AtRule): void {
+	function checkColon (source: string, index: number, node: AtRule): void {
 		let { fix } = options
 
 		options.locationChecker({

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -11,7 +11,12 @@ let { utils: { report } } = stylelint
  */
 export function atRuleNameSpaceChecker (options: {
 	root: Root,
-	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void, errTarget: string }) => void,
+	locationChecker: (opts: {
+		source: string,
+		index: number,
+		err: (msg: string) => void,
+		errTarget: string,
+	}) => void,
 	result: PostcssResult,
 	checkedRuleName: string,
 	fix?: ((atRule: AtRule) => void) | null,

--- a/lib/utils/atRuleParamIndex/index.test.ts
+++ b/lib/utils/atRuleParamIndex/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type AtRule, parse } from "postcss"
 import { describe, expect, it } from "vitest"
 
 import { atRuleParamIndex } from "./index.ts"
@@ -26,8 +26,8 @@ describe(`atRuleParamIndex`, () => {
  * @param css - The stylesheet.
  * @returns That at-rule.
  */
-function atRule (css: string): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function atRule (css: string): AtRule {
+	let list: AtRule[] = []
 
 	parse(css).walkAtRules((rule) => {
 		list.push(rule)

--- a/lib/utils/atRuleParamIndex/index.ts
+++ b/lib/utils/atRuleParamIndex/index.ts
@@ -1,9 +1,11 @@
+import type { AtRule } from "postcss"
+
 /**
  * Gets the index of the parameters in an at-rule.
  * @param atRule - The at-rule node.
  * @returns The index of the parameters.
  */
-export function atRuleParamIndex (atRule: import("postcss").AtRule): number {
+export function atRuleParamIndex (atRule: AtRule): number {
 	// Initial 1 is for the `@`
 	let index = 1 + atRule.name.length
 

--- a/lib/utils/beforeBlockString/index.test.ts
+++ b/lib/utils/beforeBlockString/index.test.ts
@@ -1,6 +1,7 @@
-import postcss from "postcss"
+import postcss, { type Container, type Parser } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { beforeEach, describe, expect, it } from "vitest"
 
 import { beforeBlockString } from "./index.ts"
@@ -82,10 +83,10 @@ describe(`beforeBlockString`, () => {
  * @param syntax - The syntax to read it with.
  * @returns What the util answers.
  */
-function postcssCheck (options?: string | { noRawBefore?: boolean }, cssString?: string, syntax: { parse: import("postcss").Parser } = postcss): string {
+function postcssCheck (options?: string | { noRawBefore?: boolean }, cssString?: string, syntax: { parse: Parser } = postcss): string {
 	let opts = typeof options === `undefined` ? {} : options
 	let css = typeof opts === `string` ? opts : cssString ?? ``
 	let root = syntax.parse(css, { from: undefined })
 
-	return beforeBlockString(root.first as import("postcss").Container, { opts: { syntax } } as unknown as import("stylelint").PostcssResult, typeof opts === `string` ? {} : opts)
+	return beforeBlockString(root.first as Container, { opts: { syntax } } as unknown as PostcssResult, typeof opts === `string` ? {} : opts)
 }

--- a/lib/utils/beforeBlockString/index.ts
+++ b/lib/utils/beforeBlockString/index.ts
@@ -1,4 +1,5 @@
-import { stringify } from "postcss"
+import { type Container, stringify } from "postcss"
+import type { PostcssResult } from "stylelint"
 
 import { hasBlock } from "../hasBlock/index.ts"
 import { nodeSyntax } from "../nodeSyntax/index.ts"
@@ -15,7 +16,7 @@ import { isAtRule, isRule } from "../typeGuards/index.ts"
  * @param options - Whether to leave the statement's `raws.before` out of the result.
  * @returns The string before the block.
  */
-export function beforeBlockString (statement: import("postcss").Container, result?: import("stylelint").PostcssResult, options: { noRawBefore?: boolean } = {}): string {
+export function beforeBlockString (statement: Container, result?: PostcssResult, options: { noRawBefore?: boolean } = {}): string {
 	let { noRawBefore = false } = options
 
 	if (!hasBlock(statement)) return ``

--- a/lib/utils/blankComments/index.ts
+++ b/lib/utils/blankComments/index.ts
@@ -1,6 +1,5 @@
-import { findCommentSpans } from "../findCommentSpans/index.ts"
-
-export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
+import { type CommentSpan, findCommentSpans } from "../findCommentSpans/index.ts"
+import type { InlineCommentSpan } from "../findInlineCommentSpans/index.ts"
 
 /**
  * Blanks every comment of a text out of it, delimiters and all, so that a reader knowing less about the text than {@link findCommentSpans} does finds no comment there to read for itself.
@@ -14,7 +13,7 @@ export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
  * @param spans - The spans its comments occupy in it, where they are already known, from either scan.
  * @returns The text, with every comment replaced by spaces.
  */
-export function blankComments (text: string, spans: (CommentSpan | import("../findInlineCommentSpans/index.ts").InlineCommentSpan)[] = findCommentSpans(text)): string {
+export function blankComments (text: string, spans: (CommentSpan | InlineCommentSpan)[] = findCommentSpans(text)): string {
 	if (spans.length === 0) return text
 
 	let pieces = []

--- a/lib/utils/blockString/index.test.ts
+++ b/lib/utils/blockString/index.test.ts
@@ -1,6 +1,7 @@
-import postcss from "postcss"
+import postcss, { type Container, type Parser } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { blockString } from "./index.ts"
@@ -43,8 +44,8 @@ describe(`blockString`, () => {
  * @param syntax - The syntax to read it with.
  * @returns What the util answers.
  */
-function postcssCheck (cssString: string, syntax: { parse: import("postcss").Parser } = postcss): string {
+function postcssCheck (cssString: string, syntax: { parse: Parser } = postcss): string {
 	let root = syntax.parse(cssString, { from: undefined })
 
-	return blockString(root.first as import("postcss").Container, { opts: { syntax } } as unknown as import("stylelint").PostcssResult)
+	return blockString(root.first as Container, { opts: { syntax } } as unknown as PostcssResult)
 }

--- a/lib/utils/blockString/index.ts
+++ b/lib/utils/blockString/index.ts
@@ -1,3 +1,6 @@
+import type { Container } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { beforeBlockString } from "../beforeBlockString/index.ts"
 import { hasBlock } from "../hasBlock/index.ts"
 import { rawNodeString } from "../rawNodeString/index.ts"
@@ -8,7 +11,7 @@ import { rawNodeString } from "../rawNodeString/index.ts"
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns The block string content.
  */
-export function blockString (statement: import("postcss").Container, result?: import("stylelint").PostcssResult): string {
+export function blockString (statement: Container, result?: PostcssResult): string {
 	if (!hasBlock(statement)) return ``
 
 	return rawNodeString(statement, result).slice(beforeBlockString(statement, result).length)

--- a/lib/utils/declarationBangSpaceChecker/index.ts
+++ b/lib/utils/declarationBangSpaceChecker/index.ts
@@ -12,13 +12,25 @@ import { setDeclarationValue } from "../setDeclarationValue/index.ts"
 let { utils: { report } } = stylelint
 
 /** The declaration as the file prints it, and where in that print one bang of it stands. */
-export type BangTarget = { text: string, index: number }
+export type BangTarget = {
+	text: string,
+	index: number,
+}
 
 /** One of the texts a declaration is printed from that a fix can write into: where it opens in that print, what it holds, how it is written back, and what is to be written into it. */
-export type DeclarationPart = { start: number, text: string, write: (text: string) => void, edits: Edit[] }
+export type DeclarationPart = {
+	start: number,
+	text: string,
+	write: (text: string) => void,
+	edits: Edit[],
+}
 
 /** A function that checks whitespace at a specific location. */
-export type LocationChecker = (args: { source: string, index: number, err: (message: string) => void }) => void
+export type LocationChecker = (args: {
+	source: string,
+	index: number,
+	err: (message: string) => void,
+}) => void
 
 /**
  * Files one edit of a printed declaration under the texts it is printed from.

--- a/lib/utils/declarationBangSpaceChecker/index.ts
+++ b/lib/utils/declarationBangSpaceChecker/index.ts
@@ -1,7 +1,8 @@
+import type { Declaration, Root } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
-import { applyEditsFromEnd } from "../applyEditsFromEnd/index.ts"
+import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationString } from "../declarationString/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
@@ -9,9 +10,6 @@ import { searchCopy } from "../searchCopy/index.ts"
 import { setDeclarationValue } from "../setDeclarationValue/index.ts"
 
 let { utils: { report } } = stylelint
-
-export type Edit = import("../applyEditsFromEnd/index.ts").Edit
-export type Declaration = import("postcss").Declaration
 
 /** The declaration as the file prints it, and where in that print one bang of it stands. */
 export type BangTarget = { text: string, index: number }
@@ -51,9 +49,9 @@ function fileEdit (parts: DeclarationPart[], edit: Edit): void {
  * @param opts - The options object.
  */
 export function declarationBangSpaceChecker (opts: {
-	root: import("postcss").Root,
+	root: Root,
 	locationChecker: LocationChecker,
-	result: import("stylelint").PostcssResult,
+	result: PostcssResult,
 	checkedRuleName: string,
 	fix?: ((target: BangTarget) => Edit[]),
 	isFixable?: ((decl: Declaration, index: number) => boolean),

--- a/lib/utils/declarationColonSource/index.test.ts
+++ b/lib/utils/declarationColonSource/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type Declaration, type Parser, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -11,10 +11,10 @@ import { declarationColonSource } from "./index.ts"
  * @param css - The stylesheet, whose first rule holds the declaration.
  * @returns The text.
  */
-function source (parser: { parse: import("postcss").Parser }, css: string): string {
-	let rule = parser.parse(css).first as import("postcss").Rule
+function source (parser: { parse: Parser }, css: string): string {
+	let rule = parser.parse(css).first as Rule
 
-	return declarationColonSource(rule.first as import("postcss").Declaration)
+	return declarationColonSource(rule.first as Declaration)
 }
 
 describe(`declarationColonSource`, () => {

--- a/lib/utils/declarationColonSource/index.ts
+++ b/lib/utils/declarationColonSource/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 
@@ -12,6 +14,6 @@ import { getDeclarationValue } from "../getDeclarationValue/index.ts"
  * @param decl - The CSS declaration node.
  * @returns The declaration as the file prints it, up to the end of the value, with a sentinel behind it.
  */
-export function declarationColonSource (decl: import("postcss").Declaration): string {
+export function declarationColonSource (decl: Declaration): string {
 	return `${decl.toString().slice(0, declarationValueIndex(decl))}${getDeclarationValue(decl)}xxx`
 }

--- a/lib/utils/declarationColonSpaceChecker/index.ts
+++ b/lib/utils/declarationColonSpaceChecker/index.ts
@@ -9,7 +9,12 @@ import { isStandardSyntaxDeclaration } from "../isStandardSyntaxDeclaration/inde
 let { utils: { report } } = stylelint
 
 /** A function that checks whitespace at a specific location. */
-export type LocationChecker = (args: { source: string, index: number, lineCheckStr: string, err: (message: string) => void }) => void
+export type LocationChecker = (args: {
+	source: string,
+	index: number,
+	lineCheckStr: string,
+	err: (message: string) => void,
+}) => void
 
 /**
  * Checks whitespace around colons in declarations.

--- a/lib/utils/declarationColonSpaceChecker/index.ts
+++ b/lib/utils/declarationColonSpaceChecker/index.ts
@@ -1,5 +1,6 @@
+import type { Declaration, Root } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { declarationColonSource } from "../declarationColonSource/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
@@ -15,11 +16,11 @@ export type LocationChecker = (args: { source: string, index: number, lineCheckS
  * @param opts - The options object.
  */
 export function declarationColonSpaceChecker (opts: {
-	root: import("postcss").Root,
+	root: Root,
 	locationChecker: LocationChecker,
-	fix?: ((decl: import("postcss").Declaration, index: number) => void),
-	isFixable?: ((decl: import("postcss").Declaration, index: number) => boolean),
-	result: import("stylelint").PostcssResult,
+	fix?: ((decl: Declaration, index: number) => void),
+	isFixable?: ((decl: Declaration, index: number) => boolean),
+	result: PostcssResult,
 	checkedRuleName: string,
 }): void {
 	let { fix } = opts

--- a/lib/utils/declarationString/index.test.ts
+++ b/lib/utils/declarationString/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Declaration, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
@@ -31,8 +31,8 @@ describe(`declarationString`, () => {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function decl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function decl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parse(css).walkDecls((d) => {
 		list.push(d)
@@ -46,8 +46,8 @@ function decl (css: string): import("postcss").Declaration {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function scssDecl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function scssDecl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parseScss(css).walkDecls((d) => {
 		list.push(d)

--- a/lib/utils/declarationString/index.ts
+++ b/lib/utils/declarationString/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 
@@ -10,7 +12,7 @@ import { getDeclarationValue } from "../getDeclarationValue/index.ts"
  * @param decl - The declaration to print.
  * @returns The declaration, from its property to the end of its bang, if it has one.
  */
-export function declarationString (decl: import("postcss").Declaration): string {
+export function declarationString (decl: Declaration): string {
 	let important = decl.important ? (decl.raws.important || ` !important`) : ``
 
 	// Only the value is spelled in two copies: the property and everything between it and the value are printed as they stand, so the string PostCSS prints holds them exactly as the file does

--- a/lib/utils/declarationValueIndex/index.test.ts
+++ b/lib/utils/declarationValueIndex/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Declaration, parse } from "postcss"
 import { describe, expect, it } from "vitest"
 
 import { declarationValueIndex } from "./index.ts"
@@ -30,8 +30,8 @@ describe(`declarationValueIndex`, () => {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function decl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function decl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parse(css).walkDecls((d) => {
 		list.push(d)

--- a/lib/utils/declarationValueIndex/index.ts
+++ b/lib/utils/declarationValueIndex/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 import { isObject, isString } from "../validateTypes/index.ts"
 
 /**
@@ -5,7 +7,7 @@ import { isObject, isString } from "../validateTypes/index.ts"
  * @param decl - The CSS declaration node.
  * @returns The starting index of the declaration's value.
  */
-export function declarationValueIndex (decl: import("postcss").Declaration): number {
+export function declarationValueIndex (decl: Declaration): number {
 	let raws = decl.raws
 	let prop = raws.prop
 	let count = 0

--- a/lib/utils/endsWithInlineComment/index.ts
+++ b/lib/utils/endsWithInlineComment/index.ts
@@ -1,4 +1,5 @@
 import { LINE_BREAK, OPENS_WITH_QUOTE, URL_CALL_AT_END } from "../../regexps.ts"
+import type { InlineCommentReading } from "../readsInlineComments/index.ts"
 
 /** Where a scan stands: what it is reading, how far it has read, the quote that would close the string it is inside, and the pattern that closes the comment it may be inside. */
 export type Scan = { state: `blockComment` | `code` | `inlineComment` | `string` | `url`, index: number, openingQuote: string }
@@ -122,7 +123,7 @@ function scanEndsInsideInlineComment (text: string): boolean {
  * @param reading - What the syntax that spelled the string makes of such a comment, defaulted to a syntax that has said nothing.
  * @returns True if the string ends with an inline comment.
  */
-export function endsWithInlineComment (source: string, reading: import("../readsInlineComments/index.ts").InlineCommentReading = NOTHING_SAID): boolean {
+export function endsWithInlineComment (source: string, reading: InlineCommentReading = NOTHING_SAID): boolean {
 	// Where no double slash opens a comment, no text ends with one, and the scan below has nothing else it could answer with
 	if (!reading.spells) return false
 

--- a/lib/utils/endsWithInlineComment/index.ts
+++ b/lib/utils/endsWithInlineComment/index.ts
@@ -2,7 +2,11 @@ import { LINE_BREAK, OPENS_WITH_QUOTE, URL_CALL_AT_END } from "../../regexps.ts"
 import type { InlineCommentReading } from "../readsInlineComments/index.ts"
 
 /** Where a scan stands: what it is reading, how far it has read, the quote that would close the string it is inside, and the pattern that closes the comment it may be inside. */
-export type Scan = { state: `blockComment` | `code` | `inlineComment` | `string` | `url`, index: number, openingQuote: string }
+export type Scan = {
+	state: `blockComment` | `code` | `inlineComment` | `string` | `url`,
+	index: number,
+	openingQuote: string,
+}
 
 /**
  * Reads one character of an inline comment.

--- a/lib/utils/findCommentSpans/index.ts
+++ b/lib/utils/findCommentSpans/index.ts
@@ -96,7 +96,11 @@ function skipString (text: string, openIndex: number): number {
 }
 
 /** The span a comment occupies in a text, in the coordinates of that text, and which of the two kinds it is. */
-export type CommentSpan = { start: number, end: number, isInline: boolean }
+export type CommentSpan = {
+	start: number,
+	end: number,
+	isInline: boolean,
+}
 
 /**
  * Finds the spans the comments of a text occupy in it, block comments and inline ones alike. A double slash belonging to an address opens no comment, whether the address is quoted or bare inside `url()`, and neither does a slash an escape spells wherever it stands; a block comment runs to its `*\/` and an inline one to the end of its line.

--- a/lib/utils/findFunctionArgumentSpans/index.ts
+++ b/lib/utils/findFunctionArgumentSpans/index.ts
@@ -82,7 +82,11 @@ function readName (text: string, runStart: number | null, runEnd: number, index:
 }
 
 /** The span the arguments of one function call occupy in a text, from the character behind its opening parenthesis to its closing one, under the name the call was made by. */
-export type FunctionArgumentSpan = { start: number, end: number, name: string }
+export type FunctionArgumentSpan = {
+	start: number,
+	end: number,
+	name: string,
+}
 
 /**
  * Finds the spans the arguments of the function calls of a text occupy in it.
@@ -98,7 +102,10 @@ export type FunctionArgumentSpan = { start: number, end: number, name: string }
 export function findFunctionArgumentSpans (text: string): FunctionArgumentSpan[] {
 	let spans: FunctionArgumentSpan[] = []
 
-	let openings: ({ start: number, name: string } | null)[] = []
+	let openings: ({
+		start: number,
+		name: string,
+	} | null)[] = []
 	let index = 0
 
 	let runStart: number | null = null

--- a/lib/utils/findInlineCommentSpans/index.ts
+++ b/lib/utils/findInlineCommentSpans/index.ts
@@ -3,7 +3,11 @@ import type { Node } from "postcss-value-parser"
 import { findCommentSpans } from "../findCommentSpans/index.ts"
 
 /** The span an inline comment occupies in a value, in the coordinates of the file, and how far the copy a syntax rewrote its comments in has run away from that value by the end of the comment. */
-export type InlineCommentSpan = { start: number, end: number, delta?: number }
+export type InlineCommentSpan = {
+	start: number,
+	end: number,
+	delta?: number,
+}
 
 /**
  * Finds the spans the inline comments of a string occupy in it. A double slash belonging to an address opens no comment, whether the address is quoted or bare inside `url()`, and neither does one inside a block comment; a comment ends with its line rather than with the string.

--- a/lib/utils/findInlineCommentSpans/index.ts
+++ b/lib/utils/findInlineCommentSpans/index.ts
@@ -1,3 +1,5 @@
+import type { Node } from "postcss-value-parser"
+
 import { findCommentSpans } from "../findCommentSpans/index.ts"
 
 /** The span an inline comment occupies in a value, in the coordinates of the file, and how far the copy a syntax rewrote its comments in has run away from that value by the end of the comment. */
@@ -39,7 +41,7 @@ export function findInlineCommentSpanAt (index: number, spans: InlineCommentSpan
  * @param spans - The spans {@link findInlineCommentSpans} found in the text the node was parsed from, which the node's positions count in.
  * @returns The span holding the node, or nothing where the node is one of the value.
  */
-export function findInlineCommentSpanHolding (valueNode: import("postcss-value-parser").Node, spans: InlineCommentSpan[]): InlineCommentSpan | undefined {
+export function findInlineCommentSpanHolding (valueNode: Node, spans: InlineCommentSpan[]): InlineCommentSpan | undefined {
 	return findInlineCommentSpanAt(valueNode.sourceIndex, spans)
 }
 
@@ -53,6 +55,6 @@ export function findInlineCommentSpanHolding (valueNode: import("postcss-value-p
  * @param spans - The spans {@link findInlineCommentSpans} found in the text the node was parsed from, which the node's positions count in.
  * @returns The span the node overlaps, or nothing where the node carries no comment's text.
  */
-export function findInlineCommentSpanTouching (valueNode: Pick<import("postcss-value-parser").Node, `sourceIndex` | `sourceEndIndex`>, spans: InlineCommentSpan[]): InlineCommentSpan | undefined {
+export function findInlineCommentSpanTouching (valueNode: Pick<Node, `sourceIndex` | `sourceEndIndex`>, spans: InlineCommentSpan[]): InlineCommentSpan | undefined {
 	return spans.find(({ start, end }) => valueNode.sourceIndex < end && valueNode.sourceEndIndex > start)
 }

--- a/lib/utils/findInterpolationSpans/index.test.ts
+++ b/lib/utils/findInterpolationSpans/index.test.ts
@@ -9,7 +9,12 @@ import { findInterpolationSpans, findInterpolationSpanTouching } from "./index.t
  * @param type - What the parser calls the node.
  * @returns The node.
  */
-function node (text: string, run: string, type: string = `word`): { type: string, value: string, sourceIndex: number, sourceEndIndex: number } {
+function node (text: string, run: string, type: string = `word`): {
+	type: string,
+	value: string,
+	sourceIndex: number,
+	sourceEndIndex: number,
+} {
 	let sourceIndex = text.indexOf(run)
 
 	return { type, value: run, sourceIndex, sourceEndIndex: sourceIndex + run.length }

--- a/lib/utils/findInterpolationSpans/index.ts
+++ b/lib/utils/findInterpolationSpans/index.ts
@@ -1,3 +1,5 @@
+import type { Node } from "postcss-value-parser"
+
 import { EVERY_INTERPOLATION } from "../../regexps.ts"
 
 /** The span an interpolation occupies in a text, counted in that text. */
@@ -26,6 +28,6 @@ export function findInterpolationSpans (text: string): InterpolationSpan[] {
  * @param spans - The spans {@link findInterpolationSpans} found in the text the node was parsed from, which the node's positions count in.
  * @returns The span the node touches, or nothing where the node carries no interpolation's text.
  */
-export function findInterpolationSpanTouching (valueNode: Pick<import("postcss-value-parser").Node, `sourceIndex` | `sourceEndIndex`> & { type?: string, value?: string }, spans: InterpolationSpan[]): InterpolationSpan | undefined {
+export function findInterpolationSpanTouching (valueNode: Pick<Node, `sourceIndex` | `sourceEndIndex`> & { type?: string, value?: string }, spans: InterpolationSpan[]): InterpolationSpan | undefined {
 	return spans.find(({ start, end }) => valueNode.sourceIndex < end && valueNode.sourceEndIndex > start)
 }

--- a/lib/utils/findInterpolationSpans/index.ts
+++ b/lib/utils/findInterpolationSpans/index.ts
@@ -3,7 +3,10 @@ import type { Node } from "postcss-value-parser"
 import { EVERY_INTERPOLATION } from "../../regexps.ts"
 
 /** The span an interpolation occupies in a text, counted in that text. */
-export type InterpolationSpan = { start: number, end: number }
+export type InterpolationSpan = {
+	start: number,
+	end: number,
+}
 
 /**
  * Finds the spans the interpolations of a text occupy in it.
@@ -28,6 +31,9 @@ export function findInterpolationSpans (text: string): InterpolationSpan[] {
  * @param spans - The spans {@link findInterpolationSpans} found in the text the node was parsed from, which the node's positions count in.
  * @returns The span the node touches, or nothing where the node carries no interpolation's text.
  */
-export function findInterpolationSpanTouching (valueNode: Pick<Node, `sourceIndex` | `sourceEndIndex`> & { type?: string, value?: string }, spans: InterpolationSpan[]): InterpolationSpan | undefined {
+export function findInterpolationSpanTouching (valueNode: Pick<Node, `sourceIndex` | `sourceEndIndex`> & {
+	type?: string,
+	value?: string,
+}, spans: InterpolationSpan[]): InterpolationSpan | undefined {
 	return spans.find(({ start, end }) => valueNode.sourceIndex < end && valueNode.sourceEndIndex > start)
 }

--- a/lib/utils/findMediaFeatureNames/index.ts
+++ b/lib/utils/findMediaFeatureNames/index.ts
@@ -1,12 +1,10 @@
 import { isSimpleBlockNode, isTokenNode, parseCommaSeparatedListOfComponentValues } from "@csstools/css-parser-algorithms"
-import { isToken, stringify, tokenize, TokenType } from "@csstools/css-tokenizer"
-import { isGeneralEnclosed, isMediaFeature, isMediaQueryInvalid, parseFromTokens } from "@csstools/media-query-list-parser"
+import { type CSSToken, isToken, stringify, type TokenIdent, tokenize, TokenType } from "@csstools/css-tokenizer"
+import { type GeneralEnclosed, isGeneralEnclosed, isMediaFeature, isMediaQueryInvalid, type MediaQuery, parseFromTokens } from "@csstools/media-query-list-parser"
 
 import { RANGE_FEATURE_OPERATOR } from "../../regexps.ts"
 
-export type MediaQueryList = Array<import("@csstools/media-query-list-parser").MediaQuery>
-
-export type TokenIdent = import("@csstools/css-tokenizer").TokenIdent
+export type MediaQueryList = Array<MediaQuery>
 
 export type MediaQuerySerializer = { stringify: () => string }
 
@@ -15,12 +13,12 @@ export type MediaQuerySerializer = { stringify: () => string }
  * @param node - The node to extract tokens from.
  * @returns Array of relevant CSS tokens.
  */
-function topLevelTokenNodes (node: import("@csstools/media-query-list-parser").GeneralEnclosed): Array<import("@csstools/css-tokenizer").CSSToken> {
+function topLevelTokenNodes (node: GeneralEnclosed): Array<CSSToken> {
 	let components = node.value.value
 
 	if (isToken(components) || components.length === 0 || isToken(components[0])) return []
 
-	let relevantTokens: Array<import("@csstools/css-tokenizer").CSSToken> = []
+	let relevantTokens: Array<CSSToken> = []
 
 	// To consume the next token if it is a scss variable
 	let lastWasDollarSign = false

--- a/lib/utils/findMediaOperator/index.ts
+++ b/lib/utils/findMediaOperator/index.ts
@@ -1,4 +1,6 @@
-import styleSearch from "style-search"
+import type { AtRule } from "postcss"
+import styleSearch, { type StyleSearchMatch } from "style-search"
+import type { PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
@@ -8,15 +10,13 @@ import { searchCopy } from "../searchCopy/index.ts"
 // `styleSearch` tries the targets in the order they are given and reports the first that matches, so the two-character operators stand in front of the one-character ones and `>=` is read whole rather than as a `>` with an `=` behind it
 const RANGE_OPERATORS = [`>=`, `<=`, `>`, `<`, `=`]
 
-export type StyleSearchMatch = import("style-search").StyleSearchMatch
-
 /**
  * Finds media operator matches in an at-rule and invokes a callback for each.
  * @param atRule - The at-rule to search.
  * @param result - The Stylelint result, which the syntax of the file is read from.
  * @param cb - The callback to invoke for each match.
  */
-export function findMediaOperator<T extends import("postcss").AtRule> (atRule: T, result: import("stylelint").PostcssResult, cb: (match: StyleSearchMatch, params: string, atRule: T) => void): void {
+export function findMediaOperator<T extends AtRule> (atRule: T, result: PostcssResult, cb: (match: StyleSearchMatch, params: string, atRule: T) => void): void {
 	if (atRule.name.toLowerCase() !== `media`) return
 
 	let params = getAtRuleParams(atRule)

--- a/lib/utils/findSelectorBlockComments/index.ts
+++ b/lib/utils/findSelectorBlockComments/index.ts
@@ -7,7 +7,10 @@ import { EVERY_ESCAPE_STRING_OR_BLOCK_COMMENT } from "../../regexps.ts"
  * @param selector - The selector to read.
  * @returns The comments, in the order they stand in.
  */
-export function findSelectorBlockComments (selector: string): Array<{ start: number, end: number }> {
+export function findSelectorBlockComments (selector: string): Array<{
+	start: number,
+	end: number,
+}> {
 	let comments = []
 
 	for (let match of selector.matchAll(EVERY_ESCAPE_STRING_OR_BLOCK_COMMENT)) {

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -1,7 +1,8 @@
-import valueParser from "postcss-value-parser"
-import stylelint from "stylelint"
+import type { Root } from "postcss"
+import valueParser, { type DivNode as ValueParserDivNode, type FunctionNode as ValueParserFunctionNode } from "postcss-value-parser"
+import stylelint, { type PostcssResult } from "stylelint"
 
-import { applyEditsFromEnd } from "../applyEditsFromEnd/index.ts"
+import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../findCommentSpans/index.ts"
@@ -17,10 +18,6 @@ import { commentsRemovedBefore, withoutComments } from "../withoutComments/index
 
 let { utils: { report } } = stylelint
 
-export type Edit = import("../applyEditsFromEnd/index.ts").Edit
-export type ValueParserFunctionNode = import("postcss-value-parser").FunctionNode
-export type ValueParserDivNode = import("postcss-value-parser").DivNode
-
 /** A function that checks whitespace at a specific location. */
 export type LocationChecker = (args: { source: string, index: number, err: (message: string) => void }) => void
 
@@ -29,10 +26,10 @@ export type LocationChecker = (args: { source: string, index: number, err: (mess
  * @param opts - The options object.
  */
 export function functionCommaSpaceChecker (opts: {
-	root: import("postcss").Root,
+	root: Root,
 	locationChecker: LocationChecker,
 	fix?: ((node: ValueParserDivNode, index: number, functionNode: ValueParserFunctionNode) => Edit[]),
-	result: import("stylelint").PostcssResult,
+	result: PostcssResult,
 	checkedRuleName: string,
 	fixPosition?: `before` | `after`,
 	ignoreFunctions?: string | RegExp | Array<string | RegExp>,

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -19,7 +19,11 @@ import { commentsRemovedBefore, withoutComments } from "../withoutComments/index
 let { utils: { report } } = stylelint
 
 /** A function that checks whitespace at a specific location. */
-export type LocationChecker = (args: { source: string, index: number, err: (message: string) => void }) => void
+export type LocationChecker = (args: {
+	source: string,
+	index: number,
+	err: (message: string) => void,
+}) => void
 
 /**
  * Checks whitespace around commas in function arguments.
@@ -94,7 +98,11 @@ export function functionCommaSpaceChecker (opts: {
 				return commaIndex - commentsRemovedBefore(hiddenArguments, commaIndex, commentSpans)
 			}
 
-			let commaDataList: { commaNode: ValueParserDivNode, checkIndex: number, nodeIndex: number }[] = []
+			let commaDataList: {
+				commaNode: ValueParserDivNode,
+				checkIndex: number,
+				nodeIndex: number,
+			}[] = []
 
 			for (let [nodeIndex, node] of valueNode.nodes.entries()) {
 				if (node.type !== `div` || node.value !== `,`) continue

--- a/lib/utils/functionCommaSpaceFix/index.ts
+++ b/lib/utils/functionCommaSpaceFix/index.ts
@@ -1,6 +1,6 @@
-export type Edit = import("../applyEditsFromEnd/index.ts").Edit
-export type ValueParserDivNode = import("postcss-value-parser").DivNode
-export type ValueParserFunctionNode = import("postcss-value-parser").FunctionNode
+import type { DivNode as ValueParserDivNode, FunctionNode as ValueParserFunctionNode } from "postcss-value-parser"
+
+import type { Edit } from "../applyEditsFromEnd/index.ts"
 
 /**
  * Measures the whitespace run standing on one side of a comma that the comma itself does not hold.

--- a/lib/utils/getAtRuleParams/index.test.ts
+++ b/lib/utils/getAtRuleParams/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type AtRule, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
@@ -31,8 +31,8 @@ describe(`getAtRuleParams`, () => {
  * @param css - The stylesheet.
  * @returns That at-rule.
  */
-function atRule (css: string): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function atRule (css: string): AtRule {
+	let list: AtRule[] = []
 
 	parse(css).walkAtRules((rule) => {
 		list.push(rule)
@@ -46,8 +46,8 @@ function atRule (css: string): import("postcss").AtRule {
  * @param css - The stylesheet.
  * @returns That at-rule.
  */
-function scssAtRule (css: string): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function scssAtRule (css: string): AtRule {
+	let list: AtRule[] = []
 
 	parseScss(css).walkAtRules((rule) => {
 		list.push(rule)

--- a/lib/utils/getAtRuleParams/index.ts
+++ b/lib/utils/getAtRuleParams/index.ts
@@ -1,3 +1,5 @@
+import type { AtRule } from "postcss"
+
 /**
  * Gets the params of an at-rule, spelled as the file spells them.
  *
@@ -5,8 +7,10 @@
  * @param atRule - The at-rule node.
  * @returns The params, spelled as the file spells them.
  */
-export function getAtRuleParams (atRule: import("postcss").AtRule): string {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = atRule.raws.params
+import type { SyntaxRaw } from "../typeGuards/index.ts"
+
+export function getAtRuleParams (atRule: AtRule): string {
+	let syntaxRaw: SyntaxRaw | undefined = atRule.raws.params
 
 	if (!syntaxRaw) return atRule.params
 

--- a/lib/utils/getBlockAfter/index.test.ts
+++ b/lib/utils/getBlockAfter/index.test.ts
@@ -1,4 +1,4 @@
-import { atRule, decl, parse, rule } from "postcss"
+import { atRule, type Container, decl, parse, type Parser, rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -53,8 +53,8 @@ describe(`getBlockAfter`, () => {
  * @param syntax - The syntax to read it with, where plain CSS is not the one.
  * @returns What the util answers.
  */
-function run (css: string, syntax?: { parse: import("postcss").Parser }): ReturnType<typeof getBlockAfter> {
+function run (css: string, syntax?: { parse: Parser }): ReturnType<typeof getBlockAfter> {
 	let root = syntax ? syntax.parse(css) : parse(css)
 
-	return getBlockAfter(root.first as import("postcss").Container)
+	return getBlockAfter(root.first as Container)
 }

--- a/lib/utils/getBlockAfter/index.ts
+++ b/lib/utils/getBlockAfter/index.ts
@@ -1,3 +1,5 @@
+import type { Container } from "postcss"
+
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { lastNodeHoldsTheBlockAfter } from "../lastNodeHoldsTheBlockAfter/index.ts"
 
@@ -8,7 +10,7 @@ import { lastNodeHoldsTheBlockAfter } from "../lastNodeHoldsTheBlockAfter/index.
  * @param statement - The statement carrying the block.
  * @returns The run, undefined where the block carries no raw for it.
  */
-export function getBlockAfter (statement: import("postcss").Container): string | undefined {
+export function getBlockAfter (statement: Container): string | undefined {
 	if (!lastNodeHoldsTheBlockAfter(statement)) return statement.raws.after
 
 	let between = statement.last.raws.between ?? ``

--- a/lib/utils/getDeclarationValue/index.test.ts
+++ b/lib/utils/getDeclarationValue/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Declaration, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
@@ -35,8 +35,8 @@ describe(`getDeclarationValue`, () => {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function decl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function decl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parse(css).walkDecls((d) => {
 		list.push(d)
@@ -50,8 +50,8 @@ function decl (css: string): import("postcss").Declaration {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function scssDecl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function scssDecl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parseScss(css).walkDecls((d) => {
 		list.push(d)

--- a/lib/utils/getDeclarationValue/index.ts
+++ b/lib/utils/getDeclarationValue/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 /**
  * Gets the value of a CSS declaration, spelled as the file spells it.
  *
@@ -5,8 +7,10 @@
  * @param decl - The CSS declaration node.
  * @returns The declaration value, including raw whitespace.
  */
-export function getDeclarationValue (decl: import("postcss").Declaration): string {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = decl.raws.value
+import type { SyntaxRaw } from "../typeGuards/index.ts"
+
+export function getDeclarationValue (decl: Declaration): string {
+	let syntaxRaw: SyntaxRaw | undefined = decl.raws.value
 
 	if (!syntaxRaw) return decl.value
 

--- a/lib/utils/getDimension/index.ts
+++ b/lib/utils/getDimension/index.ts
@@ -1,4 +1,4 @@
-import valueParser from "postcss-value-parser"
+import valueParser, { type Node } from "postcss-value-parser"
 
 import { EVERY_INTERPOLATION_CHARACTER } from "../../regexps.ts"
 import { isStandardSyntaxValue } from "../isStandardSyntaxValue/index.ts"
@@ -8,7 +8,7 @@ import { isStandardSyntaxValue } from "../isStandardSyntaxValue/index.ts"
  * @param node - The value parser node, or nothing at all.
  * @returns The dimension object, or null values where the node carries no dimension.
  */
-export function getDimension (node?: Partial<import("postcss-value-parser").Node>): { unit: null, number: null, positions: null } | (valueParser.Dimension & { positions: number[] }) {
+export function getDimension (node?: Partial<Node>): { unit: null, number: null, positions: null } | (valueParser.Dimension & { positions: number[] }) {
 	if (!node || !node.value) {
 		return {
 			unit: null,

--- a/lib/utils/getDimension/index.ts
+++ b/lib/utils/getDimension/index.ts
@@ -8,7 +8,11 @@ import { isStandardSyntaxValue } from "../isStandardSyntaxValue/index.ts"
  * @param node - The value parser node, or nothing at all.
  * @returns The dimension object, or null values where the node carries no dimension.
  */
-export function getDimension (node?: Partial<Node>): { unit: null, number: null, positions: null } | (valueParser.Dimension & { positions: number[] }) {
+export function getDimension (node?: Partial<Node>): {
+	unit: null,
+	number: null,
+	positions: null,
+} | (valueParser.Dimension & { positions: number[] }) {
 	if (!node || !node.value) {
 		return {
 			unit: null,

--- a/lib/utils/getLineBreak/index.test.ts
+++ b/lib/utils/getLineBreak/index.test.ts
@@ -1,4 +1,5 @@
-import { parse, rule } from "postcss"
+import { parse, type Rule, rule } from "postcss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { getLineBreak } from "./index.ts"
@@ -48,7 +49,7 @@ describe(`getLineBreak`, () => {
 function ask (css: string, rules: Record<string, unknown> = {}): string {
 	let root = parse(css)
 
-	return getLineBreak(root.first as import("postcss").Rule, result(rules))
+	return getLineBreak(root.first as Rule, result(rules))
 }
 
 /**
@@ -56,6 +57,6 @@ function ask (css: string, rules: Record<string, unknown> = {}): string {
  * @param rules - The rules the configuration lists.
  * @returns The result.
  */
-function result (rules: Record<string, unknown> = {}): import("stylelint").PostcssResult {
-	return { stylelint: { config: { rules } } } as unknown as import("stylelint").PostcssResult
+function result (rules: Record<string, unknown> = {}): PostcssResult {
+	return { stylelint: { config: { rules } } } as unknown as PostcssResult
 }

--- a/lib/utils/getLineBreak/index.ts
+++ b/lib/utils/getLineBreak/index.ts
@@ -1,3 +1,6 @@
+import type { Input, Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { CAPTURED_LINE_BREAK } from "../../regexps.ts"
 
 /** The setting of the one rule about the spelling of a break, under the name a configuration lists it by. */
@@ -7,7 +10,7 @@ const LINEBREAKS_RULE = `@stylistic/linebreaks`
 const BREAK_OF_OPTION = { unix: `\n`, windows: `\r\n` }
 
 /** What each file was found to end its lines with, kept against the input it was read out of, so that a file is scanned once however many fixes ask about it. */
-let lineBreaks: WeakMap<import("postcss").Input, string | undefined> = new WeakMap()
+let lineBreaks: WeakMap<Input, string | undefined> = new WeakMap()
 
 /**
  * Reads what a file ends its lines with, off the text the syntax was handed rather than off anything PostCSS prints back.
@@ -16,7 +19,7 @@ let lineBreaks: WeakMap<import("postcss").Input, string | undefined> = new WeakM
  * @param node - A node of the file being asked about.
  * @returns The break the file ends its lines with, or `undefined` where nothing can be read: a file written on one line, and a node standing in no file at all, which is one made by hand.
  */
-function lineBreakOfFile (node: import("postcss").Node): string | undefined {
+function lineBreakOfFile (node: Node): string | undefined {
 	let input = node.root().source?.input
 
 	if (!input) return
@@ -41,7 +44,7 @@ function lineBreakOfFile (node: import("postcss").Node): string | undefined {
  * @param result - The Stylelint result, which holds the configuration.
  * @returns The break to write.
  */
-export function getLineBreak (node: import("postcss").Node, result: import("stylelint").PostcssResult): string {
+export function getLineBreak (node: Node, result: PostcssResult): string {
 	let setting = result.stylelint?.config?.rules?.[LINEBREAKS_RULE]
 	let option = Array.isArray(setting) ? setting[0] : setting
 

--- a/lib/utils/getRuleSelector/index.test.ts
+++ b/lib/utils/getRuleSelector/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Document, parse, type Root, type Rule } from "postcss"
 import { parse as parseLess } from "postcss-less"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -28,7 +28,7 @@ describe(`getRuleSelector`, () => {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function rule (css: string): import("postcss").Rule {
+function rule (css: string): Rule {
 	return collect(parse(css))
 }
 
@@ -37,7 +37,7 @@ function rule (css: string): import("postcss").Rule {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function scssRule (css: string): import("postcss").Rule {
+function scssRule (css: string): Rule {
 	return collect(parseScss(css))
 }
 
@@ -46,7 +46,7 @@ function scssRule (css: string): import("postcss").Rule {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function lessRule (css: string): import("postcss").Rule {
+function lessRule (css: string): Rule {
 	return collect(parseLess(css))
 }
 
@@ -55,8 +55,8 @@ function lessRule (css: string): import("postcss").Rule {
  * @param root - The parsed stylesheet.
  * @returns That rule.
  */
-function collect (root: import("postcss").Root | import("postcss").Document): import("postcss").Rule {
-	let list: import("postcss").Rule[] = []
+function collect (root: Root | Document): Rule {
+	let list: Rule[] = []
 
 	root.walkRules((node) => {
 		list.push(node)

--- a/lib/utils/getRuleSelector/index.ts
+++ b/lib/utils/getRuleSelector/index.ts
@@ -1,3 +1,5 @@
+import type { Rule } from "postcss"
+
 /**
  * Gets the selector of a rule, spelled as the file spells it.
  *
@@ -5,8 +7,10 @@
  * @param rule - The rule node.
  * @returns The selector, spelled as the file spells it.
  */
-export function getRuleSelector (rule: import("postcss").Rule): string {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = rule.raws.selector
+import type { SyntaxRaw } from "../typeGuards/index.ts"
+
+export function getRuleSelector (rule: Rule): string {
+	let syntaxRaw: SyntaxRaw | undefined = rule.raws.selector
 
 	if (!syntaxRaw) return rule.selector
 

--- a/lib/utils/hasBlock/index.test.ts
+++ b/lib/utils/hasBlock/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Container, parse } from "postcss"
 import { expect, it } from "vitest"
 
 import { hasBlock } from "./index.ts"
@@ -38,5 +38,5 @@ it(`hasBlock`, () => {
 function postcssCheck (cssString: string): boolean {
 	let root = parse(cssString)
 
-	return hasBlock(root.first as import("postcss").Container)
+	return hasBlock(root.first as Container)
 }

--- a/lib/utils/hasBlock/index.ts
+++ b/lib/utils/hasBlock/index.ts
@@ -1,8 +1,10 @@
+import type { ChildNode, Node } from "postcss"
+
 /**
  * Checks if a statement has a block (empty or otherwise).
  * @param statement - The PostCSS container node.
  * @returns True if the `statement` has a block (empty or otherwise).
  */
-export function hasBlock<T extends import("postcss").Node> (statement: T): statement is T & { nodes: import("postcss").ChildNode[] } {
+export function hasBlock<T extends Node> (statement: T): statement is T & { nodes: ChildNode[] } {
 	return `nodes` in statement && statement.nodes !== undefined
 }

--- a/lib/utils/hasEmptyBlock/index.test.ts
+++ b/lib/utils/hasEmptyBlock/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { parse, type Rule } from "postcss"
 import { expect, it } from "vitest"
 
 import { hasEmptyBlock } from "./index.ts"
@@ -37,5 +37,5 @@ it(`hasEmptyBlock`, () => {
 function postcssCheck (cssString: string): boolean {
 	let root = parse(cssString)
 
-	return hasEmptyBlock(root.first as import("postcss").Rule)
+	return hasEmptyBlock(root.first as Rule)
 }

--- a/lib/utils/hasEmptyBlock/index.ts
+++ b/lib/utils/hasEmptyBlock/index.ts
@@ -1,3 +1,5 @@
+import type { AtRule, Rule } from "postcss"
+
 import { hasBlock } from "../hasBlock/index.ts"
 
 /**
@@ -5,6 +7,6 @@ import { hasBlock } from "../hasBlock/index.ts"
  * @param statement - The PostCSS rule or at-rule node.
  * @returns True if the statement has a block and it is empty.
  */
-export function hasEmptyBlock (statement: import("postcss").Rule | import("postcss").AtRule): boolean {
+export function hasEmptyBlock (statement: Rule | AtRule): boolean {
 	return hasBlock(statement) && statement.nodes.length === 0
 }

--- a/lib/utils/hideFalseInlineComments/index.ts
+++ b/lib/utils/hideFalseInlineComments/index.ts
@@ -1,6 +1,5 @@
-import { findCommentSpans } from "../findCommentSpans/index.ts"
-
-export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
+import { type CommentSpan, findCommentSpans } from "../findCommentSpans/index.ts"
+import type { InlineCommentSpan } from "../findInlineCommentSpans/index.ts"
 
 /**
  * Spells every double slash that opens no comment out of harm's way, so that a reader which knows less about the text than {@link findCommentSpans} does cannot take one for a comment.
@@ -12,7 +11,7 @@ export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
  * @param spans - The spans the comments of the text occupy in it, both kinds of them, where they are already known. A caller that leaves one out leaves the slash it opens on unguarded.
  * @returns The text, with the second slash of every false comment opening written as a question mark.
  */
-export function hideFalseInlineComments (text: string, spans: (CommentSpan | import("../findInlineCommentSpans/index.ts").InlineCommentSpan)[] = findCommentSpans(text)): string {
+export function hideFalseInlineComments (text: string, spans: (CommentSpan | InlineCommentSpan)[] = findCommentSpans(text)): string {
 	let openings = new Set(spans.map(({ start }) => start))
 	// The characters are taken apart only where there is something to write over, and a text carrying no false opening — every text holding no double slash among them — is handed back as it came
 	let hidden = null

--- a/lib/utils/isInlineStyleAttribute/index.test.ts
+++ b/lib/utils/isInlineStyleAttribute/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Container, parse, type Parser } from "postcss"
 import postcssHtml from "postcss-html"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest"
 import { isInlineStyleAttribute } from "./index.ts"
 
 /** The syntax as its own declaration should spell it: the parser is always there, whatever the optional field says. */
-let html = postcssHtml as { parse: import("postcss").Parser }
+let html = postcssHtml as { parse: Parser }
 
 describe(`isInlineStyleAttribute`, () => {
 	it(`the root of a style attribute`, () => {
@@ -38,11 +38,11 @@ describe(`isInlineStyleAttribute`, () => {
  * @param code - The code to parse.
  * @returns One verdict per declaration, in document order.
  */
-function parentsOf (syntax: { parse: import("postcss").Parser }, code: string): boolean[] {
+function parentsOf (syntax: { parse: Parser }, code: string): boolean[] {
 	let verdicts: boolean[] = []
 
 	syntax.parse(code).walkDecls((decl) => {
-		verdicts.push(isInlineStyleAttribute(decl.parent as import("postcss").Container))
+		verdicts.push(isInlineStyleAttribute(decl.parent as Container))
 	})
 
 	return verdicts

--- a/lib/utils/isInlineStyleAttribute/index.ts
+++ b/lib/utils/isInlineStyleAttribute/index.ts
@@ -1,3 +1,5 @@
+import type { Container } from "postcss"
+
 import { isRoot } from "../typeGuards/index.ts"
 
 /**
@@ -5,7 +7,7 @@ import { isRoot } from "../typeGuards/index.ts"
  * @param container - The container node to check.
  * @returns True if the container is the root of a `style` attribute, false otherwise.
  */
-export function isInlineStyleAttribute (container: import("postcss").Container): boolean {
+export function isInlineStyleAttribute (container: Container): boolean {
 	if (!isRoot(container)) return false
 
 	let { source } = container

--- a/lib/utils/isLastDeclarationWithoutSemicolon/index.test.ts
+++ b/lib/utils/isLastDeclarationWithoutSemicolon/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Declaration, parse, type Rule } from "postcss"
 import { describe, expect, it } from "vitest"
 
 import { isLastDeclarationWithoutSemicolon } from "./index.ts"
@@ -8,10 +8,10 @@ import { isLastDeclarationWithoutSemicolon } from "./index.ts"
  * @param css - The stylesheet.
  * @returns The first declaration of the first block.
  */
-function firstDeclaration (css: string): import("postcss").Declaration {
-	let decl = (parse(css).first as import("postcss").Rule).nodes.find((node) => node.type === `decl`)
+function firstDeclaration (css: string): Declaration {
+	let decl = (parse(css).first as Rule).nodes.find((node) => node.type === `decl`)
 
-	return decl as import("postcss").Declaration
+	return decl as Declaration
 }
 
 describe(`isLastDeclarationWithoutSemicolon`, () => {
@@ -48,7 +48,7 @@ describe(`isLastDeclarationWithoutSemicolon`, () => {
 	})
 
 	it(`a declaration on the root, which has no block to close`, () => {
-		let decl = parse(`color: pink`).first as import("postcss").Declaration
+		let decl = parse(`color: pink`).first as Declaration
 
 		expect(isLastDeclarationWithoutSemicolon(decl)).toBe(true)
 	})

--- a/lib/utils/isLastDeclarationWithoutSemicolon/index.ts
+++ b/lib/utils/isLastDeclarationWithoutSemicolon/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 import { lastNonCommentNode } from "../lastNonCommentNode/index.ts"
 
 /**
@@ -7,7 +9,7 @@ import { lastNonCommentNode } from "../lastNonCommentNode/index.ts"
  * @param decl - The declaration to ask about.
  * @returns True where the declaration closes its block with no semicolon behind it.
  */
-export function isLastDeclarationWithoutSemicolon (decl: import("postcss").Declaration): boolean {
+export function isLastDeclarationWithoutSemicolon (decl: Declaration): boolean {
 	let parent = decl.parent
 
 	if (!parent || parent.raws.semicolon) return false

--- a/lib/utils/isLessDetachedRulesetCall/index.test.ts
+++ b/lib/utils/isLessDetachedRulesetCall/index.test.ts
@@ -1,3 +1,4 @@
+import type { AtRule } from "postcss"
 import postcssLess from "postcss-less"
 import { describe, expect, it } from "vitest"
 
@@ -47,8 +48,8 @@ describe(`isLessDetachedRulesetCall`, () => {
  * @param index - Which at-rule, counted in the order the walk meets them.
  * @returns That at-rule.
  */
-function lessAtRule (code: string, index: number = 0): import("postcss").AtRule {
-	let atRules: import("postcss").AtRule[] = []
+function lessAtRule (code: string, index: number = 0): AtRule {
+	let atRules: AtRule[] = []
 
 	postcssLess.parse(code).walkAtRules((atRule) => {
 		atRules.push(atRule)

--- a/lib/utils/isLessDetachedRulesetCall/index.ts
+++ b/lib/utils/isLessDetachedRulesetCall/index.ts
@@ -1,3 +1,6 @@
+import type { AtRule } from "postcss"
+import type { AtRule as LessAtRule } from "postcss-less"
+
 /**
  * Asks whether a node the parser handed over as an at-rule is a call to a Less detached ruleset — `@dr()`, where `@dr: { … }` stands somewhere above.
  *
@@ -13,7 +16,7 @@
  * @param atRule - The at-rule node to read.
  * @returns True where the node is a call to a detached ruleset.
  */
-export function isLessDetachedRulesetCall (atRule: import("postcss").AtRule | import("postcss-less").AtRule): boolean {
+export function isLessDetachedRulesetCall (atRule: AtRule | LessAtRule): boolean {
 	if (`mixin` in atRule && atRule.mixin) return false
 
 	return !atRule.nodes && atRule.raws.afterName === `` && atRule.params.startsWith(`()`)

--- a/lib/utils/isStandardSyntaxAtRule/index.test.ts
+++ b/lib/utils/isStandardSyntaxAtRule/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type AtRule, type Parser } from "postcss"
 import postcssLess from "postcss-less"
 import postcssScss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -110,8 +110,8 @@ describe(`isStandardSyntaxAtRule`, () => {
  * @param parser - The syntax to read it with.
  * @returns The at-rules, in the order the walk meets them.
  */
-function atRules (code: string, parser: { parse: import("postcss").Parser } = postcss): import("postcss").AtRule[] {
-	let rules: import("postcss").AtRule[] = []
+function atRules (code: string, parser: { parse: Parser } = postcss): AtRule[] {
+	let rules: AtRule[] = []
 
 	parser.parse(code).walkAtRules((rule) => {
 		rules.push(rule)
@@ -125,7 +125,7 @@ function atRules (code: string, parser: { parse: import("postcss").Parser } = po
  * @param code - The stylesheet.
  * @returns That at-rule.
  */
-function atRule (code: string): import("postcss").AtRule {
+function atRule (code: string): AtRule {
 	return atRules(code)[0]
 }
 
@@ -134,7 +134,7 @@ function atRule (code: string): import("postcss").AtRule {
  * @param code - The stylesheet.
  * @returns The at-rules.
  */
-function scssAtRules (code: string): import("postcss").AtRule[] {
+function scssAtRules (code: string): AtRule[] {
 	return atRules(code, postcssScss)
 }
 
@@ -143,6 +143,6 @@ function scssAtRules (code: string): import("postcss").AtRule[] {
  * @param code - The stylesheet.
  * @returns The at-rules.
  */
-function lessAtRules (code: string): import("postcss").AtRule[] {
+function lessAtRules (code: string): AtRule[] {
 	return atRules(code, postcssLess)
 }

--- a/lib/utils/isStandardSyntaxAtRule/index.ts
+++ b/lib/utils/isStandardSyntaxAtRule/index.ts
@@ -1,3 +1,6 @@
+import type { AtRule } from "postcss"
+import type { AtRule as LessAtRule } from "postcss-less"
+
 import { isLessDetachedRulesetCall } from "../isLessDetachedRulesetCall/index.ts"
 
 /**
@@ -5,7 +8,7 @@ import { isLessDetachedRulesetCall } from "../isLessDetachedRulesetCall/index.ts
  * @param atRule - The at-rule node to check.
  * @returns True if the at-rule is standard, false otherwise.
  */
-export function isStandardSyntaxAtRule (atRule: import("postcss").AtRule | import("postcss-less").AtRule): boolean {
+export function isStandardSyntaxAtRule (atRule: AtRule | LessAtRule): boolean {
 	// Ignore scss `@content` inside mixins
 	if (!atRule.nodes && atRule.params === ``) return false
 

--- a/lib/utils/isStandardSyntaxCombinator/index.test.ts
+++ b/lib/utils/isStandardSyntaxCombinator/index.test.ts
@@ -1,5 +1,5 @@
 import { parse } from "postcss"
-import selectorParser from "postcss-selector-parser"
+import selectorParser, { type Combinator } from "postcss-selector-parser"
 import { describe, expect, it } from "vitest"
 
 import { isStandardSyntaxCombinator } from "./index.ts"
@@ -7,7 +7,7 @@ import { isStandardSyntaxCombinator } from "./index.ts"
 describe(`isStandardSyntaxCombinator`, () => {
 	it(`tag`, () => {
 		// A node of the stylesheet rather than of a selector, which the util turns away by its type
-		expect(isStandardSyntaxCombinator(parse(`a {}`).first as unknown as import("postcss-selector-parser").Combinator)).toBe(false)
+		expect(isStandardSyntaxCombinator(parse(`a {}`).first as unknown as Combinator)).toBe(false)
 	})
 	it(`descendant`, () => {
 		expect(isStandardSyntaxCombinator(combinator(`a b {}`))).toBe(true)
@@ -58,8 +58,8 @@ describe(`isStandardSyntaxCombinator`, () => {
  * @param css - The stylesheet.
  * @returns That combinator.
  */
-function combinator (css: string): import("postcss-selector-parser").Combinator {
-	let list: import("postcss-selector-parser").Combinator[] = []
+function combinator (css: string): Combinator {
+	let list: Combinator[] = []
 
 	parse(css).walkRules((rule) => {
 		selectorParser((selectorAST) => {

--- a/lib/utils/isStandardSyntaxCombinator/index.ts
+++ b/lib/utils/isStandardSyntaxCombinator/index.ts
@@ -1,9 +1,11 @@
+import type { Combinator } from "postcss-selector-parser"
+
 /**
  * Checks whether a combinator is standard (i.e. not a reference combinator).
  * @param node - The combinator node to check.
  * @returns True if the combinator is standard, false otherwise.
  */
-export function isStandardSyntaxCombinator (node: import("postcss-selector-parser").Combinator): boolean {
+export function isStandardSyntaxCombinator (node: Combinator): boolean {
 	// if it's not a combinator, then it's not a standard combinator
 	if (node.type !== `combinator`) return false
 

--- a/lib/utils/isStandardSyntaxComment/index.test.ts
+++ b/lib/utils/isStandardSyntaxComment/index.test.ts
@@ -1,4 +1,4 @@
-import { parse as parseCss } from "postcss"
+import { type Comment, parse as parseCss } from "postcss"
 import { parse as parseLess } from "postcss-less"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -28,8 +28,8 @@ describe(`isStandardSyntaxComment`, () => {
  * @param code - The stylesheet.
  * @returns That comment.
  */
-function css (code: string): import("postcss").Comment {
-	return parseCss(code).first as import("postcss").Comment
+function css (code: string): Comment {
+	return parseCss(code).first as Comment
 }
 
 /**
@@ -37,8 +37,8 @@ function css (code: string): import("postcss").Comment {
  * @param code - The stylesheet.
  * @returns That comment.
  */
-function less (code: string): import("postcss").Comment {
-	return parseLess(code).first as import("postcss").Comment
+function less (code: string): Comment {
+	return parseLess(code).first as Comment
 }
 
 /**
@@ -46,6 +46,6 @@ function less (code: string): import("postcss").Comment {
  * @param code - The stylesheet.
  * @returns That comment.
  */
-function scss (code: string): import("postcss").Comment {
-	return parseScss(code).first as import("postcss").Comment
+function scss (code: string): Comment {
+	return parseScss(code).first as Comment
 }

--- a/lib/utils/isStandardSyntaxComment/index.ts
+++ b/lib/utils/isStandardSyntaxComment/index.ts
@@ -1,9 +1,11 @@
+import type { Comment } from "postcss"
+
 /**
  * Checks if a comment has standard syntax.
  * @param comment - The comment node to check.
  * @returns True if the comment has standard syntax, false otherwise.
  */
-export function isStandardSyntaxComment (comment: import("postcss").Comment): boolean {
+export function isStandardSyntaxComment (comment: Comment): boolean {
 	// Both are asked, since the Sass parser marks an inline comment with `raws.inline` and the Less parser with `inline`.
 	if (`inline` in comment) return false
 

--- a/lib/utils/isStandardSyntaxDeclaration/index.test.ts
+++ b/lib/utils/isStandardSyntaxDeclaration/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type Declaration, type Parser } from "postcss"
 import postcssLess from "postcss-less"
 import postcssScss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -137,8 +137,8 @@ describe(`isStandardSyntaxDeclaration`, () => {
  * @param parser - The syntax to read it with.
  * @returns That declaration.
  */
-function decl (css: string, parser: { parse: import("postcss").Parser } = postcss): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function decl (css: string, parser: { parse: Parser } = postcss): Declaration {
+	let list: Declaration[] = []
 
 	parser.parse(css).walkDecls((d) => {
 		list.push(d)
@@ -154,7 +154,7 @@ function decl (css: string, parser: { parse: import("postcss").Parser } = postcs
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function scssDecl (css: string): import("postcss").Declaration {
+function scssDecl (css: string): Declaration {
 	return decl(css, postcssScss)
 }
 
@@ -163,6 +163,6 @@ function scssDecl (css: string): import("postcss").Declaration {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function lessDecl (css: string): import("postcss").Declaration {
+function lessDecl (css: string): Declaration {
 	return decl(css, postcssLess)
 }

--- a/lib/utils/isStandardSyntaxDeclaration/index.ts
+++ b/lib/utils/isStandardSyntaxDeclaration/index.ts
@@ -1,3 +1,6 @@
+import type { Declaration } from "postcss"
+import type { Declaration as LessDeclaration } from "postcss-less"
+
 import { isScssVariable } from "../isScssVariable/index.ts"
 import { isRule } from "../typeGuards/index.ts"
 
@@ -6,7 +9,7 @@ import { isRule } from "../typeGuards/index.ts"
  * @param decl - The declaration node to check.
  * @returns True if the declaration is standard syntax, false otherwise.
  */
-export function isStandardSyntaxDeclaration (decl: import("postcss").Declaration | import("postcss-less").Declaration): boolean {
+export function isStandardSyntaxDeclaration (decl: Declaration | LessDeclaration): boolean {
 	let prop = decl.prop
 	let parent = decl.parent
 

--- a/lib/utils/isStandardSyntaxFunction/index.test.ts
+++ b/lib/utils/isStandardSyntaxFunction/index.test.ts
@@ -1,4 +1,4 @@
-import valueParser from "postcss-value-parser"
+import valueParser, { type FunctionNode } from "postcss-value-parser"
 import { describe, expect, it } from "vitest"
 
 import { isStandardSyntaxFunction } from "./index.ts"
@@ -40,8 +40,8 @@ describe(`isStandardSyntaxFunction`, () => {
  * @param declValue - The value.
  * @returns That call.
  */
-function getFunction (declValue: string): import("postcss-value-parser").FunctionNode {
-	let functions: import("postcss-value-parser").FunctionNode[] = []
+function getFunction (declValue: string): FunctionNode {
+	let functions: FunctionNode[] = []
 
 	valueParser(declValue).walk((valueNode) => {
 		if (valueNode.type === `function`) functions.push(valueNode)

--- a/lib/utils/isStandardSyntaxFunction/index.ts
+++ b/lib/utils/isStandardSyntaxFunction/index.ts
@@ -1,9 +1,11 @@
+import type { Node } from "postcss-value-parser"
+
 /**
  * Checks whether a function is standard (i.e. not a preprocessor construct).
  * @param node - The function node to check.
  * @returns True if the function is standard syntax, false otherwise.
  */
-export function isStandardSyntaxFunction (node: import("postcss-value-parser").Node): boolean {
+export function isStandardSyntaxFunction (node: Node): boolean {
 	// Function nodes without names are things in parentheses like Sass lists
 	if (!node.value) return false
 

--- a/lib/utils/isStandardSyntaxRule/index.test.ts
+++ b/lib/utils/isStandardSyntaxRule/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type Parser, type Rule } from "postcss"
 import postcssLess from "postcss-less"
 import { describe, expect, it } from "vitest"
 
@@ -10,8 +10,8 @@ import { isStandardSyntaxRule } from "./index.ts"
  * @param parser - The syntax to read it with.
  * @returns That rule.
  */
-function node (code: string, parser: { parse: import("postcss").Parser } = postcss): import("postcss").Rule {
-	return parser.parse(code).first as import("postcss").Rule
+function node (code: string, parser: { parse: Parser } = postcss): Rule {
+	return parser.parse(code).first as Rule
 }
 
 /**
@@ -19,7 +19,7 @@ function node (code: string, parser: { parse: import("postcss").Parser } = postc
  * @param code - The stylesheet.
  * @returns That rule.
  */
-function lessNode (code: string): import("postcss").Rule {
+function lessNode (code: string): Rule {
 	return node(code, postcssLess)
 }
 

--- a/lib/utils/isStandardSyntaxRule/index.ts
+++ b/lib/utils/isStandardSyntaxRule/index.ts
@@ -1,3 +1,6 @@
+import type { Rule } from "postcss"
+import type { Rule as LessRule } from "postcss-less"
+
 import { LESS_EXTEND_CALL } from "../../regexps.ts"
 import { isStandardSyntaxSelector } from "../isStandardSyntaxSelector/index.ts"
 import { withoutQuotedTextAndComments } from "../withoutQuotedTextAndComments/index.ts"
@@ -7,7 +10,7 @@ import { withoutQuotedTextAndComments } from "../withoutQuotedTextAndComments/in
  * @param rule - The rule node to check.
  * @returns True if the rule is standard syntax, false otherwise.
  */
-export function isStandardSyntaxRule (rule: import("postcss").Rule | import("postcss-less").Rule): boolean {
+export function isStandardSyntaxRule (rule: Rule | LessRule): boolean {
 	if (rule.type !== `rule`) return false
 
 	// Ignore a Less `:extend`, which `postcss-less` marks the rule for by matching the text of its selector, quotes and all — so `[title=":extend(x)"]` carries the mark though what stands inside the quotes is an attribute value and nothing else. The mark is asked of the code instead, of the same copy `isStandardSyntaxSelector` reads, with every quoted run emptied. The case is left as the mark reads it, which is any case at all, though Less reads its keywords in lower case only and prints `.a:EXTEND(.b)` as it stands: the one thing this plugin would write there is the lower case `selector-pseudo-class-case` asks for, and that would turn a selector matching nothing into an extend that changes what Less compiles.

--- a/lib/utils/isStyledSyntaxDeclaration/index.ts
+++ b/lib/utils/isStyledSyntaxDeclaration/index.ts
@@ -1,10 +1,12 @@
+import type { Container, Declaration, Document } from "postcss"
+
 /**
  * Checks whether the declaration is processed by `postcss-styled-syntax`.
  * @param declaration - The CSS declaration node.
  * @returns True if the declaration is processed by postcss-styled-syntax, false otherwise.
  */
-export function isStyledSyntaxDeclaration (declaration: import("postcss").Declaration): boolean {
-	let parent: import("postcss").Container | import("postcss").Document | undefined = declaration.parent
+export function isStyledSyntaxDeclaration (declaration: Declaration): boolean {
+	let parent: Container | Document | undefined = declaration.parent
 
 	while (parent) {
 		if (parent.raws.styledSyntaxRangeStart !== undefined) return true

--- a/lib/utils/isStyledSyntaxNode/index.ts
+++ b/lib/utils/isStyledSyntaxNode/index.ts
@@ -1,8 +1,10 @@
+import type { Node } from "postcss"
+
 /**
  * Checks whether the Node is processed by `postcss-styled-syntax`.
  * @param node - The node to check.
  * @returns True if the node is processed by postcss-styled-syntax, false otherwise.
  */
-export function isStyledSyntaxNode (node: import("postcss").Node): boolean {
+export function isStyledSyntaxNode (node: Node): boolean {
 	return node.parent?.raws.styledSyntaxRangeStart !== undefined
 }

--- a/lib/utils/lastNodeHoldsTheBlockAfter/index.test.ts
+++ b/lib/utils/lastNodeHoldsTheBlockAfter/index.test.ts
@@ -1,4 +1,4 @@
-import { atRule, parse, rule } from "postcss"
+import { atRule, type Container, parse, type Parser, type Rule, rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -56,7 +56,7 @@ describe(`lastNodeHoldsTheBlockAfter`, () => {
 	})
 
 	it(`turns away a block whose own raw a fix has already filled, which no parse of this shape leaves anything in`, () => {
-		let statement = parse(`a {\n\t@extend .b;\n}`).first as import("postcss").Rule
+		let statement = parse(`a {\n\t@extend .b;\n}`).first as Rule
 
 		// What `declaration-block-trailing-semicolon` under `never` leaves behind: the flag cleared and the whitespace standing where it stood
 		statement.raws.semicolon = false
@@ -71,8 +71,8 @@ describe(`lastNodeHoldsTheBlockAfter`, () => {
  * @param syntax - The syntax to read it with, where plain CSS is not the one.
  * @returns What the util answers.
  */
-function run (css: string, syntax?: { parse: import("postcss").Parser }): ReturnType<typeof lastNodeHoldsTheBlockAfter> {
+function run (css: string, syntax?: { parse: Parser }): ReturnType<typeof lastNodeHoldsTheBlockAfter> {
 	let root = syntax ? syntax.parse(css) : parse(css)
 
-	return lastNodeHoldsTheBlockAfter(root.first as import("postcss").Container)
+	return lastNodeHoldsTheBlockAfter(root.first as Container)
 }

--- a/lib/utils/lastNodeHoldsTheBlockAfter/index.ts
+++ b/lib/utils/lastNodeHoldsTheBlockAfter/index.ts
@@ -1,3 +1,5 @@
+import type { AtRule, Container } from "postcss"
+
 import { hasBlock } from "../hasBlock/index.ts"
 import { isAtRule } from "../typeGuards/index.ts"
 
@@ -14,7 +16,7 @@ import { isAtRule } from "../typeGuards/index.ts"
  * @param statement - The statement carrying the block.
  * @returns True where the last node of the block holds that run.
  */
-export function lastNodeHoldsTheBlockAfter<T extends import("postcss").Container> (statement: T): statement is T & { last: import("postcss").AtRule } {
+export function lastNodeHoldsTheBlockAfter<T extends Container> (statement: T): statement is T & { last: AtRule } {
 	let last = statement.last
 
 	if (!last || !isAtRule(last) || hasBlock(last)) return false

--- a/lib/utils/lastNonCommentNode/index.test.ts
+++ b/lib/utils/lastNonCommentNode/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Container, parse, type Rule } from "postcss"
 import { describe, expect, it } from "vitest"
 
 import { lastNonCommentNode } from "./index.ts"
@@ -8,8 +8,8 @@ import { lastNonCommentNode } from "./index.ts"
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function firstBlock (css: string): import("postcss").Rule {
-	return parse(css).first as import("postcss").Rule
+function firstBlock (css: string): Rule {
+	return parse(css).first as Rule
 }
 
 describe(`lastNonCommentNode`, () => {
@@ -52,6 +52,6 @@ describe(`lastNonCommentNode`, () => {
 	})
 
 	it(`no container at all, which is what a node standing on no parent hands over`, () => {
-		expect(lastNonCommentNode(parse(`a {}`).parent as import("postcss").Container | undefined)).toBe(null)
+		expect(lastNonCommentNode(parse(`a {}`).parent as Container | undefined)).toBe(null)
 	})
 })

--- a/lib/utils/lastNonCommentNode/index.ts
+++ b/lib/utils/lastNonCommentNode/index.ts
@@ -1,5 +1,4 @@
-export type PostcssChildNode = import("postcss").ChildNode
-export type PostcssContainer = import("postcss").Container
+import type { ChildNode, Container } from "postcss"
 
 /**
  * Gets the last node of a container that is not a comment.
@@ -10,7 +9,7 @@ export type PostcssContainer = import("postcss").Container
  * @param container - The container to look inside.
  * @returns The last non-comment node, or null where the container holds none.
  */
-export function lastNonCommentNode (container: PostcssContainer | undefined): PostcssChildNode | null {
+export function lastNonCommentNode (container: Container | undefined): ChildNode | null {
 	let node = container ? container.last : undefined
 
 	while (node && node.type === `comment`) node = node.prev()

--- a/lib/utils/matchesStringOrRegExp/index.ts
+++ b/lib/utils/matchesStringOrRegExp/index.ts
@@ -4,7 +4,11 @@
  * @param comparison - The comparison value(s).
  * @returns False where nothing matched, or the match, the pattern it was made against and the substring it covers.
  */
-function testAgainstStringOrRegExpOrArray (value: string, comparison: string | RegExp | Array<string | RegExp>): false | { match: string, pattern: (string | RegExp), substring: string } {
+function testAgainstStringOrRegExpOrArray (value: string, comparison: string | RegExp | Array<string | RegExp>): false | {
+	match: string,
+	pattern: (string | RegExp),
+	substring: string,
+} {
 	if (!Array.isArray(comparison)) return testAgainstStringOrRegExp(value, comparison)
 
 	for (let comparisonItem of comparison) {
@@ -22,7 +26,11 @@ function testAgainstStringOrRegExpOrArray (value: string, comparison: string | R
  * @param comparison - The comparison value.
  * @returns False where nothing matched, or the match, the pattern it was made against and the substring it covers.
  */
-function testAgainstStringOrRegExp (value: string, comparison: string | RegExp): false | { match: string, pattern: (string | RegExp), substring: string } {
+function testAgainstStringOrRegExp (value: string, comparison: string | RegExp): false | {
+	match: string,
+	pattern: (string | RegExp),
+	substring: string,
+} {
 	// If it's a RegExp, test directly
 	if (comparison instanceof RegExp) {
 		let match = value.match(comparison)
@@ -56,7 +64,11 @@ function testAgainstStringOrRegExp (value: string, comparison: string | RegExp):
  * @param comparison - The comparison value(s).
  * @returns False where nothing matched, or the match, the pattern it was made against and the substring it covers.
  */
-export function matchesStringOrRegExp (input: string | Array<string>, comparison: string | RegExp | Array<string | RegExp>): false | { match: string, pattern: (string | RegExp), substring: string } {
+export function matchesStringOrRegExp (input: string | Array<string>, comparison: string | RegExp | Array<string | RegExp>): false | {
+	match: string,
+	pattern: (string | RegExp),
+	substring: string,
+} {
 	if (!Array.isArray(input)) return testAgainstStringOrRegExpOrArray(input, comparison)
 
 	for (let inputItem of input) {

--- a/lib/utils/mediaFeatureColonSpaceChecker/index.ts
+++ b/lib/utils/mediaFeatureColonSpaceChecker/index.ts
@@ -17,7 +17,11 @@ let { utils: { report } } = stylelint
  */
 export function mediaFeatureColonSpaceChecker (opts: {
 	root: Root,
-	locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
+	locationChecker: (args: {
+		source: string,
+		index: number,
+		err: (message: string) => void,
+	}) => void,
 	fix?: ((node: AtRule, index: number) => void),
 	result: PostcssResult,
 	checkedRuleName: string,

--- a/lib/utils/mediaFeatureColonSpaceChecker/index.ts
+++ b/lib/utils/mediaFeatureColonSpaceChecker/index.ts
@@ -1,5 +1,6 @@
+import type { AtRule, Root } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import { MEDIA_AT_RULE } from "../../regexps.ts"
@@ -15,10 +16,10 @@ let { utils: { report } } = stylelint
  * @param opts - The options object.
  */
 export function mediaFeatureColonSpaceChecker (opts: {
-	root: import("postcss").Root,
+	root: Root,
 	locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
-	fix?: ((node: import("postcss").AtRule, index: number) => void),
-	result: import("stylelint").PostcssResult,
+	fix?: ((node: AtRule, index: number) => void),
+	result: PostcssResult,
 	checkedRuleName: string,
 }): void {
 	let { fix } = opts
@@ -45,7 +46,7 @@ export function mediaFeatureColonSpaceChecker (opts: {
 	 * @param index - The index of the colon.
 	 * @param node - The at-rule node.
 	 */
-	function checkColon (source: string, index: number, node: import("postcss").AtRule): void {
+	function checkColon (source: string, index: number, node: AtRule): void {
 		opts.locationChecker({
 			source,
 			index,

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
@@ -1,5 +1,6 @@
+import type { AtRule, Root } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import { LEADING_BLOCK_COMMENT, MEDIA_AT_RULE, OPENS_WITH_INLINE_COMMENT } from "../../regexps.ts"
@@ -16,12 +17,12 @@ let { utils: { report } } = stylelint
  * @param opts - The options object.
  */
 export function mediaQueryListCommaWhitespaceChecker (opts: {
-	root: import("postcss").Root,
-	result: import("stylelint").PostcssResult,
+	root: Root,
+	result: PostcssResult,
 	locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
 	checkedRuleName: string,
-	fix?: ((atRule: import("postcss").AtRule, index: number) => void),
-	isFixable?: ((params: string, index: number, atRule: import("postcss").AtRule) => boolean),
+	fix?: ((atRule: AtRule, index: number) => void),
+	isFixable?: ((params: string, index: number, atRule: AtRule) => boolean),
 	allowTrailingComments?: boolean,
 }): void {
 	let { fix } = opts
@@ -69,7 +70,7 @@ export function mediaQueryListCommaWhitespaceChecker (opts: {
 	 * @param index - The index to check.
 	 * @param node - The at-rule node.
 	 */
-	function checkComma (source: string, index: number, node: import("postcss").AtRule): void {
+	function checkComma (source: string, index: number, node: AtRule): void {
 		opts.locationChecker({
 			source,
 			index,

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
@@ -19,7 +19,11 @@ let { utils: { report } } = stylelint
 export function mediaQueryListCommaWhitespaceChecker (opts: {
 	root: Root,
 	result: PostcssResult,
-	locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
+	locationChecker: (args: {
+		source: string,
+		index: number,
+		err: (message: string) => void,
+	}) => void,
 	checkedRuleName: string,
 	fix?: ((atRule: AtRule, index: number) => void),
 	isFixable?: ((params: string, index: number, atRule: AtRule) => boolean),

--- a/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
+++ b/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type Declaration, type Parser, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -14,9 +14,9 @@ import { moveDeclarationValueHeadIntoBetween } from "./index.ts"
  * @param length - How many characters of the printed value to move.
  * @returns What the file prints, what the value now reads as, and what stands between the property and it.
  */
-function move (parser: { parse: import("postcss").Parser }, css: string, length: number): { printed: string, value: string, between: string | undefined } {
-	let rule = parser.parse(css).first as import("postcss").Rule
-	let decl = rule.first as import("postcss").Declaration
+function move (parser: { parse: Parser }, css: string, length: number): { printed: string, value: string, between: string | undefined } {
+	let rule = parser.parse(css).first as Rule
+	let decl = rule.first as Declaration
 
 	moveDeclarationValueHeadIntoBetween(decl, length)
 

--- a/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
+++ b/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
@@ -14,7 +14,11 @@ import { moveDeclarationValueHeadIntoBetween } from "./index.ts"
  * @param length - How many characters of the printed value to move.
  * @returns What the file prints, what the value now reads as, and what stands between the property and it.
  */
-function move (parser: { parse: Parser }, css: string, length: number): { printed: string, value: string, between: string | undefined } {
+function move (parser: { parse: Parser }, css: string, length: number): {
+	printed: string,
+	value: string,
+	between: string | undefined,
+} {
 	let rule = parser.parse(css).first as Rule
 	let decl = rule.first as Declaration
 

--- a/lib/utils/moveDeclarationValueHeadIntoBetween/index.ts
+++ b/lib/utils/moveDeclarationValueHeadIntoBetween/index.ts
@@ -1,3 +1,5 @@
+import type { Declaration } from "postcss"
+
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 import { setDeclarationValue } from "../setDeclarationValue/index.ts"
 
@@ -15,7 +17,7 @@ import { setDeclarationValue } from "../setDeclarationValue/index.ts"
  * @param length - How many characters of the printed value to move, never more than that value holds. Both rules hand over nothing at all where no run stands at its head — a value opening on the word it holds, and a value that is empty.
  * @returns The declaration that was passed in.
  */
-export function moveDeclarationValueHeadIntoBetween (decl: import("postcss").Declaration, length: number): import("postcss").Declaration {
+export function moveDeclarationValueHeadIntoBetween (decl: Declaration, length: number): Declaration {
 	let value = getDeclarationValue(decl)
 	let tail = value.slice(length)
 

--- a/lib/utils/movesEndIntoInlineComment/index.ts
+++ b/lib/utils/movesEndIntoInlineComment/index.ts
@@ -1,4 +1,5 @@
 import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
+import type { InlineCommentReading } from "../readsInlineComments/index.ts"
 
 /**
  * Asks whether a fix would take the character a text ends with from outside an inline comment into one.
@@ -15,6 +16,6 @@ import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
  * @param reading - What the syntax the text was spelled in makes of such a comment.
  * @returns True where the character moves into a comment.
  */
-export function movesEndIntoInlineComment (standingText: string, fixedText: string, reading: import("../readsInlineComments/index.ts").InlineCommentReading): boolean {
+export function movesEndIntoInlineComment (standingText: string, fixedText: string, reading: InlineCommentReading): boolean {
 	return !endsWithInlineComment(standingText, reading) && endsWithInlineComment(fixedText, reading)
 }

--- a/lib/utils/nextNonCommentNode/index.test.ts
+++ b/lib/utils/nextNonCommentNode/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Declaration, type Node, parse, type Rule } from "postcss"
 import { beforeEach, describe, expect, it } from "vitest"
 
 import { nextNonCommentNode } from "./index.ts"
@@ -10,11 +10,11 @@ describe(`nextNonCommentNode`, () => {
 	let caseA = ``
 	let caseB = ``
 
-	let aNode: import("postcss").Rule | undefined
+	let aNode: Rule | undefined
 
-	let bNode: import("postcss").Rule | undefined
+	let bNode: Rule | undefined
 
-	let colorNode: import("postcss").Declaration | undefined
+	let colorNode: Declaration | undefined
 
 	beforeEach(() => {
 		aNode = undefined
@@ -76,7 +76,7 @@ describe(`nextNonCommentNode`, () => {
 	it(`the callback is called for each comment stepped over, with the node standing behind it`, () => {
 		let root = parse(`a { /* x */ /* y */ color: pink; }`)
 
-		let steps: [string, import("postcss").Node | undefined][] = []
+		let steps: [string, Node | undefined][] = []
 
 		root.walkRules((rule) => {
 			aNode = rule
@@ -108,7 +108,7 @@ describe(`nextNonCommentNode`, () => {
 	it(`the callback is called with nothing behind a comment the block ends with`, () => {
 		let root = parse(`a { /* x */ }`)
 
-		let steps: [string, import("postcss").Node | undefined][] = []
+		let steps: [string, Node | undefined][] = []
 
 		root.walkRules((rule) => {
 			aNode = rule

--- a/lib/utils/nextNonCommentNode/index.ts
+++ b/lib/utils/nextNonCommentNode/index.ts
@@ -1,6 +1,6 @@
-import { isComment } from "../typeGuards/index.ts"
+import type { Comment, Node as PostcssNode } from "postcss"
 
-export type PostcssNode = import("postcss").Node
+import { isComment } from "../typeGuards/index.ts"
 
 /**
  * Gets the next non-comment node in a PostCSS AST at or after a given node.
@@ -12,7 +12,7 @@ export type PostcssNode = import("postcss").Node
  * @param onComment - Called for each comment the walk steps over, with the node standing behind that comment.
  * @returns The next non-comment node, or null if none exists.
  */
-export function nextNonCommentNode (startNode: PostcssNode | undefined, onComment?: (comment: import("postcss").Comment, nextNode: PostcssNode | undefined) => void): PostcssNode | null {
+export function nextNonCommentNode (startNode: PostcssNode | undefined, onComment?: (comment: Comment, nextNode: PostcssNode | undefined) => void): PostcssNode | null {
 	let node = startNode
 
 	while (node && node.next) {

--- a/lib/utils/nodeString/index.test.ts
+++ b/lib/utils/nodeString/index.test.ts
@@ -1,6 +1,7 @@
-import postcss, { parse } from "postcss"
+import postcss, { type Node, parse, type Parser, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { nodeString } from "./index.ts"
@@ -53,7 +54,7 @@ describe(`nodeString`, () => {
 	it(`falls back to PostCSS's own stringifier where no syntax is to be had`, () => {
 		let root = parse(`a { color: pink }`)
 
-		expect(nodeString(root.first as import("postcss").Rule)).toBe(`a { color: pink }`)
+		expect(nodeString(root.first as Rule)).toBe(`a { color: pink }`)
 	})
 })
 
@@ -64,10 +65,10 @@ describe(`nodeString`, () => {
  * @param type - The type of the node to print.
  * @returns That node, as `nodeString` prints it.
  */
-function first (syntax: { parse: import("postcss").Parser }, css: string, type: string): string {
+function first (syntax: { parse: Parser }, css: string, type: string): string {
 	let root = syntax.parse(css, { from: undefined })
 
-	let found: import("postcss").Node | undefined
+	let found: Node | undefined
 
 	root.walk((node) => {
 		if (found === undefined && node.type === type) found = node
@@ -75,5 +76,5 @@ function first (syntax: { parse: import("postcss").Parser }, css: string, type: 
 
 	if (!found) throw new Error(`The stylesheet holds no node of the type "${type}"`)
 
-	return nodeString(found, { opts: { syntax } } as unknown as import("stylelint").PostcssResult)
+	return nodeString(found, { opts: { syntax } } as unknown as PostcssResult)
 }

--- a/lib/utils/nodeString/index.ts
+++ b/lib/utils/nodeString/index.ts
@@ -1,3 +1,6 @@
+import type { Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { nodeSyntax } from "../nodeSyntax/index.ts"
 
 /**
@@ -14,7 +17,7 @@ import { nodeSyntax } from "../nodeSyntax/index.ts"
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns The node, spelled as the file spells it.
  */
-export function nodeString (node: import("postcss").Node, result?: import("stylelint").PostcssResult): string {
+export function nodeString (node: Node, result?: PostcssResult): string {
 	// A file read as plain CSS has no syntax of its own, and `toString` reaches for PostCSS's stringifier where it is handed none
 	return node.toString(nodeSyntax(node, result))
 }

--- a/lib/utils/nodeSyntax/index.test.ts
+++ b/lib/utils/nodeSyntax/index.test.ts
@@ -1,6 +1,9 @@
-import { parse } from "postcss"
+import { parse, type Rule } from "postcss"
 import scss, { parse as parseScss } from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
+
+import type { EmbeddedSource } from "../typeGuards/index.ts"
 
 import { nodeSyntax } from "./index.ts"
 
@@ -8,27 +11,27 @@ describe(`nodeSyntax`, () => {
 	it(`takes the syntax the file was opened with`, () => {
 		let root = parseScss(`a { color: pink }`, { from: undefined })
 
-		expect(nodeSyntax(root.first as import("postcss").Rule, { opts: { syntax: scss } } as unknown as import("stylelint").PostcssResult)).toBe(scss)
+		expect(nodeSyntax(root.first as Rule, { opts: { syntax: scss } } as unknown as PostcssResult)).toBe(scss)
 	})
 
 	it(`prefers the syntax of the node's own root, which a host language sets per embedded stylesheet`, () => {
 		let root = parse(`a { color: pink }`)
-		let source = root.source as import("../typeGuards/index.ts").EmbeddedSource
+		let source = root.source as EmbeddedSource
 
 		source.syntax = scss
 
-		expect(nodeSyntax(root.first as import("postcss").Rule, { opts: { syntax: `other` } } as unknown as import("stylelint").PostcssResult)).toBe(scss)
+		expect(nodeSyntax(root.first as Rule, { opts: { syntax: `other` } } as unknown as PostcssResult)).toBe(scss)
 	})
 
 	it(`has nothing to hand back for a file read as plain CSS`, () => {
 		let root = parse(`a { color: pink }`)
 
-		expect(nodeSyntax(root.first as import("postcss").Rule, { opts: {} } as unknown as import("stylelint").PostcssResult)).toBe(undefined)
+		expect(nodeSyntax(root.first as Rule, { opts: {} } as unknown as PostcssResult)).toBe(undefined)
 	})
 
 	it(`has nothing to hand back where no result is given`, () => {
 		let root = parse(`a { color: pink }`)
 
-		expect(nodeSyntax(root.first as import("postcss").Rule)).toBe(undefined)
+		expect(nodeSyntax(root.first as Rule)).toBe(undefined)
 	})
 })

--- a/lib/utils/nodeSyntax/index.ts
+++ b/lib/utils/nodeSyntax/index.ts
@@ -1,3 +1,6 @@
+import type { Node, Syntax } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 /**
  * The syntax a node was parsed with, which is the one that prints it back.
  *
@@ -6,8 +9,8 @@
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns That syntax, undefined where the file was read as plain CSS.
  */
-export function nodeSyntax (node: import("postcss").Node, result?: import("stylelint").PostcssResult): import("postcss").Syntax | undefined {
+export function nodeSyntax (node: Node, result?: PostcssResult): Syntax | undefined {
 	let root = node.root()
 
-	return (root.source && (root.source as { syntax?: import("postcss").Syntax }).syntax) || (result && result.opts && result.opts.syntax)
+	return (root.source && (root.source as { syntax?: Syntax }).syntax) || (result && result.opts && result.opts.syntax)
 }

--- a/lib/utils/opensAnAddress/index.ts
+++ b/lib/utils/opensAnAddress/index.ts
@@ -1,3 +1,5 @@
+import type { Node } from "postcss-value-parser"
+
 import { HEX_ESCAPE_TERMINATOR, TRAILING_HEX_ESCAPE } from "../../regexps.ts"
 import { namesAnAddress } from "../namesAnAddress/index.ts"
 
@@ -10,7 +12,7 @@ import { namesAnAddress } from "../namesAnAddress/index.ts"
  * @param siblings - The nodes the call stands among.
  * @returns The name, escapes unresolved and in the case the file writes it.
  */
-function readName (valueNode: import("postcss-value-parser").Node, index: number, siblings: import("postcss-value-parser").Node[]): string {
+function readName (valueNode: Node, index: number, siblings: Node[]): string {
 	let name = valueNode.value
 
 	for (let at = index - 1; at > 0; at -= 2) {
@@ -37,6 +39,6 @@ function readName (valueNode: import("postcss-value-parser").Node, index: number
  * @param siblings - The nodes the node stands among.
  * @returns True where the node is a call opening an address.
  */
-export function opensAnAddress (valueNode: import("postcss-value-parser").Node, index: number, siblings: import("postcss-value-parser").Node[]): boolean {
+export function opensAnAddress (valueNode: Node, index: number, siblings: Node[]): boolean {
 	return valueNode.type === `function` && namesAnAddress(readName(valueNode, index, siblings))
 }

--- a/lib/utils/parseSelector/index.ts
+++ b/lib/utils/parseSelector/index.ts
@@ -1,4 +1,6 @@
-import selectorParser from "postcss-selector-parser"
+import type { Node } from "postcss"
+import selectorParser, { type Root } from "postcss-selector-parser"
+import type { PostcssResult } from "stylelint"
 
 /**
  * Parses a CSS selector string using postcss-selector-parser.
@@ -7,7 +9,7 @@ import selectorParser from "postcss-selector-parser"
  * @param node - The PostCSS node for error reporting.
  * @returns The parsed selector, or undefined where there is no selector to parse or the parser refuses it.
  */
-export function parseSelector (selector: string, result: import("stylelint").PostcssResult, node: import("postcss").Node): import("postcss-selector-parser").Root | undefined {
+export function parseSelector (selector: string, result: PostcssResult, node: Node): Root | undefined {
 	if (!selector) return
 
 	try {

--- a/lib/utils/rawNodeString/index.ts
+++ b/lib/utils/rawNodeString/index.ts
@@ -1,3 +1,6 @@
+import type { Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { nodeString } from "../nodeString/index.ts"
 
 /**
@@ -6,7 +9,7 @@ import { nodeString } from "../nodeString/index.ts"
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns The stringified node including raw before string.
  */
-export function rawNodeString (node: import("postcss").Node, result?: import("stylelint").PostcssResult): string {
+export function rawNodeString (node: Node, result?: PostcssResult): string {
 	let before = node.raws.before
 
 	return (typeof before === `string` ? before : ``) + nodeString(node, result)

--- a/lib/utils/readIdentifierCharacter/index.ts
+++ b/lib/utils/readIdentifierCharacter/index.ts
@@ -10,7 +10,10 @@ import { LEADING_HEX_ESCAPE, LEADING_LINE_BREAK } from "../../regexps.ts"
  * @param index - The index the character is spelled from.
  * @returns The character, or nothing where the backslash spells none, and the index behind the characters spelling it.
  */
-export function readIdentifierCharacter (text: string, index: number): { character: string | undefined, end: number } {
+export function readIdentifierCharacter (text: string, index: number): {
+	character: string | undefined,
+	end: number,
+} {
 	if (text[index] !== `\\`) return { character: text[index], end: index + 1 }
 
 	let next = text[index + 1]

--- a/lib/utils/readsInlineComments/index.test.ts
+++ b/lib/utils/readsInlineComments/index.test.ts
@@ -1,9 +1,10 @@
-import { parse } from "postcss"
+import { type Declaration, parse, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
-import { inlineCommentReading, syntaxKeepsInlineComments, syntaxSpellsInlineComments } from "./index.ts"
+import { type InlineCommentReading, inlineCommentReading, syntaxKeepsInlineComments, syntaxSpellsInlineComments } from "./index.ts"
 
 describe(`syntaxSpellsInlineComments`, () => {
 	it(`no syntax at all, which is plain CSS`, () => {
@@ -56,10 +57,10 @@ describe(`syntaxKeepsInlineComments`, () => {
  * @param syntax - The syntax the file was opened with, none of it standing for plain CSS.
  * @returns What that syntax makes of such a comment.
  */
-function read (syntax?: unknown): import("./index.ts").InlineCommentReading {
-	let rule = parse(`a { color: red; }`, { from: undefined }).first as import("postcss").Rule
+function read (syntax?: unknown): InlineCommentReading {
+	let rule = parse(`a { color: red; }`, { from: undefined }).first as Rule
 
-	return inlineCommentReading(rule.first as import("postcss").Declaration, { opts: { syntax } } as unknown as import("stylelint").PostcssResult)
+	return inlineCommentReading(rule.first as Declaration, { opts: { syntax } } as unknown as PostcssResult)
 }
 
 describe(`inlineCommentReading`, () => {

--- a/lib/utils/readsInlineComments/index.ts
+++ b/lib/utils/readsInlineComments/index.ts
@@ -1,3 +1,6 @@
+import type { Document, Node, Root } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { nodeSyntax } from "../nodeSyntax/index.ts"
 import { isSyntax } from "../typeGuards/index.ts"
 
@@ -30,7 +33,7 @@ function probeSyntax (syntax?: unknown): InlineCommentReading {
 	let reading: InlineCommentReading = { spells: true, keeps: false }
 
 	try {
-		let probe: import("postcss").Root | import("postcss").Document = syntax.parse(INLINE_COMMENT_PROBE, { from: undefined })
+		let probe: Root | Document = syntax.parse(INLINE_COMMENT_PROBE, { from: undefined })
 		let readsTheProbe = false
 
 		probe.walk((node) => {
@@ -70,7 +73,7 @@ function probeSyntax (syntax?: unknown): InlineCommentReading {
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where a double slash in that node's text opens a comment.
  */
-export function readsInlineComments (node: import("postcss").Node, result: import("stylelint").PostcssResult): boolean {
+export function readsInlineComments (node: Node, result: PostcssResult): boolean {
 	return syntaxSpellsInlineComments(nodeSyntax(node, result))
 }
 
@@ -80,7 +83,7 @@ export function readsInlineComments (node: import("postcss").Node, result: impor
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns What that syntax makes of such a comment.
  */
-export function inlineCommentReading (node: import("postcss").Node, result: import("stylelint").PostcssResult): InlineCommentReading {
+export function inlineCommentReading (node: Node, result: PostcssResult): InlineCommentReading {
 	return probeSyntax(nodeSyntax(node, result))
 }
 

--- a/lib/utils/readsInlineComments/index.ts
+++ b/lib/utils/readsInlineComments/index.ts
@@ -5,7 +5,10 @@ import { nodeSyntax } from "../nodeSyntax/index.ts"
 import { isSyntax } from "../typeGuards/index.ts"
 
 /** What the probe of a syntax says about a comment opened by a double slash: whether the syntax spells one at all, and whether it leaves one standing in the value a rule reads. Which break closes one is no question of the syntax's: a line break is what PostCSS reads as one, a line feed with or without a carriage return in front of it, and every scan of a text closes such a comment there. */
-export type InlineCommentReading = { spells: boolean, keeps: boolean }
+export type InlineCommentReading = {
+	spells: boolean,
+	keeps: boolean,
+}
 
 /** The reading of {@link probeSyntax}, per syntax. */
 let inlineCommentSyntaxes: WeakMap<object, InlineCommentReading> = new WeakMap()

--- a/lib/utils/removeEmptyLinesAfter/index.test.ts
+++ b/lib/utils/removeEmptyLinesAfter/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { parse, type Rule } from "postcss"
 import { describe, expect, it } from "vitest"
 
 import { removeEmptyLinesAfter } from "./index.ts"
@@ -78,7 +78,7 @@ describe(`removeEmptyLineBefore`, () => {
 function run (css: string): string {
 	let root = parse(css)
 
-	removeEmptyLinesAfter(root.nodes[0] as import("postcss").Rule)
+	removeEmptyLinesAfter(root.nodes[0] as Rule)
 
 	return root.toString()
 }

--- a/lib/utils/removeEmptyLinesAfter/index.ts
+++ b/lib/utils/removeEmptyLinesAfter/index.ts
@@ -1,3 +1,5 @@
+import type { AtRule, Rule } from "postcss"
+
 import { EVERY_EMPTY_LINE_RUN, EVERY_SEMICOLON } from "../../regexps.ts"
 import { getBlockAfter } from "../getBlockAfter/index.ts"
 import { setBlockAfter } from "../setBlockAfter/index.ts"
@@ -13,7 +15,7 @@ import { setBlockAfter } from "../setBlockAfter/index.ts"
  * @param node - The PostCSS node to modify.
  * @returns The modified node.
  */
-export function removeEmptyLinesAfter<T extends import("postcss").Rule | import("postcss").AtRule> (node: T): T {
+export function removeEmptyLinesAfter<T extends Rule | AtRule> (node: T): T {
 	let blockAfter = getBlockAfter(node)
 
 	setBlockAfter(node, blockAfter ? blockAfter.replaceAll(EVERY_EMPTY_LINE_RUN, (run, first) => first + (run.match(EVERY_SEMICOLON) || []).join(``)) : ``)

--- a/lib/utils/requiresTrailingSemicolon/index.test.ts
+++ b/lib/utils/requiresTrailingSemicolon/index.test.ts
@@ -1,7 +1,10 @@
-import { parse } from "postcss"
+import { type AtRule, type Container, type Document, parse, type Parser, type ProcessOptions, type Root, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
+
+import type { EmbeddedSource } from "../typeGuards/index.ts"
 
 import { requiresTrailingSemicolon } from "./index.ts"
 
@@ -12,14 +15,14 @@ import { requiresTrailingSemicolon } from "./index.ts"
  * @param asked - The syntax to ask the question under, where it is not the one that parsed.
  * @returns What the util makes of that node.
  */
-function lastNodeOfTheBlock (syntax: { parse: import("postcss").Parser }, code: string, asked?: unknown): boolean {
+function lastNodeOfTheBlock (syntax: { parse: Parser }, code: string, asked?: unknown): boolean {
 	let root = syntax.parse(code, { from: undefined })
-	let block = root.last as import("postcss").Container
+	let block = root.last as Container
 	let node = block.nodes ? block.last : block
 
 	if (!node) throw new Error(`The block holds no node`)
 
-	return requiresTrailingSemicolon(node, { opts: { syntax: asked === undefined ? syntax : asked } } as unknown as import("stylelint").PostcssResult)
+	return requiresTrailingSemicolon(node, { opts: { syntax: asked === undefined ? syntax : asked } } as unknown as PostcssResult)
 }
 
 /**
@@ -34,9 +37,9 @@ function closingALessBlock (node: string): boolean {
 describe(`requiresTrailingSemicolon`, () => {
 	describe(`the syntax`, () => {
 		it(`no syntax at all, which is plain CSS`, () => {
-			let rule = parse(`a { @layer l; }`).first as import("postcss").Rule
+			let rule = parse(`a { @layer l; }`).first as Rule
 
-			expect(requiresTrailingSemicolon(rule.first as import("postcss").AtRule, { opts: {} } as unknown as import("stylelint").PostcssResult)).toBe(false)
+			expect(requiresTrailingSemicolon(rule.first as AtRule, { opts: {} } as unknown as PostcssResult)).toBe(false)
 		})
 
 		it(`a syntax that reads the probe and spells no Less variable in it`, () => {
@@ -61,12 +64,12 @@ describe(`requiresTrailingSemicolon`, () => {
 
 		it(`the syntax of the node's own stylesheet, which is asked ahead of the one the file was opened with`, () => {
 			let root = less.parse(`a { @extend .b; }`, { from: undefined })
-			let source = root.source as import("../typeGuards/index.ts").EmbeddedSource
-			let rule = root.first as import("postcss").Rule
+			let source = root.source as EmbeddedSource
+			let rule = root.first as Rule
 
 			source.syntax = scss
 
-			expect(requiresTrailingSemicolon(rule.last as import("postcss").AtRule, { opts: { syntax: less } } as unknown as import("stylelint").PostcssResult)).toBe(false)
+			expect(requiresTrailingSemicolon(rule.last as AtRule, { opts: { syntax: less } } as unknown as PostcssResult)).toBe(false)
 		})
 
 		it(`one parse of the probe per syntax, however many nodes are asked about`, () => {
@@ -79,7 +82,7 @@ describe(`requiresTrailingSemicolon`, () => {
 				 * @param options - The options of the parse.
 				 * @returns What Less makes of it.
 				 */
-				parse (code: string, options?: import("postcss").ProcessOptions): import("postcss").Root | import("postcss").Document {
+				parse (code: string, options?: ProcessOptions): Root | Document {
 					parses += 1
 
 					return less.parse(code, options)

--- a/lib/utils/requiresTrailingSemicolon/index.ts
+++ b/lib/utils/requiresTrailingSemicolon/index.ts
@@ -1,3 +1,7 @@
+import type { Document, Node, Root } from "postcss"
+import type { AtRule } from "postcss-less"
+import type { PostcssResult } from "stylelint"
+
 import { hasBlock } from "../hasBlock/index.ts"
 import { isLessDetachedRulesetCall } from "../isLessDetachedRulesetCall/index.ts"
 import { nodeSyntax } from "../nodeSyntax/index.ts"
@@ -28,7 +32,7 @@ function readsAsLess (syntax: unknown): boolean {
 	let verdict = false
 
 	try {
-		let probe: import("postcss").Root | import("postcss").Document = syntax.parse(LESS_PROBE, { from: undefined })
+		let probe: Root | Document = syntax.parse(LESS_PROBE, { from: undefined })
 
 		probe.walkAtRules((atRule) => {
 			verdict = Boolean(`variable` in atRule && atRule.variable)
@@ -58,7 +62,7 @@ function readsAsLess (syntax: unknown): boolean {
  * @param atRule - The node to read.
  * @returns True where Less reads it as an at-rule.
  */
-function isLessAtRule (atRule: import("postcss-less").AtRule): boolean {
+function isLessAtRule (atRule: AtRule): boolean {
 	if (atRule.mixin) return false
 
 	return !isLessDetachedRulesetCall(atRule)
@@ -78,7 +82,7 @@ function isLessAtRule (atRule: import("postcss-less").AtRule): boolean {
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where the semicolon behind that node is not the fix's to take away.
  */
-export function requiresTrailingSemicolon (node: import("postcss").Node, result: import("stylelint").PostcssResult): boolean {
+export function requiresTrailingSemicolon (node: Node, result: PostcssResult): boolean {
 	if (!isAtRule(node) || hasBlock(node) || !isLessAtRule(node)) return false
 
 	return readsAsLess(nodeSyntax(node, result))

--- a/lib/utils/restoreSelectorInlineComments/index.ts
+++ b/lib/utils/restoreSelectorInlineComments/index.ts
@@ -1,4 +1,5 @@
 import { findSelectorBlockComments } from "../findSelectorBlockComments/index.ts"
+import type { InlineComment } from "../findSelectorInlineComments/index.ts"
 
 /**
  * Gives a selector's inline comments their source spelling back, so that a fix written to the raw suits the copy `postcss-scss` prints.
@@ -8,7 +9,7 @@ import { findSelectorBlockComments } from "../findSelectorBlockComments/index.ts
  * @param inlineComments - The inline comments of the selector.
  * @returns The selector spelled the way the source spells it.
  */
-export function restoreSelectorInlineComments (rawSelector: string, inlineComments: import("../findSelectorInlineComments/index.ts").InlineComment[]): string {
+export function restoreSelectorInlineComments (rawSelector: string, inlineComments: InlineComment[]): string {
 	if (inlineComments.length === 0) return rawSelector
 
 	let comments = findSelectorBlockComments(rawSelector)

--- a/lib/utils/rewriteInlineComments/index.ts
+++ b/lib/utils/rewriteInlineComments/index.ts
@@ -1,7 +1,5 @@
 import { EVERY_COMMENT_DELIMITER } from "../../regexps.ts"
-import { findInlineCommentSpans } from "../findInlineCommentSpans/index.ts"
-
-export type InlineCommentSpan = import("../findInlineCommentSpans/index.ts").InlineCommentSpan
+import { findInlineCommentSpans, type InlineCommentSpan } from "../findInlineCommentSpans/index.ts"
 
 /**
  * Rewrites the inline comments of a value into block comments, as `postcss-scss` does when it fills the raw of that value: the two slashes opening a comment become the two characters opening a block comment, its line break becomes the two closing them, and a `*` followed by `/` in the text — or the other way round — is cut in two so that it closes nothing.

--- a/lib/utils/ruleCheck/index.ts
+++ b/lib/utils/ruleCheck/index.ts
@@ -1,2 +1,4 @@
 /** The check a rule returns once it has its options: what Stylelint calls with the root of a stylesheet and the result to report into. `RuleBase` is what Stylelint types a rule's call signature by, and every rule of the plugin spells its return type through this one name. */
-export type RuleCheck = ReturnType<import("stylelint").RuleBase>
+import type { RuleBase } from "stylelint"
+
+export type RuleCheck = ReturnType<RuleBase>

--- a/lib/utils/searchCopy/index.test.ts
+++ b/lib/utils/searchCopy/index.test.ts
@@ -1,11 +1,12 @@
-import { parse } from "postcss"
+import { type Declaration, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { searchCopy } from "./index.ts"
 
-const CSS_RESULT = { opts: {} } as unknown as import("stylelint").PostcssResult
-const SCSS_RESULT = { opts: { syntax: { parse: parseScss } } } as unknown as import("stylelint").PostcssResult
+const CSS_RESULT = { opts: {} } as unknown as PostcssResult
+const SCSS_RESULT = { opts: { syntax: { parse: parseScss } } } as unknown as PostcssResult
 
 describe(`searchCopy`, () => {
 	it(`a double slash of plain CSS is code, and its second slash is spelled out of the search's way`, () => {
@@ -48,8 +49,8 @@ describe(`searchCopy`, () => {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function cssDecl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function cssDecl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parse(css).walkDecls((d) => {
 		list.push(d)
@@ -63,8 +64,8 @@ function cssDecl (css: string): import("postcss").Declaration {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function scssDecl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function scssDecl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parseScss(css).walkDecls((d) => {
 		list.push(d)

--- a/lib/utils/searchCopy/index.ts
+++ b/lib/utils/searchCopy/index.ts
@@ -17,7 +17,10 @@ import { readsInlineComments } from "../readsInlineComments/index.ts"
  * @param result - The Stylelint result, which the syntax of the file is read from.
  * @returns The copy to hand the search, and the spans the comments occupy in the text it was made of.
  */
-export function searchCopy (text: string, node: Node, result: PostcssResult): { searchString: string, commentSpans: CommentSpan[] } {
+export function searchCopy (text: string, node: Node, result: PostcssResult): {
+	searchString: string,
+	commentSpans: CommentSpan[],
+} {
 	let commentSpans = findCommentSpans(text, readsInlineComments(node, result))
 
 	// The masking is handed no spans because the blanking left it none to guard: every comment is gone from the copy, so every double slash still standing in it opens none

--- a/lib/utils/searchCopy/index.ts
+++ b/lib/utils/searchCopy/index.ts
@@ -1,9 +1,10 @@
+import type { Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { blankComments } from "../blankComments/index.ts"
-import { findCommentSpans } from "../findCommentSpans/index.ts"
+import { type CommentSpan, findCommentSpans } from "../findCommentSpans/index.ts"
 import { hideFalseInlineComments } from "../hideFalseInlineComments/index.ts"
 import { readsInlineComments } from "../readsInlineComments/index.ts"
-
-export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
 
 /**
  * Builds the copy of a node's text that a scan is handed in place of the text itself, and hands back the comments it was built from.
@@ -16,7 +17,7 @@ export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
  * @param result - The Stylelint result, which the syntax of the file is read from.
  * @returns The copy to hand the search, and the spans the comments occupy in the text it was made of.
  */
-export function searchCopy (text: string, node: import("postcss").Node, result: import("stylelint").PostcssResult): { searchString: string, commentSpans: CommentSpan[] } {
+export function searchCopy (text: string, node: Node, result: PostcssResult): { searchString: string, commentSpans: CommentSpan[] } {
 	let commentSpans = findCommentSpans(text, readsInlineComments(node, result))
 
 	// The masking is handed no spans because the blanking left it none to guard: every comment is gone from the copy, so every double slash still standing in it opens none

--- a/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
+++ b/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
@@ -19,7 +19,11 @@ let { utils: { report } } = stylelint
 export function selectorAttributeOperatorSpaceChecker (options: {
 	root: Root,
 	result: PostcssResult,
-	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
+	locationChecker: (opts: {
+		source: string,
+		index: number,
+		err: (msg: string) => void,
+	}) => void,
 	checkedRuleName: string,
 	checkBeforeOperator: boolean,
 	fix?: ((attributeNode: Attribute) => void),

--- a/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
+++ b/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
@@ -1,11 +1,14 @@
+import type { Node, Root } from "postcss"
+import type { Attribute } from "postcss-selector-parser"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
 import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -14,19 +17,19 @@ let { utils: { report } } = stylelint
  * @param options - The options object.
  */
 export function selectorAttributeOperatorSpaceChecker (options: {
-	root: import("postcss").Root,
-	result: import("stylelint").PostcssResult,
+	root: Root,
+	result: PostcssResult,
 	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
 	checkedRuleName: string,
 	checkBeforeOperator: boolean,
-	fix?: ((attributeNode: import("postcss-selector-parser").Attribute) => void),
+	fix?: ((attributeNode: Attribute) => void),
 }): void {
 	let { fix } = options
 
 	options.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) return
 
-		let selectorRaws: import("../typeGuards/index.ts").SyntaxRaw | undefined = rule.raws.selector
+		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector
 
 		if (!selector.includes(`[`) || !selector.includes(`=`)) return
@@ -74,7 +77,7 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 		 * @param attributeNode - The attribute node.
 		 * @param operator - The operator being checked.
 		 */
-		function checkOperator (source: string, index: number, node: import("postcss").Node, attributeNode: import("postcss-selector-parser").Attribute, operator: string): void {
+		function checkOperator (source: string, index: number, node: Node, attributeNode: Attribute, operator: string): void {
 			options.locationChecker({
 				source,
 				index,

--- a/lib/utils/selectorCombinatorSpaceChecker/index.ts
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.ts
@@ -1,4 +1,6 @@
-import stylelint from "stylelint"
+import type { Node, Root } from "postcss"
+import type { Combinator, Node as SelectorParserNode } from "postcss-selector-parser"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { WHITESPACE } from "../../regexps.ts"
 import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
@@ -7,6 +9,7 @@ import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -18,7 +21,7 @@ export type LocationChecker = (args: { source: string, index: number, errTarget:
  * @param node - The node to start from.
  * @returns The node, or nothing if the node is preceded by comments only.
  */
-function prevNonComment (node: import("postcss-selector-parser").Node): import("postcss-selector-parser").Node | undefined {
+function prevNonComment (node: SelectorParserNode): SelectorParserNode | undefined {
 	let prev = node.prev()
 
 	while (prev && prev.type === `comment`) prev = prev.prev()
@@ -31,12 +34,12 @@ function prevNonComment (node: import("postcss-selector-parser").Node): import("
  * @param opts - The options object.
  */
 export function selectorCombinatorSpaceChecker (opts: {
-	root: import("postcss").Root,
-	result: import("stylelint").PostcssResult,
+	root: Root,
+	result: PostcssResult,
 	locationChecker: LocationChecker,
 	locationType: `before` | `after`,
 	checkedRuleName: string,
-	fix?: ((combinator: import("postcss-selector-parser").Combinator) => void),
+	fix?: ((combinator: Combinator) => void),
 }): void {
 	let { fix } = opts
 	let hasFixed
@@ -46,7 +49,7 @@ export function selectorCombinatorSpaceChecker (opts: {
 
 		hasFixed = false
 
-		let selectorRaws: import("../typeGuards/index.ts").SyntaxRaw | undefined = rule.raws.selector
+		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector
 		let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 
@@ -96,7 +99,7 @@ export function selectorCombinatorSpaceChecker (opts: {
 	 * @param node - The parent node.
 	 * @param reportIndex - The index of the combinator in the source of the parent node.
 	 */
-	function check (source: string, combinator: import("postcss-selector-parser").Combinator, index: number, node: import("postcss").Node, reportIndex: number): void {
+	function check (source: string, combinator: Combinator, index: number, node: Node, reportIndex: number): void {
 		// A comment standing beside a combinator is folded into the raws of that side, and a raw is what the parser prints in place of the spaces the fix writes. Stylelint counts a fixer as applied whatever it does, so a write nothing would print has to be declined here rather than from inside the fixer, or the warning goes down with it and `--fix` reports a clean pass on a file it has not touched.
 		let isFixable = fix && combinator.raws?.spaces?.[opts.locationType] === undefined
 

--- a/lib/utils/selectorCombinatorSpaceChecker/index.ts
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.ts
@@ -14,7 +14,12 @@ import type { SyntaxRaw } from "../typeGuards/index.ts"
 let { utils: { report } } = stylelint
 
 /** A function that checks whitespace at a specific location. */
-export type LocationChecker = (args: { source: string, index: number, errTarget: string, err: (message: string) => void }) => void
+export type LocationChecker = (args: {
+	source: string,
+	index: number,
+	errTarget: string,
+	err: (message: string) => void,
+}) => void
 
 /**
  * Gets the closest preceding sibling that is not a comment.

--- a/lib/utils/selectorListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/selectorListCommaWhitespaceChecker/index.ts
@@ -1,19 +1,21 @@
+import type { Root, Rule } from "postcss"
 import styleSearch from "style-search"
-import stylelint from "stylelint"
+import stylelint, { type PostcssResult } from "stylelint"
 
-import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
+import { findSelectorInlineComments, type InlineComment } from "../findSelectorInlineComments/index.ts"
 import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 let { utils: { report } } = stylelint
 
 export interface SelectorListCommaWhitespaceCheckerOptions {
 
 	/** The PostCSS root node. */
-	root: import("postcss").Root,
+	root: Root,
 
 	/** The Stylelint result. */
-	result: import("stylelint").PostcssResult,
+	result: PostcssResult,
 
 	/** The location checker function. */
 	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
@@ -22,10 +24,10 @@ export interface SelectorListCommaWhitespaceCheckerOptions {
 	checkedRuleName: string,
 
 	/** The fix function. */
-	fix?: ((rule: import("postcss").Rule, index: number) => void),
+	fix?: ((rule: Rule, index: number) => void),
 
 	/** Tells whether this particular problem can be fixed. Stylelint counts a fixer as applied whatever it does, so a rule that cannot repair a problem has to say so here rather than from inside the fixer. */
-	isFixable?: ((selector: string, index: number, inlineComments: import("../findSelectorInlineComments/index.ts").InlineComment[]) => boolean),
+	isFixable?: ((selector: string, index: number, inlineComments: InlineComment[]) => boolean),
 }
 
 /**
@@ -38,7 +40,7 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 	opts.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) return
 
-		let selectorRaws: import("../typeGuards/index.ts").SyntaxRaw | undefined = rule.raws.selector
+		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector
 
 		// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw, reported in the file's own coordinates, and handed to the rule's fixer as the raw spells it, since the raw is the copy the rule slices.
@@ -63,7 +65,7 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 	 * @param node - The rule node.
 	 * @param inlineComments - The inline comments of the selector.
 	 */
-	function checkDelimiter (source: string, index: number, node: import("postcss").Rule, inlineComments: import("../findSelectorInlineComments/index.ts").InlineComment[]): void {
+	function checkDelimiter (source: string, index: number, node: Rule, inlineComments: InlineComment[]): void {
 		opts.locationChecker({
 			source,
 			index,

--- a/lib/utils/selectorListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/selectorListCommaWhitespaceChecker/index.ts
@@ -18,7 +18,11 @@ export interface SelectorListCommaWhitespaceCheckerOptions {
 	result: PostcssResult,
 
 	/** The location checker function. */
-	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
+	locationChecker: (opts: {
+		source: string,
+		index: number,
+		err: (msg: string) => void,
+	}) => void,
 
 	/** The name of the rule being checked. */
 	checkedRuleName: string,

--- a/lib/utils/setAtRuleParams/index.test.ts
+++ b/lib/utils/setAtRuleParams/index.test.ts
@@ -1,6 +1,8 @@
-import { parse } from "postcss"
+import { type AtRule, parse } from "postcss"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
+
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setAtRuleParams } from "./index.ts"
 
@@ -41,7 +43,7 @@ describe(`setAtRuleParams`, () => {
 
 		setAtRuleParams(node, `screen // c\n  and (min-width: 2px)`)
 
-		expect((node.raws.params as import("../typeGuards/index.ts").SyntaxRaw).scss).toBe(`screen // c\n  and (min-width: 2px)`)
+		expect((node.raws.params as SyntaxRaw).scss).toBe(`screen // c\n  and (min-width: 2px)`)
 	})
 
 	it(`keeps the raw beside it in step`, () => {
@@ -49,7 +51,7 @@ describe(`setAtRuleParams`, () => {
 
 		setAtRuleParams(node, `screen // c\n  and (min-width: 2px)`)
 
-		expect((node.raws.params as import("../typeGuards/index.ts").SyntaxRaw).raw).toBe(`screen /* c*/\n  and (min-width: 2px)`)
+		expect((node.raws.params as SyntaxRaw).raw).toBe(`screen /* c*/\n  and (min-width: 2px)`)
 	})
 
 	it(`the syntax prints what was written`, () => {
@@ -68,8 +70,8 @@ describe(`setAtRuleParams`, () => {
  * @param css - The stylesheet.
  * @returns That at-rule.
  */
-function atRule (css: string): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function atRule (css: string): AtRule {
+	let list: AtRule[] = []
 
 	parse(css).walkAtRules((rule) => {
 		list.push(rule)
@@ -83,8 +85,8 @@ function atRule (css: string): import("postcss").AtRule {
  * @param css - The stylesheet.
  * @returns That at-rule.
  */
-function scssAtRule (css: string): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function scssAtRule (css: string): AtRule {
+	let list: AtRule[] = []
 
 	parseScss(css).walkAtRules((rule) => {
 		list.push(rule)

--- a/lib/utils/setAtRuleParams/index.ts
+++ b/lib/utils/setAtRuleParams/index.ts
@@ -1,8 +1,9 @@
+import type { AtRule } from "postcss"
+
 import { findInlineCommentSpans } from "../findInlineCommentSpans/index.ts"
 import { rewriteInlineComments } from "../rewriteInlineComments/index.ts"
 import { syncLessVariableValue } from "../syncLessVariableValue/index.ts"
-
-export type AtRule = import("postcss").AtRule
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 /**
  * Sets the params of an at-rule, in the copy of them the syntax prints.
@@ -13,7 +14,7 @@ export type AtRule = import("postcss").AtRule
  * @returns The at-rule that was passed in.
  */
 export function setAtRuleParams (atRule: AtRule, params: string): AtRule {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = atRule.raws.params
+	let syntaxRaw: SyntaxRaw | undefined = atRule.raws.params
 
 	if (syntaxRaw) {
 		if (typeof syntaxRaw.scss === `string`) {

--- a/lib/utils/setBlockAfter/index.test.ts
+++ b/lib/utils/setBlockAfter/index.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "postcss"
+import { type Container, parse, type Parser, type Rule } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
@@ -28,7 +28,7 @@ describe(`setBlockAfter`, () => {
 	})
 
 	it(`hands back the statement it was given`, () => {
-		let statement = parse(`a {\n\t@extend .b\n}`).first as import("postcss").Rule
+		let statement = parse(`a {\n\t@extend .b\n}`).first as Rule
 
 		expect(setBlockAfter(statement, ` `)).toBe(statement)
 	})
@@ -41,10 +41,10 @@ describe(`setBlockAfter`, () => {
  * @param syntax - The syntax to read it with, where plain CSS is not the one.
  * @returns The stylesheet as it prints after the write.
  */
-function run (css: string, after: string, syntax?: { parse: import("postcss").Parser }): string {
+function run (css: string, after: string, syntax?: { parse: Parser }): string {
 	let root = syntax ? syntax.parse(css) : parse(css)
 
-	setBlockAfter(root.first as import("postcss").Container, after)
+	setBlockAfter(root.first as Container, after)
 
 	return syntax ? root.toString(syntax) : root.toString()
 }

--- a/lib/utils/setBlockAfter/index.ts
+++ b/lib/utils/setBlockAfter/index.ts
@@ -1,7 +1,7 @@
+import type { Container } from "postcss"
+
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { lastNodeHoldsTheBlockAfter } from "../lastNodeHoldsTheBlockAfter/index.ts"
-
-export type Container = import("postcss").Container
 
 /**
  * Sets the block's final raw, in the raw the parser filed it in — which is the one {@link lastNodeHoldsTheBlockAfter} names and `getBlockAfter` reads back.

--- a/lib/utils/setDeclarationValue/index.test.ts
+++ b/lib/utils/setDeclarationValue/index.test.ts
@@ -1,6 +1,8 @@
-import { parse } from "postcss"
+import { type Declaration, parse } from "postcss"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
+
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setDeclarationValue } from "./index.ts"
 
@@ -41,7 +43,7 @@ describe(`setDeclarationValue`, () => {
 
 		setDeclarationValue(node, `0 // c\n  2px`)
 
-		expect((node.raws.value as import("../typeGuards/index.ts").SyntaxRaw).scss).toBe(`0 // c\n  2px`)
+		expect((node.raws.value as SyntaxRaw).scss).toBe(`0 // c\n  2px`)
 	})
 
 	it(`keeps the raw beside it in step`, () => {
@@ -49,7 +51,7 @@ describe(`setDeclarationValue`, () => {
 
 		setDeclarationValue(node, `0 // c\n  2px`)
 
-		expect((node.raws.value as import("../typeGuards/index.ts").SyntaxRaw).raw).toBe(`0 /* c*/\n  2px`)
+		expect((node.raws.value as SyntaxRaw).raw).toBe(`0 /* c*/\n  2px`)
 	})
 
 	it(`the syntax prints what was written`, () => {
@@ -68,8 +70,8 @@ describe(`setDeclarationValue`, () => {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function decl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function decl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parse(css).walkDecls((d) => {
 		list.push(d)
@@ -83,8 +85,8 @@ function decl (css: string): import("postcss").Declaration {
  * @param css - The stylesheet.
  * @returns That declaration.
  */
-function scssDecl (css: string): import("postcss").Declaration {
-	let list: import("postcss").Declaration[] = []
+function scssDecl (css: string): Declaration {
+	let list: Declaration[] = []
 
 	parseScss(css).walkDecls((d) => {
 		list.push(d)

--- a/lib/utils/setDeclarationValue/index.ts
+++ b/lib/utils/setDeclarationValue/index.ts
@@ -1,7 +1,8 @@
+import type { Declaration } from "postcss"
+
 import { findInlineCommentSpans } from "../findInlineCommentSpans/index.ts"
 import { rewriteInlineComments } from "../rewriteInlineComments/index.ts"
-
-export type Declaration = import("postcss").Declaration
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 /**
  * Sets the value of a CSS declaration, in the copy of it the syntax prints.
@@ -12,7 +13,7 @@ export type Declaration = import("postcss").Declaration
  * @returns The declaration that was passed in.
  */
 export function setDeclarationValue (decl: Declaration, value: string): Declaration {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = decl.raws.value
+	let syntaxRaw: SyntaxRaw | undefined = decl.raws.value
 
 	if (syntaxRaw) {
 		if (typeof syntaxRaw.scss === `string`) {

--- a/lib/utils/setRuleSelector/index.test.ts
+++ b/lib/utils/setRuleSelector/index.test.ts
@@ -1,7 +1,9 @@
-import { parse } from "postcss"
+import { type Document, parse, type Root, type Rule } from "postcss"
 import { parse as parseLess } from "postcss-less"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
+
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setRuleSelector } from "./index.ts"
 
@@ -42,7 +44,7 @@ describe(`setRuleSelector`, () => {
 
 		setRuleSelector(node, `a // c\r\n, b`)
 
-		expect((node.raws.selector as import("../typeGuards/index.ts").SyntaxRaw).scss).toBe(`a // c\r\n, b`)
+		expect((node.raws.selector as SyntaxRaw).scss).toBe(`a // c\r\n, b`)
 	})
 
 	it(`keeps the raw beside it in step`, () => {
@@ -50,7 +52,7 @@ describe(`setRuleSelector`, () => {
 
 		setRuleSelector(node, `a // c\r\n, b`)
 
-		expect((node.raws.selector as import("../typeGuards/index.ts").SyntaxRaw).raw).toBe(`a /* c*/\r\n, b`)
+		expect((node.raws.selector as SyntaxRaw).raw).toBe(`a /* c*/\r\n, b`)
 	})
 
 	it(`the syntax prints what was written`, () => {
@@ -78,7 +80,7 @@ describe(`setRuleSelector`, () => {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function rule (css: string): import("postcss").Rule {
+function rule (css: string): Rule {
 	return collect(parse(css))
 }
 
@@ -87,7 +89,7 @@ function rule (css: string): import("postcss").Rule {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function scssRule (css: string): import("postcss").Rule {
+function scssRule (css: string): Rule {
 	return collect(parseScss(css))
 }
 
@@ -96,7 +98,7 @@ function scssRule (css: string): import("postcss").Rule {
  * @param css - The stylesheet.
  * @returns That rule.
  */
-function lessRule (css: string): import("postcss").Rule {
+function lessRule (css: string): Rule {
 	return collect(parseLess(css))
 }
 
@@ -105,8 +107,8 @@ function lessRule (css: string): import("postcss").Rule {
  * @param root - The parsed stylesheet.
  * @returns That rule.
  */
-function collect (root: import("postcss").Root | import("postcss").Document): import("postcss").Rule {
-	let list: import("postcss").Rule[] = []
+function collect (root: Root | Document): Rule {
+	let list: Rule[] = []
 
 	root.walkRules((node) => {
 		list.push(node)

--- a/lib/utils/setRuleSelector/index.ts
+++ b/lib/utils/setRuleSelector/index.ts
@@ -1,7 +1,8 @@
+import type { Rule } from "postcss"
+
 import { findInlineCommentSpans } from "../findInlineCommentSpans/index.ts"
 import { rewriteInlineComments } from "../rewriteInlineComments/index.ts"
-
-export type Rule = import("postcss").Rule
+import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 /**
  * Sets the selector of a rule, in the copy of it the syntax prints.
@@ -12,7 +13,7 @@ export type Rule = import("postcss").Rule
  * @returns The rule that was passed in.
  */
 export function setRuleSelector (rule: Rule, selector: string): Rule {
-	let syntaxRaw: import("../typeGuards/index.ts").SyntaxRaw | undefined = rule.raws.selector
+	let syntaxRaw: SyntaxRaw | undefined = rule.raws.selector
 
 	if (syntaxRaw) {
 		if (typeof syntaxRaw.scss === `string`) {

--- a/lib/utils/syncLessVariableValue/index.test.ts
+++ b/lib/utils/syncLessVariableValue/index.test.ts
@@ -1,4 +1,4 @@
-import postcss from "postcss"
+import postcss, { type AtRule, type Node, type Parser } from "postcss"
 import postcssLess from "postcss-less"
 import { describe, expect, it } from "vitest"
 
@@ -55,8 +55,8 @@ describe(`syncLessVariableValue`, () => {
  * @param parser - The syntax to read it with.
  * @returns That at-rule.
  */
-function atRule (code: string, parser: { parse: import("postcss").Parser } = postcss): import("postcss").AtRule {
-	let list: import("postcss").AtRule[] = []
+function atRule (code: string, parser: { parse: Parser } = postcss): AtRule {
+	let list: AtRule[] = []
 
 	parser.parse(code).walkAtRules((rule) => {
 		list.push(rule)
@@ -70,7 +70,7 @@ function atRule (code: string, parser: { parse: import("postcss").Parser } = pos
  * @param code - The stylesheet.
  * @returns That at-rule.
  */
-function lessAtRule (code: string): import("postcss").AtRule {
+function lessAtRule (code: string): AtRule {
 	return atRule(code, postcssLess)
 }
 
@@ -79,6 +79,6 @@ function lessAtRule (code: string): import("postcss").AtRule {
  * @param node - A node of that stylesheet.
  * @returns The stylesheet.
  */
-function less (node: import("postcss").Node): string {
+function less (node: Node): string {
 	return node.root().toString(postcssLess)
 }

--- a/lib/utils/syncLessVariableValue/index.ts
+++ b/lib/utils/syncLessVariableValue/index.ts
@@ -1,4 +1,7 @@
-export type AtRule = import("postcss").AtRule | import("postcss-less").AtRule
+import type { AtRule as PostcssAtRule } from "postcss"
+import type { AtRule as LessAtRule } from "postcss-less"
+
+export type AtRule = PostcssAtRule | LessAtRule
 
 /**
  * Mirrors the params just written to an at-rule into the value that `postcss-less` prints.

--- a/lib/utils/toSelectorSourceIndex/index.ts
+++ b/lib/utils/toSelectorSourceIndex/index.ts
@@ -1,10 +1,12 @@
+import type { InlineComment } from "../findSelectorInlineComments/index.ts"
+
 /**
  * Converts an index of the parsed selector into an index of the source the node is stringified from.
  * @param index - The index in the parsed selector.
  * @param inlineComments - The inline comments of the selector.
  * @returns The index in the source.
  */
-export function toSelectorSourceIndex (index: number, inlineComments: import("../findSelectorInlineComments/index.ts").InlineComment[]): number {
+export function toSelectorSourceIndex (index: number, inlineComments: InlineComment[]): number {
 	let delta = 0
 
 	for (let inlineComment of inlineComments) {

--- a/lib/utils/transformSelector/index.test.ts
+++ b/lib/utils/transformSelector/index.test.ts
@@ -1,4 +1,5 @@
 import { rule } from "postcss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it, vi } from "vitest"
 
 import { transformSelector } from "./index.ts"
@@ -6,7 +7,7 @@ import { transformSelector } from "./index.ts"
 describe(`transformSelector`, () => {
 	it(`success`, () => {
 		let warn = vi.fn()
-		let result = { warn } as unknown as import("stylelint").PostcssResult
+		let result = { warn } as unknown as PostcssResult
 		let ruleNode = rule({ selector: `a, b > c` })
 		let callback = vi.fn()
 
@@ -17,7 +18,7 @@ describe(`transformSelector`, () => {
 
 	it(`failure`, () => {
 		let warn = vi.fn()
-		let result = { warn } as unknown as import("stylelint").PostcssResult
+		let result = { warn } as unknown as PostcssResult
 		let ruleNode = rule({ selector: `a[}` })
 		let callback = vi.fn()
 

--- a/lib/utils/transformSelector/index.ts
+++ b/lib/utils/transformSelector/index.ts
@@ -1,4 +1,6 @@
-import selectorParser from "postcss-selector-parser"
+import type { Rule } from "postcss"
+import selectorParser, { type Root } from "postcss-selector-parser"
+import type { PostcssResult } from "stylelint"
 
 /**
  * Runs a callback over a rule's parsed selector and writes the result back into the rule.
@@ -7,7 +9,7 @@ import selectorParser from "postcss-selector-parser"
  * @param callback - The callback to transform the selector.
  * @returns The selector as the callback left it, or undefined where the parser refused it.
  */
-export function transformSelector (result: import("stylelint").PostcssResult, node: import("postcss").Rule, callback: (root: import("postcss-selector-parser").Root) => void): string | undefined {
+export function transformSelector (result: PostcssResult, node: Rule, callback: (root: Root) => void): string | undefined {
 	try {
 		return selectorParser(callback).processSync(node, { updateSelector: true })
 	}

--- a/lib/utils/typeGuards/index.ts
+++ b/lib/utils/typeGuards/index.ts
@@ -1,18 +1,18 @@
-export type Node = import("postcss").Node
-export type NodeSource = import("postcss").Source
+import type { AtRule, Comment, Declaration, Document, Node, Parser, Root, Rule, Source as NodeSource, Syntax } from "postcss"
+import type { FunctionNode, Node as ValueParserNode } from "postcss-value-parser"
 
 /** The raw of a selector, a value or a set of params. PostCSS keeps the text with its comments in `raw` beside the copy it hands back in `value`, and `postcss-scss` keeps a third copy under `scss`, spelled as the file spells it with every `//` comment in place, which is the one it prints. */
 export type SyntaxRaw = { raw: string, value: string, scss?: string }
 
 /** The source of a root `postcss-html` read out of a page, beside what PostCSS gives every node: whether the block came out of a `style` attribute, the language the block names, and the syntax it was parsed with. */
-export type EmbeddedSource = import("postcss").Source & { inline?: boolean, lang?: string, syntax?: import("postcss").Syntax }
+export type EmbeddedSource = NodeSource & { inline?: boolean, lang?: string, syntax?: Syntax }
 
 /**
  * Checks if a node is a PostCSS Root node.
  * @param node - The node to check.
  * @returns True if the node is a Root, false otherwise.
  */
-export function isRoot (node: Node): node is import("postcss").Root {
+export function isRoot (node: Node): node is Root {
 	return node.type === `root`
 }
 
@@ -21,7 +21,7 @@ export function isRoot (node: Node): node is import("postcss").Root {
  * @param node - The node to check.
  * @returns True if the node is a Rule, false otherwise.
  */
-export function isRule (node: Node): node is import("postcss").Rule {
+export function isRule (node: Node): node is Rule {
 	return node.type === `rule`
 }
 
@@ -30,7 +30,7 @@ export function isRule (node: Node): node is import("postcss").Rule {
  * @param node - The node to check.
  * @returns True if the node is an AtRule, false otherwise.
  */
-export function isAtRule (node: Node): node is import("postcss").AtRule {
+export function isAtRule (node: Node): node is AtRule {
 	return node.type === `atrule`
 }
 
@@ -39,7 +39,7 @@ export function isAtRule (node: Node): node is import("postcss").AtRule {
  * @param node - The node to check.
  * @returns True if the node is a Comment, false otherwise.
  */
-export function isComment (node: Node): node is import("postcss").Comment {
+export function isComment (node: Node): node is Comment {
 	return node.type === `comment`
 }
 
@@ -48,7 +48,7 @@ export function isComment (node: Node): node is import("postcss").Comment {
  * @param node - The node to check.
  * @returns True if the node is a Declaration, false otherwise.
  */
-export function isDeclaration (node: Node): node is import("postcss").Declaration {
+export function isDeclaration (node: Node): node is Declaration {
 	return node.type === `decl`
 }
 
@@ -57,7 +57,7 @@ export function isDeclaration (node: Node): node is import("postcss").Declaratio
  * @param node - The node to check.
  * @returns True if the node is a Document, false otherwise.
  */
-export function isDocument (node: Node): node is import("postcss").Document {
+export function isDocument (node: Node): node is Document {
 	return node.type === `document`
 }
 
@@ -66,7 +66,7 @@ export function isDocument (node: Node): node is import("postcss").Document {
  * @param node - The node to check.
  * @returns True if the node is a Function, false otherwise.
  */
-export function isValueFunction (node: import("postcss-value-parser").Node): node is import("postcss-value-parser").FunctionNode {
+export function isValueFunction (node: ValueParserNode): node is FunctionNode {
 	return node.type === `function`
 }
 
@@ -84,7 +84,7 @@ export function hasSource (node: Node): node is (Node & { source: NodeSource }) 
  * @param value - The value a configuration named as a syntax, or nothing at all.
  * @returns True where it can parse.
  */
-export function isSyntax (value: unknown): value is { parse: import("postcss").Parser } {
+export function isSyntax (value: unknown): value is { parse: Parser } {
 	// PostCSS itself is a function carrying `parse`, and a syntax package is an object carrying one
 	return (typeof value === `object` || typeof value === `function`) && value !== null && `parse` in value && typeof value.parse === `function`
 }

--- a/lib/utils/typeGuards/index.ts
+++ b/lib/utils/typeGuards/index.ts
@@ -2,10 +2,18 @@ import type { AtRule, Comment, Declaration, Document, Node, Parser, Root, Rule, 
 import type { FunctionNode, Node as ValueParserNode } from "postcss-value-parser"
 
 /** The raw of a selector, a value or a set of params. PostCSS keeps the text with its comments in `raw` beside the copy it hands back in `value`, and `postcss-scss` keeps a third copy under `scss`, spelled as the file spells it with every `//` comment in place, which is the one it prints. */
-export type SyntaxRaw = { raw: string, value: string, scss?: string }
+export type SyntaxRaw = {
+	raw: string,
+	value: string,
+	scss?: string,
+}
 
 /** The source of a root `postcss-html` read out of a page, beside what PostCSS gives every node: whether the block came out of a `style` attribute, the language the block names, and the syntax it was parsed with. */
-export type EmbeddedSource = NodeSource & { inline?: boolean, lang?: string, syntax?: Syntax }
+export type EmbeddedSource = NodeSource & {
+	inline?: boolean,
+	lang?: string,
+	syntax?: Syntax,
+}
 
 /**
  * Checks if a node is a PostCSS Root node.

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -18,7 +18,11 @@ export interface ValueListCommaWhitespaceCheckerOptions {
 	result: PostcssResult,
 
 	/** The location checker function. */
-	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
+	locationChecker: (opts: {
+		source: string,
+		index: number,
+		err: (msg: string) => void,
+	}) => void,
 
 	/** The name of the rule being checked. */
 	checkedRuleName: string,

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -1,5 +1,6 @@
-import styleSearch from "style-search"
-import stylelint from "stylelint"
+import type { Declaration, Root } from "postcss"
+import styleSearch, { type StyleSearchMatch } from "style-search"
+import stylelint, { type PostcssResult } from "stylelint"
 
 import { declarationString } from "../declarationString/index.ts"
 import { isStandardSyntaxDeclaration } from "../isStandardSyntaxDeclaration/index.ts"
@@ -11,10 +12,10 @@ let { utils: { report } } = stylelint
 export interface ValueListCommaWhitespaceCheckerOptions {
 
 	/** The PostCSS root node. */
-	root: import("postcss").Root,
+	root: Root,
 
 	/** The Stylelint result. */
-	result: import("stylelint").PostcssResult,
+	result: PostcssResult,
 
 	/** The location checker function. */
 	locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
@@ -23,13 +24,13 @@ export interface ValueListCommaWhitespaceCheckerOptions {
 	checkedRuleName: string,
 
 	/** The fix function. */
-	fix?: ((node: import("postcss").Declaration, index: number) => void),
+	fix?: ((node: Declaration, index: number) => void),
 
 	/** Tells whether this particular problem can be fixed. The declaration comes with it as the checker has already printed it, so that a rule reading the text in front of the comma need not print it again. */
-	isFixable?: ((node: import("postcss").Declaration, index: number, declString: string) => boolean),
+	isFixable?: ((node: Declaration, index: number, declString: string) => boolean),
 
 	/** The index determination function. */
-	determineIndex?: ((declString: string, match: import("style-search").StyleSearchMatch) => number | false),
+	determineIndex?: ((declString: string, match: StyleSearchMatch) => number | false),
 }
 
 /**
@@ -67,7 +68,7 @@ export function valueListCommaWhitespaceChecker (opts: ValueListCommaWhitespaceC
 	 * @param index - The index of the comma.
 	 * @param node - The declaration node.
 	 */
-	function checkComma (source: string, index: number, node: import("postcss").Declaration): void {
+	function checkComma (source: string, index: number, node: Declaration): void {
 		opts.locationChecker({
 			source,
 			index,

--- a/lib/utils/withoutComments/index.ts
+++ b/lib/utils/withoutComments/index.ts
@@ -2,7 +2,10 @@ import { LEADING_NON_WHITESPACE, TRAILING_SPACES } from "../../regexps.ts"
 import { type CommentSpan, findCommentSpans } from "../findCommentSpans/index.ts"
 
 /** The run a comment takes out of a text when it is removed from it, from the first character taken to the one behind the last. */
-export type RemovedRun = { start: number, end: number }
+export type RemovedRun = {
+	start: number,
+	end: number,
+}
 
 /**
  * Says which runs of a text its comments take with them when they are removed.

--- a/lib/utils/withoutComments/index.ts
+++ b/lib/utils/withoutComments/index.ts
@@ -1,7 +1,5 @@
 import { LEADING_NON_WHITESPACE, TRAILING_SPACES } from "../../regexps.ts"
-import { findCommentSpans } from "../findCommentSpans/index.ts"
-
-export type CommentSpan = import("../findCommentSpans/index.ts").CommentSpan
+import { type CommentSpan, findCommentSpans } from "../findCommentSpans/index.ts"
 
 /** The run a comment takes out of a text when it is removed from it, from the first character taken to the one behind the last. */
 export type RemovedRun = { start: number, end: number }

--- a/lib/utils/writesIntoInlineComment/index.test.ts
+++ b/lib/utils/writesIntoInlineComment/index.test.ts
@@ -1,6 +1,7 @@
-import { parse } from "postcss"
+import { type Container, type Document, type Node, parse, type Parser, type Root } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
 import { writesIntoInlineComment } from "./index.ts"
@@ -16,13 +17,13 @@ const PLAIN_CSS = { parse }
  * @param spelledBetween - The run the fix would leave standing between that node and the write.
  * @returns What the utility answers.
  */
-function ask (syntax: { parse: import("postcss").Parser }, code: string, pick: (root: import("postcss").Root | import("postcss").Document) => import("postcss").Node | undefined, spelledBetween?: string): boolean {
+function ask (syntax: { parse: Parser }, code: string, pick: (root: Root | Document) => Node | undefined, spelledBetween?: string): boolean {
 	let root = syntax.parse(code, { from: undefined })
 	let node = pick(root)
 
 	if (!node) throw new Error(`The case picks no node`)
 
-	return writesIntoInlineComment(node, { opts: { syntax } } as unknown as import("stylelint").PostcssResult, spelledBetween)
+	return writesIntoInlineComment(node, { opts: { syntax } } as unknown as PostcssResult, spelledBetween)
 }
 
 /**
@@ -30,8 +31,8 @@ function ask (syntax: { parse: import("postcss").Parser }, code: string, pick: (
  * @param root - The parsed stylesheet.
  * @returns That statement.
  */
-function block (root: import("postcss").Root | import("postcss").Document): import("postcss").Container {
-	return root.first as import("postcss").Container
+function block (root: Root | Document): Container {
+	return root.first as Container
 }
 
 describe(`writesIntoInlineComment`, () => {

--- a/lib/utils/writesIntoInlineComment/index.ts
+++ b/lib/utils/writesIntoInlineComment/index.ts
@@ -1,3 +1,6 @@
+import type { Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
 import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
 import { getAtRuleParams } from "../getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
@@ -13,7 +16,7 @@ const A_WRITTEN_CHARACTER = `;`
  * @param node - The node to ask about.
  * @returns True where it is such a comment.
  */
-function isInlineComment (node: import("postcss").Node): boolean {
+function isInlineComment (node: Node): boolean {
 	return isComment(node) && Boolean((`inline` in node && node.inline) || node.raws.inline)
 }
 
@@ -30,7 +33,7 @@ function isInlineComment (node: import("postcss").Node): boolean {
  * @param node - The node the write would stand behind.
  * @returns That text, empty where the node ends with something no comment can hold.
  */
-function textAWriteFollows (node: import("postcss").Node): string {
+function textAWriteFollows (node: Node): string {
 	if (isComment(node)) return isInlineComment(node) ? `//` : ``
 
 	if (isDeclaration(node)) return getDeclarationValue(node) + (node.raws.important || ``)
@@ -53,7 +56,7 @@ function textAWriteFollows (node: import("postcss").Node): string {
  * @param spelledBetween - The run that will stand between the node and the write once the fix has run, where the write does not land on the whitespace the node ends with.
  * @returns True where such a write would land inside an inline comment.
  */
-export function writesIntoInlineComment (node: import("postcss").Node, result: import("stylelint").PostcssResult, spelledBetween?: string): boolean {
+export function writesIntoInlineComment (node: Node, result: PostcssResult, spelledBetween?: string): boolean {
 	let text = textAWriteFollows(node)
 	let reading = inlineCommentReading(node, result)
 

--- a/scripts/harness/cache.ts
+++ b/scripts/harness/cache.ts
@@ -97,7 +97,7 @@ function fileOf (kind: string, name: string, key: string): string {
  * @param rows - The rows by key.
  * @returns A hash of each row by the same key.
  */
-function digestOf (rows: Record<string, unknown>): Record<string, string> {
+function digestOf (rows: Record<string, unknown> | unknown[]): Record<string, string> {
 	let digest: Record<string, string> = {}
 
 	for (let [key, row] of Object.entries(rows)) digest[key] = createHash(`sha1`).update(JSON.stringify(row)).digest(`hex`).slice(0, 16)
@@ -123,12 +123,12 @@ function digestFileOf (kind: string, name: string, key: string): string {
  * @param key - The key.
  * @returns The rows, or nothing where none were kept.
  */
-function read (kind: string, name: string, key: string): unknown | undefined {
+function read<T> (kind: string, name: string, key: string): T | undefined {
 	let file = fileOf(kind, name, key)
 
 	if (!existsSync(file)) return
 
-	return JSON.parse(readFileSync(file, `utf8`))
+	return JSON.parse(readFileSync(file, `utf8`)) as T
 }
 
 /** The digests read in this process, by file. */
@@ -161,14 +161,14 @@ function readDigest (kind: string, name: string, key: string): Record<string, st
  * @param meta - What the key was made of, and where and when the run was made, kept beside the rows for a reader and for the collector.
  * @param digest - The digest of the rows, where the caller has it already.
  */
-function write (kind: string, name: string, key: string, rows: unknown, meta: object, digest?: Record<string, string>): void {
+function write (kind: string, name: string, key: string, rows: Record<string, unknown> | unknown[], meta: object, digest?: Record<string, string>): void {
 	let file = fileOf(kind, name, key)
 
 	if (existsSync(file)) throw new Error(`${file} is already written; a result is written once, and a second answer to the same question is a finding rather than an update`)
 
 	mkdirSync(path.dirname(file), { recursive: true })
 	writeFileSync(file, JSON.stringify(rows))
-	writeFileSync(digestFileOf(kind, name, key), JSON.stringify(digest ?? digestOf(rows as Record<string, unknown>)))
+	writeFileSync(digestFileOf(kind, name, key), JSON.stringify(digest ?? digestOf(rows)))
 	writeFileSync(`${file.slice(0, -5)}.meta.json`, `${JSON.stringify({ ...meta, writtenAt: new Date().toISOString() }, null, `\t`)}\n`)
 	chmodSync(file, READ_ONLY)
 	chmodSync(digestFileOf(kind, name, key), READ_ONLY)

--- a/scripts/harness/diff.ts
+++ b/scripts/harness/diff.ts
@@ -10,7 +10,12 @@
  * @param head - The rows of the branch, by key.
  * @returns The keys the branch added, the keys it removed, the keys it changed, and how many it left as they were.
  */
-function diff (base: Record<string, unknown>, head: Record<string, unknown>): { added: string[], removed: string[], changed: string[], same: number } {
+function diff (base: Record<string, unknown>, head: Record<string, unknown>): {
+	added: string[],
+	removed: string[],
+	changed: string[],
+	same: number,
+} {
 	let added = []
 	let removed = []
 	let changed = []

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -22,7 +22,15 @@ const CONFIGURATION_COMMENT = `stylelint`
 const SEVERITY = `error`
 
 /** What a rule said, in the fields the oracles read; the warning standing in for a parse error carries no position. */
-export type Warning = { rule?: string, text: string, line?: number, column?: number, endLine?: number, endColumn?: number, severity?: string }
+export type Warning = {
+	rule?: string,
+	text: string,
+	line?: number,
+	column?: number,
+	endLine?: number,
+	endColumn?: number,
+	severity?: string,
+}
 
 /** A rule by its short name, with its primary option and, where there is one, its secondary options. */
 export type RuleSetting = [string, unknown, object?]
@@ -31,10 +39,22 @@ export type RuleSetting = [string, unknown, object?]
 export type Registry = Record<string, Rule>
 
 /** What the rules said and wrote, or why the text could not be read. */
-export type Answer = { unparsable: true, detail: string } | { unparsable: false, usable: boolean, warnings: Warning[], code: string }
+export type Answer = {
+	unparsable: true,
+	detail: string,
+} | {
+	unparsable: false,
+	usable: boolean,
+	warnings: Warning[],
+	code: string,
+}
 
 /** The configuration `runs.ts` builds: a plugin named by its path, a syntax named by its package, and the rules under their namespaced names. */
-export type Config = { plugins: string[], customSyntax?: string, rules: Record<string, unknown> }
+export type Config = {
+	plugins: string[],
+	customSyntax?: string,
+	rules: Record<string, unknown>,
+}
 
 /** The syntaxes a run can name, each loaded once on first use. */
 let syntaxes: Map<string, Syntax> = new Map()
@@ -103,7 +123,13 @@ function settingsOf (rules: Record<string, unknown>): RuleSetting[] {
  * @param [options.fix] - Whether the rules are let write.
  * @returns What the rules said and wrote, or why the text could not be read at all. A run is `usable` where no rule objected to its options, as `isUsable` of the oracles has it.
  */
-async function lintDirect ({ code, rules, registry, syntax, fix = false }: { code: string, rules: RuleSetting[], registry: Registry, syntax?: string | Syntax, fix?: boolean }): Promise<Answer> {
+async function lintDirect ({ code, rules, registry, syntax, fix = false }: {
+	code: string,
+	rules: RuleSetting[],
+	registry: Registry,
+	syntax?: string | Syntax,
+	fix?: boolean,
+}): Promise<Answer> {
 	let parser = await loadSyntax(syntax)
 
 	let result: PostcssResult
@@ -112,12 +138,18 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }: { cod
 		result = postcss().process(code, { from: undefined, syntax: parser }).sync() as PostcssResult
 	}
 	catch (error) {
-		let { reason, message } = error as { reason?: string, message: string }
+		let { reason, message } = error as {
+			reason?: string,
+			message: string,
+		}
 
 		return { unparsable: true, detail: reason ?? message }
 	}
 
-	let config: { fix: boolean, rules: Record<string, [unknown, object | undefined]> } = { fix, rules: {} }
+	let config: {
+		fix: boolean,
+		rules: Record<string, [unknown, object | undefined]>,
+	} = { fix, rules: {} }
 
 	let ruleSeverities: Record<string, RuleSeverity> = {}
 
@@ -155,7 +187,10 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }: { cod
 	let usable = true
 
 	// What `report` hangs on a warning beyond what PostCSS declares: the kind of warning where it is not a rule's, and the rule where it is
-	for (let warning of (result.warnings() as (PostcssWarning & { stylelintType?: string, rule?: string })[])) {
+	for (let warning of (result.warnings() as (PostcssWarning & {
+		stylelintType?: string,
+		rule?: string,
+	})[])) {
 		if (warning.stylelintType === `invalidOption`) {
 			usable = false
 			continue
@@ -182,7 +217,14 @@ let registries: Map<string, Registry> = new Map()
  * @param [options.fix] - Whether the rules are let write.
  * @returns The answer, shaped like Stylelint's.
  */
-async function lint ({ code, config, fix = false }: { code: string, config: Config, fix?: boolean }): Promise<{ results: [{ warnings: Warning[], invalidOptionWarnings: { text: string }[] }], code: string | undefined }> {
+async function lint ({ code, config, fix = false }: {
+	code: string,
+	config: Config,
+	fix?: boolean,
+}): Promise<{
+	results: [{ warnings: Warning[], invalidOptionWarnings: { text: string }[] }],
+	code: string | undefined,
+}> {
 	let [plugin] = config.plugins
 	let registry = registries.get(plugin)
 

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -9,7 +9,8 @@
 import { EOL } from "node:os"
 import path from "node:path"
 
-import postcss from "postcss"
+import postcss, { type Document, type Root, type Syntax, type Warning as PostcssWarning } from "postcss"
+import type { PostcssResult, Rule, RuleMeta, RuleSeverity, StylelintPostcssResult } from "stylelint"
 
 import { entryAt } from "./checkout.ts"
 import { BREAK_AS_STYLELINT_READS_IT } from "./regexps.ts"
@@ -20,9 +21,6 @@ const CONFIGURATION_COMMENT = `stylelint`
 /** The severity every rule is given, since a run here has no configuration to set another. */
 const SEVERITY = `error`
 
-/** A syntax as a configuration hands one over: what parses a text and what prints it back. */
-export type Syntax = import("postcss").Syntax
-
 /** What a rule said, in the fields the oracles read; the warning standing in for a parse error carries no position. */
 export type Warning = { rule?: string, text: string, line?: number, column?: number, endLine?: number, endColumn?: number, severity?: string }
 
@@ -30,7 +28,7 @@ export type Warning = { rule?: string, text: string, line?: number, column?: num
 export type RuleSetting = [string, unknown, object?]
 
 /** The rules of one checkout by their short names, as `lib/rules/index.js` exports them. */
-export type Registry = Record<string, import("stylelint").Rule>
+export type Registry = Record<string, Rule>
 
 /** What the rules said and wrote, or why the text could not be read. */
 export type Answer = { unparsable: true, detail: string } | { unparsable: false, usable: boolean, warnings: Warning[], code: string }
@@ -108,10 +106,10 @@ function settingsOf (rules: Record<string, unknown>): RuleSetting[] {
 async function lintDirect ({ code, rules, registry, syntax, fix = false }: { code: string, rules: RuleSetting[], registry: Registry, syntax?: string | Syntax, fix?: boolean }): Promise<Answer> {
 	let parser = await loadSyntax(syntax)
 
-	let result: import("stylelint").PostcssResult
+	let result: PostcssResult
 
 	try {
-		result = postcss().process(code, { from: undefined, syntax: parser }).sync() as import("stylelint").PostcssResult
+		result = postcss().process(code, { from: undefined, syntax: parser }).sync() as PostcssResult
 	}
 	catch (error) {
 		let { reason, message } = error as { reason?: string, message: string }
@@ -121,16 +119,16 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }: { cod
 
 	let config: { fix: boolean, rules: Record<string, [unknown, object | undefined]> } = { fix, rules: {} }
 
-	let ruleSeverities: Record<string, import("stylelint").RuleSeverity> = {}
+	let ruleSeverities: Record<string, RuleSeverity> = {}
 
-	let ruleMetadata: Record<string, Partial<import("stylelint").RuleMeta>> = {}
+	let ruleMetadata: Record<string, Partial<RuleMeta>> = {}
 	// The least of a result the rules read: `report` looks the rule's severity, its metadata and the configuration up here, and the fields it never touches are left out
-	let stylelint = { ruleSeverities, customMessages: {}, customUrls: {}, ruleMetadata, fixersData: {}, rangesOfComputedEditInfos: [], disabledRanges: {}, config } as unknown as import("stylelint").StylelintPostcssResult
+	let stylelint = { ruleSeverities, customMessages: {}, customUrls: {}, ruleMetadata, fixersData: {}, rangesOfComputedEditInfos: [], disabledRanges: {}, config } as unknown as StylelintPostcssResult
 
 	result.stylelint = stylelint
 
 	let context = { configurationComment: CONFIGURATION_COMMENT, newline: code.match(BREAK_AS_STYLELINT_READS_IT)?.[0] ?? EOL }
-	let parsed = result.root as import("postcss").Root | import("postcss").Document
+	let parsed = result.root as Root | Document
 	let roots = parsed.type === `document` ? parsed.nodes : [parsed]
 
 	for (let [name, primary, secondary] of rules) {
@@ -157,7 +155,7 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }: { cod
 	let usable = true
 
 	// What `report` hangs on a warning beyond what PostCSS declares: the kind of warning where it is not a rule's, and the rule where it is
-	for (let warning of (result.warnings() as (import("postcss").Warning & { stylelintType?: string, rule?: string })[])) {
+	for (let warning of (result.warnings() as (PostcssWarning & { stylelintType?: string, rule?: string })[])) {
 		if (warning.stylelintType === `invalidOption`) {
 			usable = false
 			continue

--- a/scripts/harness/verify-lint.ts
+++ b/scripts/harness/verify-lint.ts
@@ -81,7 +81,13 @@ function disagreement (expected: Answer, actual: Answer): string | null {
 
 let compared = 0
 
-let failures: { label: string, fix: boolean, field: string, expected: Answer, actual: Answer }[] = []
+let failures: {
+	label: string,
+	fix: boolean,
+	field: string,
+	expected: Answer,
+	actual: Answer,
+}[] = []
 
 /**
  * Compares one configuration over one text, checking and fixing.

--- a/scripts/harness/verify-lint.ts
+++ b/scripts/harness/verify-lint.ts
@@ -13,7 +13,7 @@ import stylelint from "stylelint"
 import { RULE_OPTIONS } from "../oracles/options.ts"
 import { buildRuns, isUsable } from "../oracles/runs.ts"
 
-import { lintDirect, loadRules, settingsOf } from "./lint.ts"
+import { type Answer, type Config, lintDirect, loadRules, settingsOf } from "./lint.ts"
 
 /** The registry of this checkout, which is the one every oracle reads too. */
 const REGISTRY = await loadRules(new URL(`../../lib`, import.meta.url).pathname)
@@ -28,7 +28,7 @@ const PAIRS_PER_FIXTURE = 24
  * @param fix - Whether the rules are let write.
  * @returns The answer in the runner's shape.
  */
-async function askStylelint (code: string, config: import("./lint.ts").Config, fix: boolean): Promise<import("./lint.ts").Answer> {
+async function askStylelint (code: string, config: Config, fix: boolean): Promise<Answer> {
 	let result
 
 	try {
@@ -58,7 +58,7 @@ async function askStylelint (code: string, config: import("./lint.ts").Config, f
  * @param fix - Whether the rules are let write.
  * @returns The answer.
  */
-function askRunner (code: string, config: import("./lint.ts").Config, fix: boolean): Promise<import("./lint.ts").Answer> {
+function askRunner (code: string, config: Config, fix: boolean): Promise<Answer> {
 	return lintDirect({ code, rules: settingsOf(config.rules), registry: REGISTRY, syntax: config.customSyntax, fix })
 }
 
@@ -68,7 +68,7 @@ function askRunner (code: string, config: import("./lint.ts").Config, fix: boole
  * @param actual - What the runner said.
  * @returns The field, or null where the two agree.
  */
-function disagreement (expected: import("./lint.ts").Answer, actual: import("./lint.ts").Answer): string | null {
+function disagreement (expected: Answer, actual: Answer): string | null {
 	if (expected.unparsable !== actual.unparsable) return `unparsable`
 	if (expected.unparsable || actual.unparsable) return null
 	if (expected.usable !== actual.usable) return `usable`
@@ -81,7 +81,7 @@ function disagreement (expected: import("./lint.ts").Answer, actual: import("./l
 
 let compared = 0
 
-let failures: { label: string, fix: boolean, field: string, expected: import("./lint.ts").Answer, actual: import("./lint.ts").Answer }[] = []
+let failures: { label: string, fix: boolean, field: string, expected: Answer, actual: Answer }[] = []
 
 /**
  * Compares one configuration over one text, checking and fixing.
@@ -90,7 +90,7 @@ let failures: { label: string, fix: boolean, field: string, expected: import("./
  * @param config - The configuration.
  * @returns Nothing; a disagreement is recorded.
  */
-async function compare (label: string, code: string, config: import("./lint.ts").Config): Promise<void> {
+async function compare (label: string, code: string, config: Config): Promise<void> {
 	for (let fix of [false, true]) {
 		// The two are asked in turn so that a run of this script stays as light on the machine as the oracle it stands in for
 		// eslint-disable-next-line no-await-in-loop

--- a/scripts/oracles/comments.ts
+++ b/scripts/oracles/comments.ts
@@ -10,7 +10,7 @@ import { stdout } from "node:process"
 
 import { lint } from "../harness/lint.ts"
 
-import { buildRuns, isUsable } from "./runs.ts"
+import { buildRuns, isUsable, type Run } from "./runs.ts"
 
 /** Every opening a comment can be spelled with, counted apart so that one kind turning into the other is a finding too. */
 const EVERY_BLOCK_OPENING = /\/\*/gu
@@ -30,7 +30,7 @@ function tally (text: string): string {
  * @param run - The rule, the option, the syntax and the fixture.
  * @returns The finding, or null where there is none.
  */
-async function probe (run: import("./runs.ts").Run): Promise<object | null> {
+async function probe (run: Run): Promise<object | null> {
 	let before = tally(run.code)
 
 	if (before === `block:0 inline:0`) return null

--- a/scripts/oracles/compare.ts
+++ b/scripts/oracles/compare.ts
@@ -80,8 +80,7 @@ for (let [side, revision] of Object.entries(sides)) {
 	for (let oracle of ORACLES) {
 		let inputs = inputsOf(oracle, revision)
 		let key = keyOf(inputs)
-		// The store hands back what was written, and an oracle writes its rows as a list
-		let rows = read(`oracles`, oracle, key) as Record<string, unknown>[] | undefined
+		let rows = read<Record<string, unknown>[]>(`oracles`, oracle, key)
 
 		if (rows) results[side][oracle] = rows
 		else plan.push({ side, revision, oracle, key, inputs })

--- a/scripts/oracles/compare.ts
+++ b/scripts/oracles/compare.ts
@@ -66,7 +66,13 @@ function run (oracle: string, revision: string): Record<string, unknown>[] {
 let [base = defaultBase(), head = `worktree`] = argv.slice(2)
 let sides = { base, head }
 
-let plan: { side: string, revision: string, oracle: string, key: string, inputs: Record<string, string> }[] = []
+let plan: {
+	side: string,
+	revision: string,
+	oracle: string,
+	key: string,
+	inputs: Record<string, string>,
+}[] = []
 
 let results: Record<string, Record<string, Record<string, unknown>[]>> = { base: {}, head: {} }
 

--- a/scripts/oracles/control.ts
+++ b/scripts/oracles/control.ts
@@ -10,9 +10,9 @@
 
 import { stdout } from "node:process"
 
-import { lint } from "../harness/lint.ts"
+import { type Config, lint } from "../harness/lint.ts"
 
-import { buildRuns } from "./runs.ts"
+import { buildRuns, type Run } from "./runs.ts"
 
 /** The inline comment every fixture is written with, and the block comment of exactly its width that stands in its place. Both are spelled out of the source of this file, so that nothing here is read as a comment of its own. */
 const INLINE_COMMENT = `//${` `}c`
@@ -44,7 +44,7 @@ const CORPUS: [string, string][] = [
  * @param config - The Stylelint configuration.
  * @returns The warnings, each with its position.
  */
-async function warningsOf (code: string, config: import("../harness/lint.ts").Config): Promise<string[]> {
+async function warningsOf (code: string, config: Config): Promise<string[]> {
 	let result = await lint({ code, config, fix: false })
 
 	return result.results[0].warnings.map((warning) => `${warning.line}:${warning.column} ${warning.text}`)
@@ -55,7 +55,7 @@ async function warningsOf (code: string, config: import("../harness/lint.ts").Co
  * @param run - The rule, the option, the syntax and the fixture.
  * @returns The finding, or null where the two agree.
  */
-async function probe (run: import("./runs.ts").Run): Promise<object | null> {
+async function probe (run: Run): Promise<object | null> {
 	let inline
 	let block
 

--- a/scripts/oracles/converge.ts
+++ b/scripts/oracles/converge.ts
@@ -16,14 +16,14 @@ import { stdout } from "node:process"
 
 import { lint } from "../harness/lint.ts"
 
-import { buildRuns, isUsable } from "./runs.ts"
+import { buildRuns, isUsable, type Run } from "./runs.ts"
 
 /**
  * Names a run, without carrying its configuration into the report.
  * @param run - The run to name.
  * @returns The four fields that identify it.
  */
-function label (run: import("./runs.ts").Run): object {
+function label (run: Run): object {
 	return { rule: run.rule, primary: run.primary, syntaxName: run.syntaxName, name: run.name }
 }
 
@@ -32,7 +32,7 @@ function label (run: import("./runs.ts").Run): object {
  * @param run - The rule, the option, the syntax and the fixture.
  * @returns The finding, or null where there is none.
  */
-async function probe (run: import("./runs.ts").Run): Promise<object | null> {
+async function probe (run: Run): Promise<object | null> {
 	let history = [run.code]
 	let current = run.code
 

--- a/scripts/oracles/nodes.ts
+++ b/scripts/oracles/nodes.ts
@@ -10,16 +10,16 @@
 
 import { stdout } from "node:process"
 
-import postcss from "postcss"
+import postcss, { type Parser } from "postcss"
 import less from "postcss-less"
 import scss from "postcss-scss"
 
 import { lint } from "../harness/lint.ts"
 
-import { buildRuns, isUsable } from "./runs.ts"
+import { buildRuns, isUsable, type Run } from "./runs.ts"
 
 /** The parser each syntax of a run is read back with, so that what came out of the fix is counted the way what went in was written. */
-const PARSERS: Record<string, { parse: import("postcss").Parser }> = { css: postcss, less, scss }
+const PARSERS: Record<string, { parse: Parser }> = { css: postcss, less, scss }
 
 /**
  * Counts the declarations, rules and at-rules a stylesheet holds.
@@ -47,7 +47,7 @@ function tally (code: string, syntaxName: string): string | null {
  * @param run - The rule, the option, the syntax and the fixture.
  * @returns The finding, or null where there is none.
  */
-async function probe (run: import("./runs.ts").Run): Promise<object | null> {
+async function probe (run: Run): Promise<object | null> {
 	let before = tally(run.code, run.syntaxName)
 
 	// A fixture the syntax cannot read is no fixture, and one holding nothing to lose is nothing to ask about

--- a/scripts/oracles/pairs.ts
+++ b/scripts/oracles/pairs.ts
@@ -48,7 +48,11 @@ const CONFIGS = Object.entries(RULE_OPTIONS).flatMap(([rule, primaries]) => prim
  * @param fix - Whether the rules are let write.
  * @returns What the run left and what it said, and whether it is a run an oracle can read at all.
  */
-async function lint (code: string, rules: Record<string, unknown>, fix: boolean): Promise<{ code: string, warnings: number, usable: boolean }> {
+async function lint (code: string, rules: Record<string, unknown>, fix: boolean): Promise<{
+	code: string,
+	warnings: number,
+	usable: boolean,
+}> {
 	let result
 
 	try {
@@ -70,8 +74,14 @@ async function lint (code: string, rules: Record<string, unknown>, fix: boolean)
  * @param source - The fixture.
  * @returns The configurations that rewrote it.
  */
-async function activeOn (source: string): Promise<{ rule: string, primary: unknown }[]> {
-	let active: { rule: string, primary: unknown }[] = []
+async function activeOn (source: string): Promise<{
+	rule: string,
+	primary: unknown,
+}[]> {
+	let active: {
+		rule: string,
+		primary: unknown,
+	}[] = []
 
 	for (let config of CONFIGS) {
 		// eslint-disable-next-line no-await-in-loop
@@ -91,7 +101,13 @@ async function activeOn (source: string): Promise<{ rule: string, primary: unkno
  * @param b - The other.
  * @returns The row, or null where the order decides nothing.
  */
-async function probe (name: string, source: string, a: { rule: string, primary: unknown }, b: { rule: string, primary: unknown }): Promise<object | null> {
+async function probe (name: string, source: string, a: {
+	rule: string,
+	primary: unknown,
+}, b: {
+	rule: string,
+	primary: unknown,
+}): Promise<object | null> {
 	let aFirst = await lint(source, { [a.rule]: a.primary, [b.rule]: b.primary }, true)
 	let bFirst = await lint(source, { [b.rule]: b.primary, [a.rule]: a.primary }, true)
 

--- a/scripts/oracles/runs.ts
+++ b/scripts/oracles/runs.ts
@@ -1,6 +1,7 @@
 import { env } from "node:process"
 
 import { entryAt } from "../harness/checkout.ts"
+import type { Config } from "../harness/lint.ts"
 
 import { FIXTURES, INLINE_FIXTURES } from "./fixtures.ts"
 import { RULE_OPTIONS } from "./options.ts"
@@ -8,7 +9,7 @@ import { RULE_OPTIONS } from "./options.ts"
 /** The plugin is loaded by its place on disk, so that an oracle runs the same from any directory — and from another checkout's `lib/` where `HARNESS_LIB` names one, which is how a base is measured with the branch's oracles without moving the working tree. */
 const PLUGIN = entryAt(env.HARNESS_LIB || new URL(`../../lib`, import.meta.url).pathname, `index`)
 
-export type Run = { rule: string, primary: unknown, syntaxName: string, name: string, code: string, config: import("../harness/lint.ts").Config }
+export type Run = { rule: string, primary: unknown, syntaxName: string, name: string, code: string, config: Config }
 
 /**
  * Builds every run an oracle makes: every rule, under every primary option it accepts, over every fixture the syntax can hold.

--- a/scripts/oracles/runs.ts
+++ b/scripts/oracles/runs.ts
@@ -9,7 +9,14 @@ import { RULE_OPTIONS } from "./options.ts"
 /** The plugin is loaded by its place on disk, so that an oracle runs the same from any directory — and from another checkout's `lib/` where `HARNESS_LIB` names one, which is how a base is measured with the branch's oracles without moving the working tree. */
 const PLUGIN = entryAt(env.HARNESS_LIB || new URL(`../../lib`, import.meta.url).pathname, `index`)
 
-export type Run = { rule: string, primary: unknown, syntaxName: string, name: string, code: string, config: Config }
+export type Run = {
+	rule: string,
+	primary: unknown,
+	syntaxName: string,
+	name: string,
+	code: string,
+	config: Config,
+}
 
 /**
  * Builds every run an oracle makes: every rule, under every primary option it accepts, over every fixture the syntax can hold.
@@ -42,7 +49,10 @@ function buildRuns (corpus?: [string, string][]): Run[] {
  * @param result - The result of one lint, of which the warnings and the objections to the options are read.
  * @returns True where the run is worth reading.
  */
-function isUsable (result: { warnings: { rule?: string }[], invalidOptionWarnings?: unknown[] }): boolean {
+function isUsable (result: {
+	warnings: { rule?: string }[],
+	invalidOptionWarnings?: unknown[],
+}): boolean {
 	if (result.warnings.some((warning) => warning.rule === `CssSyntaxError`)) return false
 
 	return (result.invalidOptionWarnings ?? []).length === 0

--- a/scripts/oracles/twins.ts
+++ b/scripts/oracles/twins.ts
@@ -21,9 +21,9 @@
 
 import { stdout } from "node:process"
 
-import { lint } from "../harness/lint.ts"
+import { type Config, lint } from "../harness/lint.ts"
 
-import { buildRuns, isUsable } from "./runs.ts"
+import { buildRuns, isUsable, type Run } from "./runs.ts"
 
 /** Every break of a text, a Windows pair counting as one so that normalising never leaves an empty line behind it. */
 const EVERY_BREAK = /\r?\n/gu
@@ -67,7 +67,7 @@ function normalise (code: string): string {
  * @param config - The configuration to lint it under.
  * @returns What the rule said and wrote, or why the run cannot be read.
  */
-async function ask (code: string, config: import("../harness/lint.ts").Config): Promise<{ read: false, unparsable: boolean, detail?: string } | { read: true, warnings: string[], positions: string[], output: string }> {
+async function ask (code: string, config: Config): Promise<{ read: false, unparsable: boolean, detail?: string } | { read: true, warnings: string[], positions: string[], output: string }> {
 	let checked
 	let fixed
 
@@ -98,7 +98,7 @@ async function ask (code: string, config: import("../harness/lint.ts").Config): 
  * @param run - The run to name.
  * @returns The four fields that identify it.
  */
-function label (run: import("./runs.ts").Run): object {
+function label (run: Run): object {
 	return { rule: run.rule, primary: run.primary, syntaxName: run.syntaxName, name: run.name }
 }
 
@@ -107,7 +107,7 @@ function label (run: import("./runs.ts").Run): object {
  * @param run - The rule, the option, the syntax and the fixture.
  * @returns Every finding of this run, and the empty array where there is none.
  */
-async function probe (run: import("./runs.ts").Run): Promise<object[]> {
+async function probe (run: Run): Promise<object[]> {
 	if (SPELLING_IS_THE_SUBJECT.has(run.rule)) return []
 
 	// The fixture is normalised rather than passed over where it spells a break with a pair already: respelling a line feed in a text that holds `\r\n` would make two breaks of one, while normalising first makes every fixture a line-feed original with a twin, and the `crlf` shape of the shared corpus — one of the few carrying whitespace in front of a break, which is what #247 turns on — joins the run instead of being skipped

--- a/scripts/oracles/twins.ts
+++ b/scripts/oracles/twins.ts
@@ -67,7 +67,16 @@ function normalise (code: string): string {
  * @param config - The configuration to lint it under.
  * @returns What the rule said and wrote, or why the run cannot be read.
  */
-async function ask (code: string, config: Config): Promise<{ read: false, unparsable: boolean, detail?: string } | { read: true, warnings: string[], positions: string[], output: string }> {
+async function ask (code: string, config: Config): Promise<{
+	read: false,
+	unparsable: boolean,
+	detail?: string,
+} | {
+	read: true,
+	warnings: string[],
+	positions: string[],
+	output: string,
+}> {
 	let checked
 	let fixed
 

--- a/scripts/sweeps/eol.ts
+++ b/scripts/sweeps/eol.ts
@@ -7,6 +7,8 @@
 import { FIXTURES, INLINE_FIXTURES } from "../oracles/fixtures.ts"
 import { RULE_OPTIONS } from "../oracles/options.ts"
 
+import type { Sweep } from "./run.ts"
+
 /** The four spellings a whole file is broken with. */
 const SPELLINGS = { lf: `\n`, crlf: `\r\n`, cr: `\r`, ff: `\f` }
 
@@ -19,11 +21,11 @@ const EVERY_WHITESPACE_RUN = /\s+/gu
 /** Every break of a fixture, a Windows pair counting as one. */
 const EVERY_BREAK = /\r\n|[\n\r\f]/gu
 
-const name = `eol`
+const name: Sweep[`name`] = `eol`
 
-const corpus = [...FIXTURES, ...INLINE_FIXTURES].flatMap(([fixture, code]) => {
+const corpus: Sweep[`corpus`] = [...FIXTURES, ...INLINE_FIXTURES].flatMap(([fixture, code]): [string, string][] => {
 	let source = code.replaceAll(EVERY_BREAK, `\n`)
-	let rows = Object.entries(SPELLINGS).map(([spelling, character]) => [`${fixture}|whole|${spelling}`, source.replaceAll(`\n`, character)])
+	let rows: [string, string][] = Object.entries(SPELLINGS).map(([spelling, character]) => [`${fixture}|whole|${spelling}`, source.replaceAll(`\n`, character)])
 	let runs = [...source.matchAll(EVERY_WHITESPACE_RUN)]
 
 	for (let [index, run] of runs.entries()) {
@@ -35,6 +37,6 @@ const corpus = [...FIXTURES, ...INLINE_FIXTURES].flatMap(([fixture, code]) => {
 	return rows
 })
 
-const configs = Object.entries(RULE_OPTIONS).flatMap(([rule, primaries]) => primaries.map((primary) => ({ rule, primary })))
+const configs: Sweep[`configs`] = Object.entries(RULE_OPTIONS).flatMap(([rule, primaries]) => primaries.map((primary) => ({ rule, primary })))
 
 export { configs, corpus, name }

--- a/scripts/sweeps/function-parentheses-breaks.ts
+++ b/scripts/sweeps/function-parentheses-breaks.ts
@@ -6,6 +6,8 @@
 
 import { multiply, place } from "../harness/matrix.ts"
 
+import type { Sweep } from "./run.ts"
+
 const LINE_SEPARATOR = String.fromCodePoint(0x2028)
 const PARAGRAPH_SEPARATOR = String.fromCodePoint(0x2029)
 const NO_BREAK_SPACE = String.fromCodePoint(0x00a0)
@@ -16,14 +18,14 @@ const COMMENTS = { inline: `//c`, inlineThenBlockOpener: `//c/*x`, block: `/*b*/
 
 const TAILS = { none: ``, block: `/*t*/`, blockOverLs: `/*t${LINE_SEPARATOR}u*/`, blockOverLf: `/*t\nu*/`, blockOpen: `/*t*`, word: `d` }
 
-const name = `function-parentheses-breaks`
+const name: Sweep[`name`] = `function-parentheses-breaks`
 
-const corpus = place(
+const corpus: Sweep[`corpus`] = place(
 	multiply({ comment: COMMENTS, first: BREAKS, second: BREAKS, tail: TAILS }, ({ comment, first, second, tail }) => `translate(1px, 2px ${comment}${first}${tail}${second})`),
 	{ singleLine: (value) => `a { transform: ${value}; }`, multiLine: (value) => `a { transform: 1px,\n${value}; }` },
 )
 
-const configs = [
+const configs: Sweep[`configs`] = [
 	{ rule: `function-parentheses-space-inside`, primary: `always` },
 	{ rule: `function-parentheses-space-inside`, primary: `never` },
 	{ rule: `function-parentheses-space-inside`, primary: `always-single-line` },

--- a/scripts/sweeps/interpolation-case.ts
+++ b/scripts/sweeps/interpolation-case.ts
@@ -6,6 +6,8 @@
 
 import { multiply, place } from "../harness/matrix.ts"
 
+import type { Sweep } from "./run.ts"
+
 const OPENERS: Record<string, string> = { sass: `#{`, less: `@{`, postcssSimpleVars: `$(` }
 
 const CLOSERS: Record<string, string> = { sass: `}`, less: `}`, postcssSimpleVars: `)` }
@@ -32,9 +34,9 @@ const CONTROLS: [string, string][] = [
 	[`control|parens`, `(10PX)`],
 ]
 
-const name = `interpolation-case`
+const name: Sweep[`name`] = `interpolation-case`
 
-const corpus = place(
+const corpus: Sweep[`corpus`] = place(
 	[
 		...multiply({ spelling: OPENERS, text: TEXTS, head: HEADS, tail: TAILS }, ({ spelling, text, head, tail }) => {
 			let language = Object.keys(OPENERS).find((key) => OPENERS[key] === spelling)
@@ -54,7 +56,7 @@ const corpus = place(
 	},
 )
 
-const configs = [
+const configs: Sweep[`configs`] = [
 	{ rule: `unit-case`, primary: `lower` },
 	{ rule: `unit-case`, primary: `upper` },
 	{ rule: `color-hex-case`, primary: `lower` },

--- a/scripts/sweeps/printed-node.ts
+++ b/scripts/sweeps/printed-node.ts
@@ -8,6 +8,8 @@
 
 import { place } from "../harness/matrix.ts"
 
+import type { Sweep } from "./run.ts"
+
 /** The comment, in the two spellings of the same width, and the two shapes that carry no comment. A block comment is what the inline one is measured against, since neither the file nor the code around it differs by a character between the two. */
 const COMMENTS = { inline: `// c`, block: `/**/`, none: ``, twoInline: `// c\n\t// c` }
 
@@ -32,7 +34,7 @@ const PLACES: Record<string, (comment: string) => string> = {
 }
 
 /** The shapes whose printed copy parts from the file for a reason other than a comment: a Less mixin call, whose leading dot and flag live in raws PostCSS prints neither of, and a Sass nested property, a declaration carrying a block that `postcss-scss` prints and PostCSS's own stringifier drops. The detached ruleset and the free semicolon behind a brace are controls: the two stringifiers agree on both, and a corpus in which every shape diverges says nothing about what the change does where none does. Five of them put a bang and a comma on either side of that block and three put a sibling behind it, since a rule reading a declaration's own text has to be measured on one that holds something to read and on one the rule does not pass over: the first draft of this branch handed such a declaration to the bang and comma checkers with the block laid onto the end of it, and every bang and comma the block held came past the checker a second time; the second draft handed it to the `declaration-block-semicolon-*-before` rules the same way, and every fixture that had it standing last in its block was passed over by all four of them before they could say so. */
-const RAW_SHAPES = [
+const RAW_SHAPES: [string, string][] = [
 	[`raw|lessMixinCall`, `a {\n\t.m()\n}\n`],
 	[`raw|lessMixinCallWithBang`, `a {\n\t.m() !important\n}\n`],
 	[`raw|lessMixinCallThenDecl`, `a {\n\t.m();\n\tcolor: pink;\n}\n`],
@@ -53,15 +55,15 @@ const RAW_SHAPES = [
 	[`raw|freeSemicolonBehindBrace`, `a { &:hover { color: pink;; }; }\n`],
 ]
 
-const name = `printed-node`
+const name: Sweep[`name`] = `printed-node`
 
-const corpus = [
+const corpus: Sweep[`corpus`] = [
 	...place(Object.entries(COMMENTS), PLACES),
 	...RAW_SHAPES,
 ]
 
 /** Every rule this branch rewrites a measurement in, under every primary option `scripts/oracles/options.ts` lists for it. */
-const configs = ([
+const configs: Sweep[`configs`] = ([
 	[`at-rule-semicolon-newline-after`, [`always`]],
 	[`at-rule-semicolon-space-before`, [`always`, `never`]],
 	[`block-closing-brace-empty-line-before`, [`always-multi-line`, `never`]],

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -21,7 +21,12 @@ import { lintDirect, loadRules, type Registry, type RuleSetting } from "../harne
 const SYNTAXES: Record<string, string | undefined> = { css: undefined, scss: `postcss-scss`, less: `postcss-less` }
 
 /** What a sweep module exports. */
-type Sweep = { name: string, corpus: [string, string][], configs: { rule: string, primary: unknown, secondary?: object }[], syntaxes?: string[] }
+type Sweep = {
+	name: string,
+	corpus: [string, string][],
+	configs: { rule: string, primary: unknown, secondary?: object }[],
+	syntaxes?: string[],
+}
 
 /**
  * Lints one text under one configuration, checking and fixing, and reads the fix back.
@@ -78,7 +83,10 @@ let sweep: Sweep = await import(path.resolve(file))
 let sides = { base, head: `worktree` }
 
 /** Each side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
-let results: Record<string, { digest: Record<string, string>, rows: () => Record<string, object> }> = {}
+let results: Record<string, {
+	digest: Record<string, string>,
+	rows: () => Record<string, object>,
+}> = {}
 
 for (let [side, revision] of Object.entries(sides)) {
 	// A side is measured once by what it depends on — the rules, the sweep and the runner — and read back on every later run; the two are taken in turn, base first

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -15,7 +15,7 @@ import { argv, exit, stderr, stdout } from "node:process"
 import { digestOf, hashAt, keyOf, read, readDigest, write } from "../harness/cache.ts"
 import { defaultBase, libAt, ROOT } from "../harness/checkout.ts"
 import { diff, render } from "../harness/diff.ts"
-import { lintDirect, loadRules } from "../harness/lint.ts"
+import { lintDirect, loadRules, type Registry, type RuleSetting } from "../harness/lint.ts"
 
 /** The syntax each name is read under, plain CSS under none. */
 const SYNTAXES: Record<string, string | undefined> = { css: undefined, scss: `postcss-scss`, less: `postcss-less` }
@@ -49,12 +49,12 @@ async function measureOne (options: Omit<Parameters<typeof lintDirect>[0], `fix`
  * @param registry - The rules of one side.
  * @returns Every row by its key.
  */
-async function measure (sweep: Sweep, registry: import("../harness/lint.ts").Registry): Promise<Record<string, object>> {
+async function measure (sweep: Sweep, registry: Registry): Promise<Record<string, object>> {
 	let rows: Record<string, object> = {}
 
 	for (let syntaxName of sweep.syntaxes ?? Object.keys(SYNTAXES)) {
 		for (let config of sweep.configs) {
-			let rules: import("../harness/lint.ts").RuleSetting[] = [[config.rule, config.primary, config.secondary]]
+			let rules: RuleSetting[] = [[config.rule, config.primary, config.secondary]]
 
 			for (let [key, code] of sweep.corpus) {
 				// The rows are measured in turn so that a run stays as light on the machine as the one it replaces

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -21,7 +21,7 @@ import { lintDirect, loadRules, type Registry, type RuleSetting } from "../harne
 const SYNTAXES: Record<string, string | undefined> = { css: undefined, scss: `postcss-scss`, less: `postcss-less` }
 
 /** What a sweep module exports. */
-type Sweep = {
+export type Sweep = {
 	name: string,
 	corpus: [string, string][],
 	configs: { rule: string, primary: unknown, secondary?: object }[],
@@ -97,8 +97,16 @@ for (let [side, revision] of Object.entries(sides)) {
 	if (digest) {
 		let rows: Record<string, object> | undefined
 
-		// The store hands back what was written, and a sweep writes its rows by key
-		results[side] = { digest, rows: (): Record<string, object> => (rows ??= (read(`sweeps`, sweep.name, key) as Record<string, object>)) }
+		results[side] = {
+			digest,
+			rows: (): Record<string, object> => {
+				rows ??= read<Record<string, object>>(`sweeps`, sweep.name, key)
+
+				if (!rows) throw new Error(`The store holds the digest of ${sweep.name} and not its rows`)
+
+				return rows
+			},
+		}
 		continue
 	}
 

--- a/types/postcss-less.d.ts
+++ b/types/postcss-less.d.ts
@@ -29,7 +29,10 @@ declare module "postcss-less" {
 
 	let parse: Parser
 	let stringify: Stringifier
-	let less: { parse: Parser, stringify: Stringifier }
+	let less: {
+		parse: Parser,
+		stringify: Stringifier,
+	}
 
 	export default less
 	export { parse, stringify }


### PR DESCRIPTION
The tidy-up between step 5 and the finale of the TypeScript migration, in three commits — nothing here changes an output, and every one of them is what the reviews of #442–#445 asked for.

```
make verify          check, lint, test (9103 passed, 1 skipped), prose-check, breaks-check, build — green
make oracles         converge 0, control 2, comments 0, twins 15, nodes 0, pairs 252 rows; +0 −0 ~0 on every oracle
make harness-check   52 160 runs compared, 0 disagreements
make sweep           eol: 500 448 rows, 0 changed, 0 added, 0 removed
```

## The fix

- **Import a type by name.** Every type-level `import("…").Name` — 551 of them, the spelling JSDoc had for a type of another module — is an `import type` line, or a `type` binding in the import the module already had. Where two modules offer one name, or a local declaration holds it, the second carries the module's prefix: `Node` and `Rule` are PostCSS's, `ValueParserNode`, `SelectorParserNode` and `StylelintRule` say whose the others are. An alias that only renamed such an import is the import itself, and a module re-exporting a type it merely borrowed no longer does.
- **Write an object type over several lines.** An object type of two members or more is written one member to a line, with a tab and a trailing comma, as the repository writes an object; a member that is such a literal opens up with its parent. The one-line spelling came from the JSDoc typedefs, which could be written no other way; 96 of them stood in signatures, aliases and interfaces. Three `rule` functions grew past their `max-lines-per-function` ceilings by the lines of their types, and the ceilings follow (`unit-case` joins the 176 group; `indentation` is 259), with the reason written beside them.
- **Type what the harness reads back and what a sweep exports.** `read<T>` of the result store hands back what its caller expects, in place of a cast at each caller; a sweep's rows are asked for through a check that the store holds them. `Sweep` is exported from `run.ts`, and every sweep module types its `name`, `corpus` and `configs` by it.

## What the review turned up

No defect. Three of its findings changed the branch: the three `max-lines-per-function` ceilings the second commit had raised are back where they stood, since four hoisted aliases (`Problem`, `SecondaryOptions`, `HeldRaw`, the `SyntaxRaw` `string-quotes` already imported) take the object types out of the functions; two imports kept a `Postcss` prefix where nothing shared the name, and `document-with-roots.test.ts` imported `Document` twice; and three claims of the commit messages said more than the code does — `StylelintRule` named a binding that exists nowhere, `read<T>` moves a cast rather than removing one, and a `Sweep` annotation on a dynamic import checks nothing — and say what it does now.
