### PR TITLE
Turn on `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -30,7 +30,7 @@
 				"skipBlankLines": true
 			}
 		],
-		// Off for good: `eqeqeq` and `no-eq-null` are both on, so `value == null` is refused twice over, while this rule refuses `value === undefined`. Between the three there is no spelling left for the question the plugin asks 16 times, `typeof value === "undefined"` aside, and none of the 21 places handing `report` a `fix` of `undefined` reads better as a conditional spread.
+		// Off for good: `eqeqeq` and `no-eq-null` are both on, so `value == null` is refused twice over, while this rule refuses `value === undefined`. Between the three there is no spelling left for the question the plugin asks throughout, `typeof value === "undefined"` aside, and the handful of places that answer a question with `? … : undefined` say what they mean by it.
 		"no-undefined": "off",
 		// Off for the whole project: a type is declared where it is named and exported there, and a rule opens on what it is — its name, its messages and its `meta` — and closes on the implementation. The shared config carries the rule still; it goes there with the next release.
 		"import/exports-last": "off",

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -14,8 +14,8 @@ describe(`the plugin in the wrong field of a config`, () => {
 			} as unknown as Config,
 		})
 
-		expect(results[0].warnings).toHaveLength(1)
-		expect(results[0].warnings[0].rule).toBe(`@stylistic/color-hex-case`)
+		expect(results[0]?.warnings).toHaveLength(1)
+		expect(results[0]?.warnings[0]?.rule).toBe(`@stylistic/color-hex-case`)
 	})
 
 	it(`stops the run with a configuration error where it is listed in "extends"`, async () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,7 +7,7 @@ import type { ConfigurationError } from "./utils/configurationError/index.ts"
 /** The code Stylelint exits with when its configuration is invalid. */
 const EXIT_CODE_INVALID_CONFIG = 78
 
-let rulesPlugins = Object.keys(rules).map((name) => stylelint.createPlugin(addNamespace(name), rules[name]))
+let rulesPlugins = Object.entries(rules).map(([name, rule]) => stylelint.createPlugin(addNamespace(name), rule))
 
 /** Stylelint reads `extends` on every config it is told to extend, and never on a plugin, so this getter runs only where the package has been listed in the wrong field. Without it Stylelint loads the package as a config, finds no rules in it, and reports every `@stylistic/` rule as unknown — an error about the rules, whose cause is the field they were never reached from. */
 Object.defineProperty(rulesPlugins, `extends`, {

--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -113,9 +113,7 @@ function rule (primary: `ratio` | `number-where-possible` | `as-written`, second
 				result,
 				ruleName,
 				// A comment standing between the two numbers is code, and the run that takes the second number away holds it: taking a comment out of a stylesheet is nothing this rule was asked to do, so the problem is reported and the value left for a reader to settle
-				fix: edits.some((edit) => holdsComment(edit, comments))
-					? undefined
-					: (): void => write(applyEditsFromEnd(text, edits)),
+				...(!edits.some((edit) => holdsComment(edit, comments)) && { fix: (): void => write(applyEditsFromEnd(text, edits)) }),
 			})
 		}
 	}
@@ -124,7 +122,7 @@ function rule (primary: `ratio` | `number-where-possible` | `as-written`, second
 /** The two numbers a `<ratio>` is written with, as the value parser read them. */
 type Ratio = {
 	width: ValueParserNode,
-	height?: ValueParserNode,
+	height: ValueParserNode | undefined,
 }
 
 /**

--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -170,9 +170,13 @@ function findRatio (nodes: ValueParserNode[]): Ratio | undefined {
 		return
 	}
 
-	if (numbers.length === 0 || (hasSolidus && numbers.length !== 2)) return
+	if (hasSolidus && numbers.length !== 2) return
 
-	return { width: numbers[0], height: numbers[1] }
+	let [width, height] = numbers
+
+	if (!width) return
+
+	return { width, height }
 }
 
 /**

--- a/lib/rules/block-closing-brace-newline-before/index.ts
+++ b/lib/rules/block-closing-brace-newline-before/index.ts
@@ -101,8 +101,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 					node: statement,
 					index,
 					endIndex: index,
-					fix: isFixable
-						? (): void => {
+					...(isFixable && {
+						fix: (): void => {
 							let raw = getBlockAfter(statement)
 
 							if (typeof raw !== `string`) return
@@ -116,8 +116,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 								setBlockAfter(statement, newlineIndex >= 0 ? newlineBefore + newlineAfter.slice(newlineIndex) : newlineBefore + getLineBreak(root, result) + newlineAfter)
 							}
 							else if (primary === `never-multi-line`) setBlockAfter(statement, raw.replaceAll(EVERY_WHITESPACE, ``))
-						}
-						: undefined,
+						},
+					}),
 				})
 			}
 		}

--- a/lib/rules/block-closing-brace-space-before/index.ts
+++ b/lib/rules/block-closing-brace-space-before/index.ts
@@ -98,16 +98,16 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 						endIndex: index,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								let raw = getBlockAfter(statement)
 
 								if (typeof raw !== `string`) return
 
 								if (primary.startsWith(`always`)) setBlockAfter(statement, raw.replace(TRAILING_WHITESPACE, ` `))
 								else if (primary.startsWith(`never`)) setBlockAfter(statement, raw.replace(TRAILING_WHITESPACE, ``))
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/block-opening-brace-newline-after/index.test.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.test.ts
@@ -828,7 +828,7 @@ describe(`${ruleName} on a run of comments longer than the stack is deep`, () =>
 			fix: true,
 		})
 
-		expect(results[0].warnings.map((warning) => warning.text)).toEqual([messages.expectedAfter()])
+		expect(results[0]?.warnings.map((warning) => warning.text)).toEqual([messages.expectedAfter()])
 		expect(fixed.code).toBe(`a {${run}\ncolor: pink; }`)
 	})
 
@@ -844,7 +844,7 @@ describe(`${ruleName} on a run of comments longer than the stack is deep`, () =>
 			fix: true,
 		})
 
-		expect(results[0].warnings.map((warning) => warning.text)).toEqual([messages.rejectedAfterMultiLine()])
+		expect(results[0]?.warnings.map((warning) => warning.text)).toEqual([messages.rejectedAfterMultiLine()])
 		expect(fixed.code).toBe(`a {${run}color: pink;\nbackground: orange; }`)
 	})
 })
@@ -869,7 +869,7 @@ async function fixQuietly (code: string, option: string): Promise<{
 		config: { plugins, rules: { [ruleName]: option } },
 	})
 
-	return { code: fixed.code, warnings: reported.results[0].warnings.length }
+	return { code: fixed.code, warnings: reported.results[0]?.warnings.length ?? 0 }
 }
 
 describe(`${ruleName} on the whitespace it carries past a comment`, () => {

--- a/lib/rules/block-opening-brace-newline-after/index.test.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.test.ts
@@ -1,6 +1,7 @@
 import stylelint from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
 import plugins from "../../index.ts"
 
 import { messages, ruleName } from "./index.ts"
@@ -869,7 +870,7 @@ async function fixQuietly (code: string, option: string): Promise<{
 		config: { plugins, rules: { [ruleName]: option } },
 	})
 
-	return { code: fixed.code, warnings: reported.results[0]?.warnings.length ?? 0 }
+	return { code: fixed.code, warnings: pick(reported.results).warnings.length }
 }
 
 describe(`${ruleName} on the whitespace it carries past a comment`, () => {

--- a/lib/rules/block-opening-brace-newline-after/index.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.ts
@@ -135,8 +135,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, sec
 						endIndex: problemIndex,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								let nodeToCheckRaws = nodeToCheck.raws
 
 								if (typeof nodeToCheckRaws.before !== `string`) return
@@ -175,8 +175,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, sec
 
 									nodeToCheckRaws.before = ``
 								}
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/block-opening-brace-newline-before/index.ts
+++ b/lib/rules/block-opening-brace-newline-before/index.ts
@@ -93,8 +93,8 @@ function rule (primary: `always` | `always-single-line` | `never-single-line` | 
 						endIndex: index,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								if (typeof statement.raws.between !== `string`) return
 
 								if (primary.startsWith(`always`)) {
@@ -104,8 +104,8 @@ function rule (primary: `always` | `always-single-line` | `never-single-line` | 
 									else statement.raws.between += getLineBreak(root, result)
 								}
 								else if (primary.startsWith(`never`)) statement.raws.between = statement.raws.between.replace(TRAILING_WHITESPACE, ``)
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/block-opening-brace-space-before/index.ts
+++ b/lib/rules/block-opening-brace-space-before/index.ts
@@ -119,8 +119,8 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 						endIndex: index,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								if (primary.startsWith(`always`)) {
 									statement.raws.between = `${beforeWhitespace} `
 
@@ -128,8 +128,8 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 								}
 
 								if (primary.startsWith(`never`)) statement.raws.between = beforeWhitespace
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/declaration-block-semicolon-newline-after/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.ts
@@ -87,8 +87,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 						endIndex: problemIndex,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								if (primary.startsWith(`always`)) {
 									// Trim up to the break that already stands there, whichever character it is, and add one only where none does
 									let index = nodeToCheck.raws.before.search(LINE_BREAK)
@@ -99,8 +99,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 								}
 
 								if (primary === `never-multi-line`) nodeToCheck.raws.before = ``
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/declaration-block-semicolon-newline-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.ts
@@ -82,8 +82,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 						endIndex: problemIndex,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								if (primary.startsWith(`always`)) {
 									// The semicolon stands behind `!important`, so wherever the declaration carries the flag, the raw holding it is the text the break goes into, and PostCSS keeps that raw only where the flag is spelled some other way than ` !important`. The raw is kept rather than written anew, so that a comment, and any other layout standing in front of the flag, survives the fix
 									if (decl.important) decl.raws.important = (decl.raws.important || ` !important`).replace(TRAILING_WHITESPACE, getLineBreak(root, result))
@@ -104,8 +104,8 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 										setDeclarationValue(decl, newValue)
 									}
 								}
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/declaration-block-semicolon-space-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-space-before/index.ts
@@ -86,8 +86,8 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 						endIndex: problemIndex,
 						result,
 						ruleName,
-						fix: isFixable
-							? (): void => {
+						...(isFixable && {
+							fix: (): void => {
 								if (primary.startsWith(`always`)) {
 									// The raw is kept rather than written anew, so that a comment, and any other layout standing in front of the flag, survives the fix
 									if (decl.important) decl.raws.important = (decl.raws.important || ` !important`).replace(TRAILING_WHITESPACE, ` `)
@@ -106,8 +106,8 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 										setDeclarationValue(decl, newValue)
 									}
 								}
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -283,8 +283,8 @@ function rule (primary: `always` | `never`, secondaryOptions: { ignore?: `single
 					endIndex: problemIndex,
 					result,
 					ruleName,
-					fix: isFixable(node, primary, spelledBetween, result)
-						? (): void => {
+					...(isFixable(node, primary, spelledBetween, result) && {
+						fix: (): void => {
 							if (primary === `always` && !hasSemicolon) {
 								parent.raws.semicolon = true
 
@@ -295,8 +295,8 @@ function rule (primary: `always` | `never`, secondaryOptions: { ignore?: `single
 								}
 							}
 							else if (primary === `never`) takeTheTrailingSemicolonsAway(node)
-						}
-						: undefined,
+						},
+					}),
 				})
 			}
 		}

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -83,7 +83,7 @@ function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: Inl
  * @param ranges - The stretches to take out, in ascending order and none of them overlapping.
  * @returns What is left once they are gone.
  */
-function withoutRanges (text: string, ranges: number[][]): string {
+function withoutRanges (text: string, ranges: [number, number][]): string {
 	let kept = ``
 	let index = 0
 
@@ -102,8 +102,8 @@ function withoutRanges (text: string, ranges: number[][]): string {
  * @param lists - The lists to fold, in whatever order each of them holds its stretches.
  * @returns The one list.
  */
-function mergeRanges (lists: number[][][]): number[][] {
-	let merged: number[][] = []
+function mergeRanges (lists: [number, number][][]): [number, number][] {
+	let merged: [number, number][] = []
 
 	for (let [start, end] of lists.flat().toSorted(([one], [other]) => one - other)) {
 		let last = merged.at(-1)
@@ -127,7 +127,7 @@ function mergeRanges (lists: number[][][]): number[][] {
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the character move into a comment.
  */
-function movesIntoComment (declValue: string, characterIndex: number, emptied: number[][], reading: InlineCommentReading): boolean {
+function movesIntoComment (declValue: string, characterIndex: number, emptied: [number, number][], reading: InlineCommentReading): boolean {
 	let standingText = declValue.slice(0, characterIndex + 1)
 
 	return movesEndIntoInlineComment(standingText, withoutRanges(standingText, emptied), reading)
@@ -170,8 +170,8 @@ function getAfterSpan (valueNode: FunctionNode): {
  * @param openingIndex - Where the text behind that parenthesis begins.
  * @returns The stretches, in ascending order and none of them overlapping.
  */
-function getFixEmptiedBefore (valueNode: FunctionNode, openingIndex: number): number[][] {
-	let emptied = [[openingIndex, openingIndex + valueNode.before.length]]
+function getFixEmptiedBefore (valueNode: FunctionNode, openingIndex: number): [number, number][] {
+	let emptied: [number, number][] = [[openingIndex, openingIndex + valueNode.before.length]]
 
 	for (let node of valueNode.nodes) {
 		if (node.type === `comment`) continue
@@ -191,8 +191,8 @@ function getFixEmptiedBefore (valueNode: FunctionNode, openingIndex: number): nu
  * @param valueNode - The function whose closing parenthesis is being fixed.
  * @returns The stretches, in ascending order and none of them overlapping.
  */
-function getFixEmptiedAfter (valueNode: FunctionNode): number[][] {
-	let emptied: number[][] = []
+function getFixEmptiedAfter (valueNode: FunctionNode): [number, number][] {
+	let emptied: [number, number][] = []
 
 	for (let node of [...valueNode.nodes].toReversed()) {
 		if (node.type === `comment`) continue
@@ -225,7 +225,7 @@ function getNeverFixability (read: {
 	checkBefore: string,
 	checkAfter: string,
 	firstIndex: number,
-	measured: number[][],
+	measured: [number, number][],
 	reading: InlineCommentReading,
 }): {
 	isOpeningFixable: boolean,
@@ -399,10 +399,10 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 function getCheckBefore (valueNode: FunctionNode, openingIndex: number, declValue: string, inlineComments: InlineCommentSpan[]): {
 	before: string,
 	firstIndex: number,
-	measured: number[][],
+	measured: [number, number][],
 } {
 	let before = valueNode.before
-	let measured = [[openingIndex, openingIndex + valueNode.before.length]]
+	let measured: [number, number][] = [[openingIndex, openingIndex + valueNode.before.length]]
 	let firstIndex = valueNode.sourceEndIndex - 1
 
 	for (let node of valueNode.nodes) {

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -375,7 +375,7 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 					node: decl,
 					index: problemIndex,
 					endIndex: problemIndex,
-					fix,
+					...(fix && { fix }),
 				})
 			}
 		})

--- a/lib/rules/function-parentheses-space-inside/index.ts
+++ b/lib/rules/function-parentheses-space-inside/index.ts
@@ -282,7 +282,7 @@ function rule (primary: `always` | `never` | `always-single-line` | `never-singl
 					node: decl,
 					index: problemIndex,
 					endIndex: problemIndex,
-					fix,
+					...(fix && { fix }),
 				})
 			}
 		})

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -128,9 +128,9 @@ function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {})
 					result,
 					ruleName,
 					fix () {
-						if (isFirstChild && isString(node.raws.before)) node.raws.before = node.raws.before.replace(SPACES_AND_TABS_BEFORE_CONTENT, expectedOpeningBraceIndentation)
+						if (!isString(node.raws.before)) return
 
-						if (isString(node.raws.before)) node.raws.before = fixIndentation(node.raws.before, expectedOpeningBraceIndentation)
+						node.raws.before = fixIndentation(isFirstChild ? node.raws.before.replace(SPACES_AND_TABS_BEFORE_CONTENT, expectedOpeningBraceIndentation) : node.raws.before, expectedOpeningBraceIndentation)
 					},
 				})
 			}
@@ -178,7 +178,7 @@ function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {})
 			if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
 
 			// Content of the line where styled expressions starts
-			let expressionStartLine = parent.parent.source.input.css.split(`\n`)[parent.source.start.line - 1] ?? ``
+			let expressionStartLine = lineAt(parent.parent.source.input.css, parent.source.start.line)
 			// Indent characters (spaces/tabs) before the content of the line where the styled expressions starts
 			let indentCharacters = expressionStartLine.match(LEADING_SPACES_AND_TABS)?.[0] ?? ``
 
@@ -674,6 +674,20 @@ function inferRootIndentLevel (root: Root, baseIndentLevel: number | `auto` | un
 	if (indents.length > 0) return Math.max(...indents.map((indent) => getIndentLevel(indent))) + newBaseIndentLevel
 
 	return newBaseIndentLevel
+}
+
+/**
+ * Reads one line of a text, counted from one as a source position counts them.
+ * @param text - The text.
+ * @param line - The number of the line.
+ * @returns The line, without its break.
+ */
+function lineAt (text: string, line: number): string {
+	let found = text.split(`\n`)[line - 1]
+
+	if (found === undefined) throw new Error(`A styled expression starts on a line its file does not hold`)
+
+	return found
 }
 
 /**

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -130,7 +130,7 @@ function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {})
 					fix () {
 						if (isFirstChild && isString(node.raws.before)) node.raws.before = node.raws.before.replace(SPACES_AND_TABS_BEFORE_CONTENT, expectedOpeningBraceIndentation)
 
-						node.raws.before = fixIndentation(node.raws.before, expectedOpeningBraceIndentation)
+						if (isString(node.raws.before)) node.raws.before = fixIndentation(node.raws.before, expectedOpeningBraceIndentation)
 					},
 				})
 			}
@@ -152,7 +152,7 @@ function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {})
 					result,
 					ruleName,
 					fix () {
-						node.raws.after = fixIndentation(node.raws.after, expectedClosingBraceIndentation)
+						if (isString(node.raws.after)) node.raws.after = fixIndentation(node.raws.after, expectedClosingBraceIndentation)
 					},
 				})
 			}
@@ -682,9 +682,7 @@ function inferRootIndentLevel (root: Root, baseIndentLevel: number | `auto` | un
  * @param whitespace - The whitespace to use for indentation.
  * @returns The fixed string.
  */
-function fixIndentation (str: string | undefined, whitespace: string): string | undefined {
-	if (!isString(str)) return str
-
+function fixIndentation (str: string, whitespace: string): string {
 	return str.replaceAll(EVERY_LINE_BREAK_AND_INDENT, `$1${whitespace}`)
 }
 

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -178,7 +178,7 @@ function rule (primary: number | `tab`, secondaryOptions: SecondaryOptions = {})
 			if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
 
 			// Content of the line where styled expressions starts
-			let expressionStartLine = parent.parent.source.input.css.split(`\n`)[parent.source.start.line - 1]
+			let expressionStartLine = parent.parent.source.input.css.split(`\n`)[parent.source.start.line - 1] ?? ``
 			// Indent characters (spaces/tabs) before the content of the line where the styled expressions starts
 			let indentCharacters = expressionStartLine.match(LEADING_SPACES_AND_TABS)?.[0] ?? ``
 

--- a/lib/rules/index.test.ts
+++ b/lib/rules/index.test.ts
@@ -53,6 +53,8 @@ describe(`all rules`, () => {
 		it(`"${name}" should have metadata`, async () => {
 			let rule = await rules[name]
 
+			if (!rule) throw new Error(`No rule named "${name}"`)
+
 			expect(rule.meta?.url).toBe(getRuleDocUrl(name))
 			expect([true, undefined]).toContain(rule.meta?.fixable)
 		})
@@ -70,6 +72,8 @@ describe(`fixable rules`, () => {
 		it(`"${name}" should describe fixable in the documents`, async () => {
 			let rule = await rules[name]
 
+			if (!rule) throw new Error(`No rule named "${name}"`)
+
 			if (!rule.meta?.fixable) return
 
 			let ruleDoc = await readFile(new URL(`./${name}/README.md`, import.meta.url), `utf8`)
@@ -84,6 +88,8 @@ describe(`deprecated rules`, () => {
 	for (let name of ruleNames) {
 		it(`"${name}" should describe deprecation in the document`, async () => {
 			let rule = await rules[name]
+
+			if (!rule) throw new Error(`No rule named "${name}"`)
 
 			if (!rule.meta?.deprecated) return
 

--- a/lib/rules/max-line-length/index.ts
+++ b/lib/rules/max-line-length/index.ts
@@ -112,8 +112,8 @@ function rule (primary: number, secondaryOptions: {
 			let spans: Array<[number, number]> = []
 
 			// A substring starting at or past the end of the line stands on a later line
-			while (skippedSubStringsIndex < skippedSubStrings.length && skippedSubStrings[skippedSubStringsIndex][0] < end) {
-				let [startSubString, endSubString] = skippedSubStrings[skippedSubStringsIndex]
+			for (let next = skippedSubStrings[skippedSubStringsIndex]; next && next[0] < end; next = skippedSubStrings[skippedSubStringsIndex]) {
+				let [startSubString, endSubString] = next
 
 				spans.push([Math.max(start, startSubString) - start, Math.min(end, endSubString) - start])
 				skippedSubStringsIndex += 1

--- a/lib/rules/media-feature-parentheses-space-inside/index.ts
+++ b/lib/rules/media-feature-parentheses-space-inside/index.ts
@@ -118,7 +118,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 							problems.push({
 								message: messages.rejectedClosing,
 								index: node.sourceIndex - 2 + len + indexBoost,
-								fix: isFixable ? (): void => { addEdit(edits, closingEdit(node, ``, params)) } : undefined,
+								...(isFixable && { fix: (): void => { addEdit(edits, closingEdit(node, ``, params)) } }),
 							})
 						}
 					}
@@ -151,7 +151,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 						endIndex: err.index,
 						result,
 						ruleName,
-						fix: err.fix,
+						...(err.fix && { fix: err.fix }),
 					})
 				}
 

--- a/lib/rules/named-grid-areas-alignment/index.ts
+++ b/lib/rules/named-grid-areas-alignment/index.ts
@@ -105,7 +105,7 @@ function rule (primary: true, secondaryOptions: {
 			let maxRowLength = 0
 			let formatted = table.map((row) => {
 				let formattedRow = row
-					.map((cell, index) => isMultilineDeclaration ? cell.padEnd(maxLengths[index], ` `) : cell)
+					.map((cell, index) => isMultilineDeclaration ? cell.padEnd(maxLengths[index] ?? 0, ` `) : cell)
 					.join(referenceGap)
 
 				maxRowLength = Math.max(maxRowLength, formattedRow.length)

--- a/lib/rules/no-extra-semicolons/index.ts
+++ b/lib/rules/no-extra-semicolons/index.ts
@@ -176,7 +176,7 @@ function rule (primary: true): RuleCheck {
 				endIndex: index,
 				result,
 				ruleName,
-				fix,
+				...(fix && { fix }),
 			})
 		}
 	}

--- a/lib/rules/no-missing-end-of-source-newline/integration.test.ts
+++ b/lib/rules/no-missing-end-of-source-newline/integration.test.ts
@@ -18,7 +18,7 @@ async function fix (code: string, rules: object): Promise<{
 	let fixed = await stylelint.lint({ code, config: { plugins, rules }, fix: true })
 	let read = await stylelint.lint({ code: fixed.code ?? code, config: { plugins, rules } })
 
-	return { code: fixed.code ?? code, warnings: read.results[0].warnings.length }
+	return { code: fixed.code ?? code, warnings: read.results[0]?.warnings.length ?? 0 }
 }
 
 /**

--- a/lib/rules/no-missing-end-of-source-newline/integration.test.ts
+++ b/lib/rules/no-missing-end-of-source-newline/integration.test.ts
@@ -1,6 +1,7 @@
 import stylelint from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
 import plugins from "../../index.ts"
 
 /**
@@ -18,7 +19,7 @@ async function fix (code: string, rules: object): Promise<{
 	let fixed = await stylelint.lint({ code, config: { plugins, rules }, fix: true })
 	let read = await stylelint.lint({ code: fixed.code ?? code, config: { plugins, rules } })
 
-	return { code: fixed.code ?? code, warnings: read.results[0]?.warnings.length ?? 0 }
+	return { code: fixed.code ?? code, warnings: pick(read.results).warnings.length }
 }
 
 /**

--- a/lib/rules/no-multiple-whitespaces/index.ts
+++ b/lib/rules/no-multiple-whitespaces/index.ts
@@ -100,8 +100,7 @@ function fixWhitespaceErrors (value: string, errors: {
 }[]): string {
 	let newValue = value
 
-	for (let j = errors.length - 1; j >= 0; j -= 1) {
-		let e = errors[j]
+	for (let e of errors.toReversed()) {
 		newValue = `${newValue.slice(0, e.start)} ${newValue.slice(e.start + e.count)}`
 	}
 
@@ -135,7 +134,7 @@ function rule (primary: true): RuleCheck {
 
 			// Main character iteration to find multiple whitespace errors
 			for (let i = 0; i < value.length; i += 1) {
-				let char = value[i]
+				let char = value.charAt(i)
 
 				let stringState = handleStringChar(char, inString, stringChar, value, i)
 				inString = stringState.inString
@@ -154,7 +153,7 @@ function rule (primary: true): RuleCheck {
 				if (isInlineWhitespace(char)) {
 					// afterNewline: skip leading whitespace (indentation) after a newline
 					if (afterNewline) {
-						while (i < value.length && isInlineWhitespace(value[i])) i += 1
+						while (i < value.length && isInlineWhitespace(value.charAt(i))) i += 1
 						afterNewline = false
 						i -= 1
 						continue
@@ -163,7 +162,7 @@ function rule (primary: true): RuleCheck {
 					let whitespaceStart = i
 					let whitespaceCount = 0
 
-					while (i < value.length && isInlineWhitespace(value[i])) {
+					while (i < value.length && isInlineWhitespace(value.charAt(i))) {
 						whitespaceCount += 1
 						i += 1
 					}

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -167,7 +167,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 				node,
 				index,
 				endIndex: index,
-				fix,
+				...(fix && { fix }),
 			})
 		}
 	}

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -90,7 +90,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 				if (primary === `always`) {
 					let match = FRACTION_WITHOUT_LEADING_ZERO.exec(valueNode.value)
 
-					if (match === null || match[0] === null || match[1] === null) return
+					if (match === null || match[1] === undefined) return
 
 					// The match reaches back a character to make sure the dot opens a number, so it is one longer than the number itself wherever it did: subtracting the number's length gives the index the dot stands at, which is 1 for `-.5` and 0 for `.5`.
 					let capturingGroupIndex = match[0].length - match[1].length
@@ -111,10 +111,11 @@ function rule (primary: `always` | `never`): RuleCheck {
 				if (primary === `never`) {
 					let match = FRACTION_WITH_LEADING_ZEROS.exec(valueNode.value)
 
-					if (match === null || match[0] === null || match[1] === null || match[2] === null) return
+					if (match === null || match[1] === undefined || match[2] === undefined) return
 
 					// The match reaches back a character to make sure the zeros open a number, so subtracting the zeros and the fraction behind them from the whole gives the index the first zero stands at, which is 1 for `-00.5` and 0 for `00.5`.
-					let capturingGroupIndex = match[0].length - (match[1].length + match[2].length)
+					let zeros = match[1]
+					let capturingGroupIndex = match[0].length - (zeros.length + match[2].length)
 
 					let index = valueNode.sourceIndex + match.index + capturingGroupIndex
 
@@ -122,7 +123,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 						neverFixPositions.unshift({
 							startIndex: index,
 							// `match[1]` is the run of zeros itself, so its length is how far the fix reaches
-							endIndex: index + match[1].length,
+							endIndex: index + zeros.length,
 						})
 					}
 

--- a/lib/rules/number-no-trailing-zeros/index.ts
+++ b/lib/rules/number-no-trailing-zeros/index.ts
@@ -82,7 +82,7 @@ function rule (primary: true): RuleCheck {
 
 				// `match[1]` is whatever digits stand between the decimal point and the trailing zeros, and may be empty
 				// `match[2]` is the trailing zeros themselves
-				if (match === null || match[1] === null || match[2] === null) return
+				if (match === null || match[1] === undefined || match[2] === undefined) return
 
 				// The index is made of four parts:
 				//  where the value node begins +

--- a/lib/rules/selector-attribute-brackets-space-inside/index.ts
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.ts
@@ -140,7 +140,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 					result,
 					ruleName,
 					node: ruleNode,
-					fix,
+					...(fix && { fix }),
 				})
 			}
 		})

--- a/lib/rules/selector-list-comma-newline-after/index.ts
+++ b/lib/rules/selector-list-comma-newline-after/index.ts
@@ -93,11 +93,11 @@ function rule (primary: `always` | `always-multi-line` | `never-multi-line`, _se
 								endIndex: sourceIndex,
 								result,
 								ruleName,
-								fix: closesInlineComment
-									? undefined
-									: (): void => {
+								...(!closesInlineComment && {
+									fix: (): void => {
 										fixIndices.push(fixIndex)
 									},
+								}),
 							})
 						},
 					})

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
@@ -157,7 +157,7 @@ function rule (primary: `always` | `never`): RuleCheck {
 					result,
 					ruleName,
 					node: ruleNode,
-					fix,
+					...(fix && { fix }),
 				})
 			}
 		})

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -216,7 +216,9 @@ function rule (primary: `lower` | `upper`): RuleCheck {
  * @returns What stands in front of the first bang, or the whole text where it holds none.
  */
 function withoutBangFlag (text: string): string {
-	return text.split(`!`)[0] ?? ``
+	let bang = text.indexOf(`!`)
+
+	return bang === -1 ? text : text.slice(0, bang)
 }
 
 rule.ruleName = ruleName

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -102,7 +102,11 @@ function rule (primary: `lower` | `upper`): RuleCheck {
 				let index = getIndex(node)
 				// The warning opens where the unit's first character stands and closes one character past its last, so it covers the run that reading was taken from and nothing besides. `getDimension` reads its unit out of a copy with the interpolation and the hack units taken out, and `positions` is the only way from a length counted in that copy to a place in the text the file spells: a bang flag riding behind the unit, a `\9` written after it and the brace an interpolation was broken on all stay outside a run measured this way.
 				let unitStart = positions[number.length]
-				let unitEnd = positions[number.length + unit.length - 1] + 1
+				let unitLast = positions[number.length + unit.length - 1]
+
+				if (unitStart === undefined || unitLast === undefined) return null
+
+				let unitEnd = unitLast + 1
 
 				return {
 					index: index + valueNode.sourceIndex + unitStart,
@@ -212,9 +216,7 @@ function rule (primary: `lower` | `upper`): RuleCheck {
  * @returns What stands in front of the first bang, or the whole text where it holds none.
  */
 function withoutBangFlag (text: string): string {
-	let [beforeFlag] = text.split(`!`)
-
-	return beforeFlag
+	return text.split(`!`)[0] ?? ``
 }
 
 rule.ruleName = ruleName

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -51,7 +51,7 @@ export function atRuleNameSpaceChecker (options: {
 					endIndex: index,
 					result: options.result,
 					ruleName: options.checkedRuleName,
-					fix: fix ? (): void => fix(node) : undefined,
+					...(fix && { fix: (): void => fix(node) }),
 				})
 			},
 			errTarget: `@${node.name}`,

--- a/lib/utils/atRuleParamIndex/index.test.ts
+++ b/lib/utils/atRuleParamIndex/index.test.ts
@@ -1,6 +1,8 @@
 import { type AtRule, parse } from "postcss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { atRuleParamIndex } from "./index.ts"
 
 describe(`atRuleParamIndex`, () => {
@@ -33,9 +35,5 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/atRuleParamIndex/index.test.ts
+++ b/lib/utils/atRuleParamIndex/index.test.ts
@@ -33,5 +33,9 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/declarationBangSpaceChecker/index.ts
+++ b/lib/utils/declarationBangSpaceChecker/index.ts
@@ -107,11 +107,11 @@ export function declarationBangSpaceChecker (opts: {
 						endIndex: index,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: fix && isFixable
-							? (): void => {
+						...(fix && isFixable && {
+							fix: (): void => {
 								for (let edit of fix({ text: declString, index })) fileEdit(parts, edit)
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/utils/declarationColonSpaceChecker/index.ts
+++ b/lib/utils/declarationColonSpaceChecker/index.ts
@@ -66,7 +66,7 @@ export function declarationColonSpaceChecker (opts: {
 						endIndex: problemIndex,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: fix && isFixable ? (): void => fix(decl, startIndex) : undefined,
+						...(fix && isFixable && { fix: (): void => fix(decl, startIndex) }),
 					})
 				},
 			})

--- a/lib/utils/declarationString/index.test.ts
+++ b/lib/utils/declarationString/index.test.ts
@@ -38,7 +38,11 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -53,5 +57,9 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/declarationString/index.test.ts
+++ b/lib/utils/declarationString/index.test.ts
@@ -2,6 +2,8 @@ import { type Declaration, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { declarationString } from "./index.ts"
 
 describe(`declarationString`, () => {
@@ -38,11 +40,7 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -57,9 +55,5 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/declarationValueIndex/index.test.ts
+++ b/lib/utils/declarationValueIndex/index.test.ts
@@ -1,6 +1,8 @@
 import { type Declaration, parse } from "postcss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { declarationValueIndex } from "./index.ts"
 
 describe(`declarationValueIndex`, () => {
@@ -37,9 +39,5 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/declarationValueIndex/index.test.ts
+++ b/lib/utils/declarationValueIndex/index.test.ts
@@ -37,5 +37,9 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/endsWithInlineComment/index.ts
+++ b/lib/utils/endsWithInlineComment/index.ts
@@ -14,7 +14,7 @@ export type Scan = {
  * @param scan - Where the scan stands, moved on by what is read.
  */
 function readInsideInlineComment (text: string, scan: Scan): void {
-	let char = text[scan.index]
+	let char = text.charAt(scan.index)
 
 	// Which characters are breaks is the one thing the two languages disagree about, and the reading the scan was opened under is which of the two it is being asked as
 	if (LINE_BREAK.test(char)) scan.state = `code`

--- a/lib/utils/findCommentSpans/index.ts
+++ b/lib/utils/findCommentSpans/index.ts
@@ -56,7 +56,7 @@ function skipUrl (text: string, openIndex: number, behindIdentifier: boolean): n
 	let index = behindName
 
 	while (index < text.length && depth > 0) {
-		let character = text[index]
+		let character = text.charAt(index)
 
 		if (character === `\\`) {
 			index += 2
@@ -117,7 +117,7 @@ export function findCommentSpans (text: string, spellsInlineComments: boolean = 
 	let behindIdentifier = false
 
 	while (index < text.length) {
-		let character = text[index]
+		let character = text.charAt(index)
 		let next = text[index + 1]
 
 		if (character === `\\`) {

--- a/lib/utils/findFunctionArgumentSpans/index.ts
+++ b/lib/utils/findFunctionArgumentSpans/index.ts
@@ -23,7 +23,7 @@ function skipString (text: string, openIndex: number): number {
  * @returns The index behind what was skipped, or null where code stands there.
  */
 function skipNonCode (text: string, index: number): number | null {
-	let character = text[index]
+	let character = text.charAt(index)
 	let next = text[index + 1]
 
 	if (character === `"` || character === `'`) return skipString(text, index)
@@ -114,7 +114,7 @@ export function findFunctionArgumentSpans (text: string): FunctionArgumentSpan[]
 	let runEnd = -1
 
 	while (index < text.length) {
-		let character = text[index]
+		let character = text.charAt(index)
 		let skipped = skipNonCode(text, index)
 		let escape = character === `\\` ? escapeLength(text, index) : 0
 

--- a/lib/utils/findMediaFeatureNames/index.ts
+++ b/lib/utils/findMediaFeatureNames/index.ts
@@ -84,7 +84,7 @@ export function findMediaFeatureNames (mediaQueryParams: string, callback: (medi
 				let topLevelTokens = topLevelTokenNodes(node)
 				for (let i = 0; i < topLevelTokens.length; i += 1) {
 					let token = topLevelTokens[i]
-					if (token[0] !== TokenType.Ident) continue
+					if (!token || token[0] !== TokenType.Ident) continue
 
 					let nextToken = topLevelTokens[i + 1]
 					let prevToken = topLevelTokens[i - 1]

--- a/lib/utils/findSelectorInlineComments/index.ts
+++ b/lib/utils/findSelectorInlineComments/index.ts
@@ -65,8 +65,10 @@ export function findSelectorInlineComments (rawSelector: string, scssSelector?: 
 
 		delta += (endIndex - startIndex) - value.length
 
-		if (firstOrdinal !== -1) {
-			inlineComments.push({ value, firstOrdinal, lastOrdinal, tailLength: endIndex - comments[lastOrdinal].end, startIndex, endIndex, delta })
+		let lastComment = comments[lastOrdinal]
+
+		if (firstOrdinal !== -1 && lastComment) {
+			inlineComments.push({ value, firstOrdinal, lastOrdinal, tailLength: endIndex - lastComment.end, startIndex, endIndex, delta })
 		}
 
 		rawIndex = endIndex

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -36,7 +36,7 @@ export function functionCommaSpaceChecker (opts: {
 	result: PostcssResult,
 	checkedRuleName: string,
 	fixPosition?: `before` | `after`,
-	ignoreFunctions?: string | RegExp | Array<string | RegExp>,
+	ignoreFunctions?: string | RegExp | Array<string | RegExp> | undefined,
 }): void {
 	let { fix } = opts
 
@@ -161,11 +161,11 @@ export function functionCommaSpaceChecker (opts: {
 						node: decl,
 						result: opts.result,
 						ruleName: opts.checkedRuleName,
-						fix: fix && isFixable(commaNode)
-							? (): void => {
+						...(fix && isFixable(commaNode) && {
+							fix: (): void => {
 								edits.push(...fix(commaNode, nodeIndex, functionNode))
-							}
-							: undefined,
+							},
+						}),
 					})
 				}
 			}

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -93,7 +93,11 @@ export function functionCommaSpaceChecker (opts: {
 			 * @returns The index of the comma for checking.
 			 */
 			function getCommaCheckIndex (commaNode: ValueParserDivNode, nodeIndex: number): number {
-				let commaIndex = (argumentOffsets[nodeIndex] ?? 0) + commaNode.before.length
+				let openingOffset = argumentOffsets[nodeIndex]
+
+				if (openingOffset === undefined) throw new Error(`The comma stands in no argument of the function`)
+
+				let commaIndex = openingOffset + commaNode.before.length
 
 				return commaIndex - commentsRemovedBefore(hiddenArguments, commaIndex, commentSpans)
 			}

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -93,7 +93,7 @@ export function functionCommaSpaceChecker (opts: {
 			 * @returns The index of the comma for checking.
 			 */
 			function getCommaCheckIndex (commaNode: ValueParserDivNode, nodeIndex: number): number {
-				let commaIndex = argumentOffsets[nodeIndex] + commaNode.before.length
+				let commaIndex = (argumentOffsets[nodeIndex] ?? 0) + commaNode.before.length
 
 				return commaIndex - commentsRemovedBefore(hiddenArguments, commaIndex, commentSpans)
 			}

--- a/lib/utils/functionCommaSpaceFix/index.ts
+++ b/lib/utils/functionCommaSpaceFix/index.ts
@@ -19,7 +19,7 @@ function runHeldByNeighbour (index: number, functionNode: ValueParserFunctionNod
 
 		let previous = nodes[index - 1]
 
-		return previous.type === `div` ? previous.after.length : 0
+		return previous?.type === `div` ? previous.after.length : 0
 	}
 
 	return index === nodes.length - 1 ? functionNode.after.length : 0

--- a/lib/utils/getAtRuleParams/index.test.ts
+++ b/lib/utils/getAtRuleParams/index.test.ts
@@ -2,6 +2,8 @@ import { type AtRule, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { getAtRuleParams } from "./index.ts"
 
 describe(`getAtRuleParams`, () => {
@@ -38,11 +40,7 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -57,9 +55,5 @@ function scssAtRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/getAtRuleParams/index.test.ts
+++ b/lib/utils/getAtRuleParams/index.test.ts
@@ -38,7 +38,11 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -53,5 +57,9 @@ function scssAtRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/getDeclarationValue/index.test.ts
+++ b/lib/utils/getDeclarationValue/index.test.ts
@@ -2,6 +2,8 @@ import { type Declaration, parse } from "postcss"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { getDeclarationValue } from "./index.ts"
 
 describe(`getDeclarationValue`, () => {
@@ -42,11 +44,7 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -61,9 +59,5 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/getDeclarationValue/index.test.ts
+++ b/lib/utils/getDeclarationValue/index.test.ts
@@ -42,7 +42,11 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -57,5 +61,9 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/getRuleSelector/index.test.ts
+++ b/lib/utils/getRuleSelector/index.test.ts
@@ -62,5 +62,9 @@ function collect (root: Root | Document): Rule {
 		list.push(node)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/getRuleSelector/index.test.ts
+++ b/lib/utils/getRuleSelector/index.test.ts
@@ -3,6 +3,8 @@ import { parse as parseLess } from "postcss-less"
 import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { getRuleSelector } from "./index.ts"
 
 describe(`getRuleSelector`, () => {
@@ -62,9 +64,5 @@ function collect (root: Root | Document): Rule {
 		list.push(node)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/isLessDetachedRulesetCall/index.test.ts
+++ b/lib/utils/isLessDetachedRulesetCall/index.test.ts
@@ -2,6 +2,8 @@ import type { AtRule } from "postcss"
 import postcssLess from "postcss-less"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { isLessDetachedRulesetCall } from "./index.ts"
 
 describe(`isLessDetachedRulesetCall`, () => {
@@ -55,9 +57,5 @@ function lessAtRule (code: string, index: number = 0): AtRule {
 		atRules.push(atRule)
 	})
 
-	let atRule = atRules[index]
-
-	if (!atRule) throw new Error(`The stylesheet holds no at-rule at that index`)
-
-	return atRule
+	return pick(atRules, index)
 }

--- a/lib/utils/isLessDetachedRulesetCall/index.test.ts
+++ b/lib/utils/isLessDetachedRulesetCall/index.test.ts
@@ -55,5 +55,9 @@ function lessAtRule (code: string, index: number = 0): AtRule {
 		atRules.push(atRule)
 	})
 
-	return atRules[index]
+	let atRule = atRules[index]
+
+	if (!atRule) throw new Error(`The stylesheet holds no at-rule at that index`)
+
+	return atRule
 }

--- a/lib/utils/isStandardSyntaxAtRule/index.test.ts
+++ b/lib/utils/isStandardSyntaxAtRule/index.test.ts
@@ -3,21 +3,9 @@ import postcssLess from "postcss-less"
 import postcssScss from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { isStandardSyntaxAtRule } from "./index.ts"
-
-/**
- * Takes one at-rule out of a list, which the case knows to hold it.
- * @param list - The at-rules.
- * @param index - Which of them.
- * @returns That at-rule.
- */
-function at (list: AtRule[], index: number): AtRule {
-	let found = list[index]
-
-	if (!found) throw new Error(`The stylesheet holds no at-rule at that index`)
-
-	return found
-}
 
 describe(`isStandardSyntaxAtRule`, () => {
 	it(`non nested at-rules without quotes`, () => {
@@ -68,8 +56,8 @@ describe(`isStandardSyntaxAtRule`, () => {
 			`mixin`,
 			`content`,
 		])
-		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(true)
-		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(false)
+		expect(isStandardSyntaxAtRule(pick(rules, 0))).toBe(true)
+		expect(isStandardSyntaxAtRule(pick(rules, 1))).toBe(false)
 	})
 
 	// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/357
@@ -82,7 +70,7 @@ describe(`isStandardSyntaxAtRule`, () => {
 			`a { @whatever(x); }`,
 		]
 
-		for (let spelling of spellings) expect(isStandardSyntaxAtRule(at(lessAtRules(spelling), 0))).toBe(true)
+		for (let spelling of spellings) expect(isStandardSyntaxAtRule(pick(lessAtRules(spelling), 0))).toBe(true)
 	})
 
 	// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/357
@@ -90,7 +78,7 @@ describe(`isStandardSyntaxAtRule`, () => {
 		let rules = lessAtRules(`@detached-ruleset: { background: red; }; .top { @detached-ruleset (); }`)
 
 		expect(rules.length).toBe(2)
-		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(true)
+		expect(isStandardSyntaxAtRule(pick(rules, 1))).toBe(true)
 	})
 
 	it(`ignore passing rulesets to mixins`, () => {
@@ -99,22 +87,22 @@ describe(`isStandardSyntaxAtRule`, () => {
 		)
 
 		expect(rules.length).toBe(2)
-		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
-		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(false)
+		expect(isStandardSyntaxAtRule(pick(rules, 0))).toBe(false)
+		expect(isStandardSyntaxAtRule(pick(rules, 1))).toBe(false)
 	})
 
 	it(`ignore calling of mixins`, () => {
 		let rules = lessAtRules(`a { .mixin(); }`)
 
 		expect(rules.length).toBe(1)
-		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
+		expect(isStandardSyntaxAtRule(pick(rules, 0))).toBe(false)
 	})
 
 	it(`ignore variables`, () => {
 		let rules = lessAtRules(`@my-variable: 10px; .top { margin-top: @my-variable; }`)
 
 		expect(rules.length).toBe(1)
-		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
+		expect(isStandardSyntaxAtRule(pick(rules, 0))).toBe(false)
 	})
 })
 
@@ -140,11 +128,7 @@ function atRules (code: string, parser: { parse: Parser } = postcss): AtRule[] {
  * @returns That at-rule.
  */
 function atRule (code: string): AtRule {
-	let [first] = atRules(code)
-
-	if (!first) throw new Error(`The stylesheet holds no at-rule`)
-
-	return first
+	return pick(atRules(code))
 }
 
 /**

--- a/lib/utils/isStandardSyntaxAtRule/index.test.ts
+++ b/lib/utils/isStandardSyntaxAtRule/index.test.ts
@@ -5,6 +5,20 @@ import { describe, expect, it } from "vitest"
 
 import { isStandardSyntaxAtRule } from "./index.ts"
 
+/**
+ * Takes one at-rule out of a list, which the case knows to hold it.
+ * @param list - The at-rules.
+ * @param index - Which of them.
+ * @returns That at-rule.
+ */
+function at (list: AtRule[], index: number): AtRule {
+	let found = list[index]
+
+	if (!found) throw new Error(`The stylesheet holds no at-rule at that index`)
+
+	return found
+}
+
 describe(`isStandardSyntaxAtRule`, () => {
 	it(`non nested at-rules without quotes`, () => {
 		expect(isStandardSyntaxAtRule(atRule(`@charset UTF-8;`))).toBe(true)
@@ -54,8 +68,8 @@ describe(`isStandardSyntaxAtRule`, () => {
 			`mixin`,
 			`content`,
 		])
-		expect(isStandardSyntaxAtRule(rules[0])).toBe(true)
-		expect(isStandardSyntaxAtRule(rules[1])).toBe(false)
+		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(true)
+		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(false)
 	})
 
 	// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/357
@@ -68,7 +82,7 @@ describe(`isStandardSyntaxAtRule`, () => {
 			`a { @whatever(x); }`,
 		]
 
-		for (let spelling of spellings) expect(isStandardSyntaxAtRule(lessAtRules(spelling)[0])).toBe(true)
+		for (let spelling of spellings) expect(isStandardSyntaxAtRule(at(lessAtRules(spelling), 0))).toBe(true)
 	})
 
 	// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/357
@@ -76,7 +90,7 @@ describe(`isStandardSyntaxAtRule`, () => {
 		let rules = lessAtRules(`@detached-ruleset: { background: red; }; .top { @detached-ruleset (); }`)
 
 		expect(rules.length).toBe(2)
-		expect(isStandardSyntaxAtRule(rules[1])).toBe(true)
+		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(true)
 	})
 
 	it(`ignore passing rulesets to mixins`, () => {
@@ -85,22 +99,22 @@ describe(`isStandardSyntaxAtRule`, () => {
 		)
 
 		expect(rules.length).toBe(2)
-		expect(isStandardSyntaxAtRule(rules[0])).toBe(false)
-		expect(isStandardSyntaxAtRule(rules[1])).toBe(false)
+		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
+		expect(isStandardSyntaxAtRule(at(rules, 1))).toBe(false)
 	})
 
 	it(`ignore calling of mixins`, () => {
 		let rules = lessAtRules(`a { .mixin(); }`)
 
 		expect(rules.length).toBe(1)
-		expect(isStandardSyntaxAtRule(rules[0])).toBe(false)
+		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
 	})
 
 	it(`ignore variables`, () => {
 		let rules = lessAtRules(`@my-variable: 10px; .top { margin-top: @my-variable; }`)
 
 		expect(rules.length).toBe(1)
-		expect(isStandardSyntaxAtRule(rules[0])).toBe(false)
+		expect(isStandardSyntaxAtRule(at(rules, 0))).toBe(false)
 	})
 })
 
@@ -126,7 +140,11 @@ function atRules (code: string, parser: { parse: Parser } = postcss): AtRule[] {
  * @returns That at-rule.
  */
 function atRule (code: string): AtRule {
-	return atRules(code)[0]
+	let [first] = atRules(code)
+
+	if (!first) throw new Error(`The stylesheet holds no at-rule`)
+
+	return first
 }
 
 /**

--- a/lib/utils/isStandardSyntaxCombinator/index.test.ts
+++ b/lib/utils/isStandardSyntaxCombinator/index.test.ts
@@ -69,5 +69,9 @@ function combinator (css: string): Combinator {
 		}).processSync(rule.selector)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/isStandardSyntaxCombinator/index.test.ts
+++ b/lib/utils/isStandardSyntaxCombinator/index.test.ts
@@ -2,6 +2,8 @@ import { parse } from "postcss"
 import selectorParser, { type Combinator } from "postcss-selector-parser"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { isStandardSyntaxCombinator } from "./index.ts"
 
 describe(`isStandardSyntaxCombinator`, () => {
@@ -69,9 +71,5 @@ function combinator (css: string): Combinator {
 		}).processSync(rule.selector)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/isStandardSyntaxDeclaration/index.test.ts
+++ b/lib/utils/isStandardSyntaxDeclaration/index.test.ts
@@ -144,7 +144,9 @@ function decl (css: string, parser: { parse: Parser } = postcss): Declaration {
 		list.push(d)
 	})
 
-	if (list.length === 1) return list[0]
+	let [first] = list
+
+	if (first && list.length === 1) return first
 
 	throw new Error(`Expected length 1, but ${list.length}`)
 }

--- a/lib/utils/isStandardSyntaxFunction/index.test.ts
+++ b/lib/utils/isStandardSyntaxFunction/index.test.ts
@@ -47,5 +47,9 @@ function getFunction (declValue: string): FunctionNode {
 		if (valueNode.type === `function`) functions.push(valueNode)
 	})
 
-	return functions[0]
+	let [first] = functions
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/isStandardSyntaxFunction/index.test.ts
+++ b/lib/utils/isStandardSyntaxFunction/index.test.ts
@@ -1,6 +1,8 @@
 import valueParser, { type FunctionNode } from "postcss-value-parser"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { isStandardSyntaxFunction } from "./index.ts"
 
 describe(`isStandardSyntaxFunction`, () => {
@@ -47,9 +49,5 @@ function getFunction (declValue: string): FunctionNode {
 		if (valueNode.type === `function`) functions.push(valueNode)
 	})
 
-	let [first] = functions
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(functions)
 }

--- a/lib/utils/mediaFeatureColonSpaceChecker/index.ts
+++ b/lib/utils/mediaFeatureColonSpaceChecker/index.ts
@@ -64,7 +64,7 @@ export function mediaFeatureColonSpaceChecker (opts: {
 					endIndex: colonIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: fix ? (): void => fix(node, colonIndex) : undefined,
+					...(fix && { fix: (): void => fix(node, colonIndex) }),
 				})
 			},
 		})

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
@@ -90,7 +90,7 @@ export function mediaQueryListCommaWhitespaceChecker (opts: {
 					endIndex: commaIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: fix && isFixable ? (): void => fix(node, commaIndex) : undefined,
+					...(fix && isFixable && { fix: (): void => fix(node, commaIndex) }),
 				})
 			},
 		})

--- a/lib/utils/searchCopy/index.test.ts
+++ b/lib/utils/searchCopy/index.test.ts
@@ -56,7 +56,11 @@ function cssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -71,5 +75,9 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/searchCopy/index.test.ts
+++ b/lib/utils/searchCopy/index.test.ts
@@ -3,6 +3,8 @@ import { parse as parseScss } from "postcss-scss"
 import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { searchCopy } from "./index.ts"
 
 const CSS_RESULT = { opts: {} } as unknown as PostcssResult
@@ -56,11 +58,7 @@ function cssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -75,9 +73,5 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
+++ b/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
@@ -98,13 +98,13 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 						endIndex: problemIndex,
 						result: options.result,
 						ruleName: options.checkedRuleName,
-						fix: fix
-							? (): void => {
+						...(fix && {
+							fix: (): void => {
 								hasFixed = true
 
 								fix(attributeNode)
-							}
-							: undefined,
+							},
+						}),
 					})
 				},
 			})

--- a/lib/utils/selectorCombinatorSpaceChecker/index.ts
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.ts
@@ -120,13 +120,13 @@ export function selectorCombinatorSpaceChecker (opts: {
 					endIndex: reportIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: fix && isFixable
-						? (): void => {
+					...(fix && isFixable && {
+						fix: (): void => {
 							hasFixed = true
 
 							fix(combinator)
-						}
-						: undefined,
+						},
+					}),
 				})
 			},
 		})

--- a/lib/utils/selectorListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/selectorListCommaWhitespaceChecker/index.ts
@@ -85,7 +85,7 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 					endIndex: sourceIndex,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: fix && isFixable ? (): void => fix(node, index) : undefined,
+					...(fix && isFixable && { fix: (): void => fix(node, index) }),
 				})
 			},
 		})

--- a/lib/utils/setAtRuleParams/index.test.ts
+++ b/lib/utils/setAtRuleParams/index.test.ts
@@ -77,7 +77,11 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -92,5 +96,9 @@ function scssAtRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/setAtRuleParams/index.test.ts
+++ b/lib/utils/setAtRuleParams/index.test.ts
@@ -2,6 +2,7 @@ import { type AtRule, parse } from "postcss"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
 import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setAtRuleParams } from "./index.ts"
@@ -77,11 +78,7 @@ function atRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -96,9 +93,5 @@ function scssAtRule (css: string): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/setDeclarationValue/index.test.ts
+++ b/lib/utils/setDeclarationValue/index.test.ts
@@ -2,6 +2,7 @@ import { type Declaration, parse } from "postcss"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
 import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setDeclarationValue } from "./index.ts"
@@ -77,11 +78,7 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**
@@ -96,9 +93,5 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/setDeclarationValue/index.test.ts
+++ b/lib/utils/setDeclarationValue/index.test.ts
@@ -77,7 +77,11 @@ function decl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**
@@ -92,5 +96,9 @@ function scssDecl (css: string): Declaration {
 		list.push(d)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/setRuleSelector/index.test.ts
+++ b/lib/utils/setRuleSelector/index.test.ts
@@ -114,5 +114,9 @@ function collect (root: Root | Document): Rule {
 		list.push(node)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }

--- a/lib/utils/setRuleSelector/index.test.ts
+++ b/lib/utils/setRuleSelector/index.test.ts
@@ -3,6 +3,7 @@ import { parse as parseLess } from "postcss-less"
 import { parse as parseScss, stringify as stringifyScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
 import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 import { setRuleSelector } from "./index.ts"
@@ -114,9 +115,5 @@ function collect (root: Root | Document): Rule {
 		list.push(node)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }

--- a/lib/utils/syncLessVariableValue/index.test.ts
+++ b/lib/utils/syncLessVariableValue/index.test.ts
@@ -2,6 +2,8 @@ import postcss, { type AtRule, type Node, type Parser } from "postcss"
 import postcssLess from "postcss-less"
 import { describe, expect, it } from "vitest"
 
+import { pick } from "../../../vitest.helpers.ts"
+
 import { syncLessVariableValue } from "./index.ts"
 
 describe(`syncLessVariableValue`, () => {
@@ -62,11 +64,7 @@ function atRule (code: string, parser: { parse: Parser } = postcss): AtRule {
 		list.push(rule)
 	})
 
-	let [first] = list
-
-	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
-
-	return first
+	return pick(list)
 }
 
 /**

--- a/lib/utils/syncLessVariableValue/index.test.ts
+++ b/lib/utils/syncLessVariableValue/index.test.ts
@@ -62,7 +62,11 @@ function atRule (code: string, parser: { parse: Parser } = postcss): AtRule {
 		list.push(rule)
 	})
 
-	return list[0]
+	let [first] = list
+
+	if (!first) throw new Error(`The stylesheet holds no node of the kind asked for`)
+
+	return first
 }
 
 /**

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -87,7 +87,7 @@ export function valueListCommaWhitespaceChecker (opts: ValueListCommaWhitespaceC
 					endIndex: index,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,
-					fix: fix && isFixable ? (): void => fix(node, index) : undefined,
+					...(fix && isFixable && { fix: (): void => fix(node, index) }),
 				})
 			},
 		})

--- a/lib/utils/whitespaceChecker/index.ts
+++ b/lib/utils/whitespaceChecker/index.ts
@@ -109,16 +109,9 @@ export function whitespaceChecker (targetWhitespace: `space` | `newline`, expect
 	 * @param args - Where to look, and what to do about what is found.
 	 */
 	function before (args: WhitespaceCheckerArgs): void {
-		let { source, index, err, errTarget, lineCheckStr, onlyOneChar = false, allowIndentation = false } = args
+		let { source, lineCheckStr, onlyOneChar = false, allowIndentation = false } = args
 
-		activeArgs = {
-			source,
-			index,
-			err,
-			errTarget,
-			onlyOneChar,
-			allowIndentation,
-		}
+		activeArgs = { ...args, onlyOneChar, allowIndentation }
 
 		switch (expectation) {
 			case `always`:
@@ -149,9 +142,9 @@ export function whitespaceChecker (targetWhitespace: `space` | `newline`, expect
 	 * @param args - Where to look, and what to do about what is found.
 	 */
 	function after (args: WhitespaceCheckerArgs): void {
-		let { source, index, err, errTarget, lineCheckStr, onlyOneChar = false } = args
+		let { source, lineCheckStr, onlyOneChar = false } = args
 
-		activeArgs = { source, index, err, errTarget, onlyOneChar }
+		activeArgs = { ...args, onlyOneChar, allowIndentation: false }
 
 		switch (expectation) {
 			case `always`:

--- a/scripts/check-break-readings.ts
+++ b/scripts/check-break-readings.ts
@@ -76,7 +76,7 @@ const DEBT: Record<string, string[]> = {
 		`if (source.slice(index, index + 2) === \`\\r\\n\`) return`,
 	],
 	"lib/rules/indentation/index.ts": [
-		`let expressionStartLine = parent.parent.source.input.css.split(\`\\n\`)[parent.source.start.line - 1]`,
+		`let expressionStartLine = parent.parent.source.input.css.split(\`\\n\`)[parent.source.start.line - 1] ?? \`\``,
 		`target: \`\\n\`,`,
 	],
 	"lib/rules/max-empty-lines/index.ts": [`target: CRLF.test(rootString) ? \`\\r\\n\` : \`\\n\`,`],

--- a/scripts/check-break-readings.ts
+++ b/scripts/check-break-readings.ts
@@ -76,7 +76,7 @@ const DEBT: Record<string, string[]> = {
 		`if (source.slice(index, index + 2) === \`\\r\\n\`) return`,
 	],
 	"lib/rules/indentation/index.ts": [
-		`let expressionStartLine = parent.parent.source.input.css.split(\`\\n\`)[parent.source.start.line - 1] ?? \`\``,
+		`let found = text.split(\`\\n\`)[line - 1]`,
 		`target: \`\\n\`,`,
 	],
 	"lib/rules/max-empty-lines/index.ts": [`target: CRLF.test(rootString) ? \`\\r\\n\` : \`\\n\`,`],

--- a/scripts/harness/checkout.ts
+++ b/scripts/harness/checkout.ts
@@ -52,4 +52,7 @@ function defaultBase (): string {
 	return execFileSync(`git`, [`merge-base`, `HEAD`, `origin/main`], { cwd: ROOT, encoding: `utf8` }).trim()
 }
 
+/** The two sides of a comparison: the revision a branch is measured against, and the branch. */
+export type Side = `base` | `head`
+
 export { defaultBase, entryAt, libAt, ROOT }

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -23,17 +23,17 @@ const SEVERITY = `error`
 
 /** What a rule said, in the fields the oracles read; the warning standing in for a parse error carries no position. */
 export type Warning = {
-	rule?: string,
+	rule?: string | undefined,
 	text: string,
-	line?: number,
-	column?: number,
-	endLine?: number,
-	endColumn?: number,
-	severity?: string,
+	line?: number | undefined,
+	column?: number | undefined,
+	endLine?: number | undefined,
+	endColumn?: number | undefined,
+	severity?: string | undefined,
 }
 
 /** A rule by its short name, with its primary option and, where there is one, its secondary options. */
-export type RuleSetting = [string, unknown, object?]
+export type RuleSetting = [string, unknown, (object | undefined)?]
 
 /** The rules of one checkout by their short names, as `lib/rules/index.js` exports them. */
 export type Registry = Record<string, Rule>
@@ -127,7 +127,7 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false }: {
 	code: string,
 	rules: RuleSetting[],
 	registry: Registry,
-	syntax?: string | Syntax,
+	syntax?: string | Syntax | undefined,
 	fix?: boolean,
 }): Promise<Answer> {
 	let parser = await loadSyntax(syntax)

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -228,6 +228,7 @@ async function lint ({ code, config, fix = false }: {
 	let [plugin] = config.plugins
 
 	if (!plugin) throw new Error(`The configuration names no plugin`)
+
 	let registry = registries.get(plugin)
 
 	if (!registry) {

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -226,6 +226,8 @@ async function lint ({ code, config, fix = false }: {
 	code: string | undefined,
 }> {
 	let [plugin] = config.plugins
+
+	if (!plugin) throw new Error(`The configuration names no plugin`)
 	let registry = registries.get(plugin)
 
 	if (!registry) {

--- a/scripts/harness/verify-lint.ts
+++ b/scripts/harness/verify-lint.ts
@@ -39,6 +39,9 @@ async function askStylelint (code: string, config: Config, fix: boolean): Promis
 	}
 
 	let [first] = result.results
+
+	if (!first) throw new Error(`Stylelint answered with no result`)
+
 	let parseError = first.warnings.find((warning) => warning.rule === `CssSyntaxError`)
 
 	if (parseError) return { unparsable: true, detail: parseError.text }
@@ -124,7 +127,9 @@ for (let [name, run] of fixtures) {
 		let a = configs[(index * 3) % configs.length]
 		let b = configs[((index * 3) + 1) % configs.length]
 
-		for (let [first, second] of [[a, b], [b, a]]) {
+		if (!a || !b) throw new Error(`The option list holds no pair to run`)
+
+		for (let [first, second] of [[a, b], [b, a]] as const) {
 			// eslint-disable-next-line no-await-in-loop
 			await compare(`${first[0]} then ${second[0]} css ${name}`, run.code, { plugins: run.config.plugins, rules: { [first[0]]: first[1], [second[0]]: second[1] } })
 		}

--- a/scripts/oracles/compare.ts
+++ b/scripts/oracles/compare.ts
@@ -64,19 +64,39 @@ function run (oracle: string, revision: string): Record<string, unknown>[] {
 }
 
 let [base = defaultBase(), head = `worktree`] = argv.slice(2)
-let sides = { base, head }
+
+/** The two sides of a comparison. */
+type Side = `base` | `head`
+
+let sides: Record<Side, string> = { base, head }
 
 let plan: {
-	side: string,
+	side: Side,
 	revision: string,
 	oracle: string,
 	key: string,
 	inputs: Record<string, string>,
 }[] = []
 
-let results: Record<string, Record<string, Record<string, unknown>[]>> = { base: {}, head: {} }
+let results: Record<Side, Record<string, Record<string, unknown>[]>> = { base: {}, head: {} }
 
-for (let [side, revision] of Object.entries(sides)) {
+/**
+ * Hands back the rows of one oracle over one side, which every oracle has by the time the report is written.
+ * @param side - The side.
+ * @param oracle - The oracle.
+ * @returns The rows.
+ */
+function rowsOf (side: Side, oracle: string): Record<string, unknown>[] {
+	let rows = results[side][oracle]
+
+	if (!rows) throw new Error(`${oracle} has no rows over ${side}`)
+
+	return rows
+}
+
+for (let side of [`base`, `head`] as const) {
+	let revision = sides[side]
+
 	for (let oracle of ORACLES) {
 		let inputs = inputsOf(oracle, revision)
 		let key = keyOf(inputs)
@@ -120,10 +140,10 @@ let report = [`# Oracles: ${base} → ${head}`, ``]
 let summary = []
 
 for (let oracle of ORACLES) {
-	let result = diff(keyed(results.base[oracle]), keyed(results.head[oracle]))
+	let result = diff(keyed(rowsOf(`base`, oracle)), keyed(rowsOf(`head`, oracle)))
 
-	summary.push(`${oracle}: ${results.head[oracle].length} rows, +${result.added.length} −${result.removed.length} ~${result.changed.length}`)
-	report.push(`## ${oracle}`, ``, render(result, keyed(results.base[oracle]), keyed(results.head[oracle])))
+	summary.push(`${oracle}: ${rowsOf(`head`, oracle).length} rows, +${result.added.length} −${result.removed.length} ~${result.changed.length}`)
+	report.push(`## ${oracle}`, ``, render(result, keyed(rowsOf(`base`, oracle)), keyed(rowsOf(`head`, oracle))))
 }
 
 mkdirSync(path.join(ROOT, `tmp`), { recursive: true })

--- a/scripts/oracles/compare.ts
+++ b/scripts/oracles/compare.ts
@@ -12,7 +12,7 @@ import path from "node:path"
 import { argv, env, stdout } from "node:process"
 
 import { hashAt, keyOf, read, write } from "../harness/cache.ts"
-import { defaultBase, libAt, ROOT } from "../harness/checkout.ts"
+import { defaultBase, libAt, ROOT, type Side } from "../harness/checkout.ts"
 import { diff, render } from "../harness/diff.ts"
 
 /** The oracles, in the order `make oracles` has always run them. */
@@ -64,9 +64,6 @@ function run (oracle: string, revision: string): Record<string, unknown>[] {
 }
 
 let [base = defaultBase(), head = `worktree`] = argv.slice(2)
-
-/** The two sides of a comparison. */
-type Side = `base` | `head`
 
 let sides: Record<Side, string> = { base, head }
 

--- a/scripts/oracles/nodes.ts
+++ b/scripts/oracles/nodes.ts
@@ -31,7 +31,11 @@ function tally (code: string, syntaxName: string): string | null {
 	let counts = { decl: 0, rule: 0, atrule: 0 }
 
 	try {
-		PARSERS[syntaxName].parse(code).walk(({ type }) => {
+		let parser = PARSERS[syntaxName]
+
+		if (!parser) return null
+
+		parser.parse(code).walk(({ type }) => {
 			if (type === `decl` || type === `rule` || type === `atrule`) counts[type] += 1
 		})
 	}

--- a/scripts/oracles/pairs.ts
+++ b/scripts/oracles/pairs.ts
@@ -21,7 +21,7 @@ import { RULE_OPTIONS } from "./options.ts"
 import { isUsable, PLUGIN } from "./runs.ts"
 
 /** Shapes short enough to read and dirty enough that many rules have something to say about each. They are read as CSS alone: a pair races over the shape of the text rather than over the syntax it is written in, and reading each shape three times over would treble a run that is already the square of what the fixture wakes. The last two end on something other than a line break, which is what makes the fix of `no-missing-end-of-source-newline` reachable at all: every other shape here has closed its last line already, so that rule wrote nothing in any run this oracle made, and a class of [#356](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/356) went unseen. `free-semicolon` is what puts a row of that class on the board; `trailing-run` puts none on either checkout — under a maximum of one or two `max-empty-lines` rewrote nothing there before this fix, so the pair was never made at all, and under a maximum of zero, where it did rewrite, the two orders already agreed — and stands guard over a fix rather than reporting one. */
-const CORPUS = [
+const CORPUS: [string, string][] = [
 	[`tight-block`, `a{color:red}\n`],
 	[`multi-decl`, `a {\n\tcolor: red; top: 0;\n}\n`],
 	[`media`, `@media(min-width:100px){a{b:c}}\n`],
@@ -138,12 +138,12 @@ for (let [name, source] of CORPUS) {
 	// eslint-disable-next-line no-await-in-loop
 	let active = await activeOn(source)
 
-	for (let i = 0; i < active.length; i += 1) {
-		for (let j = i + 1; j < active.length; j += 1) {
-			if (active[i].rule === active[j].rule) continue
+	for (let [i, a] of active.entries()) {
+		for (let b of active.slice(i + 1)) {
+			if (a.rule === b.rule) continue
 
 			// eslint-disable-next-line no-await-in-loop
-			let finding = await probe(name, source, active[i], active[j])
+			let finding = await probe(name, source, a, b)
 
 			if (finding) findings.push(finding)
 		}

--- a/scripts/oracles/runs.ts
+++ b/scripts/oracles/runs.ts
@@ -50,7 +50,7 @@ function buildRuns (corpus?: [string, string][]): Run[] {
  * @returns True where the run is worth reading.
  */
 function isUsable (result: {
-	warnings: { rule?: string }[],
+	warnings: { rule?: string | undefined }[],
 	invalidOptionWarnings?: unknown[],
 }): boolean {
 	if (result.warnings.some((warning) => warning.rule === `CssSyntaxError`)) return false

--- a/scripts/oracles/twins.ts
+++ b/scripts/oracles/twins.ts
@@ -29,7 +29,7 @@ import { buildRuns, isUsable, type Run } from "./runs.ts"
 const EVERY_BREAK = /\r?\n/gu
 
 /** The spelling a twin is built in, under the name its rows are reported by. */
-const TWINS = [[`crlf`, `\r\n`]]
+const TWINS: [string, string][] = [[`crlf`, `\r\n`]]
 
 /** Every syntax, fixture and spelling already reported as one the syntax cannot read, since the parse happens before any rule does and reporting it per rule would say one thing two hundred and three times. */
 let reportedUnparsable = new Set()

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -24,7 +24,7 @@ const SYNTAXES: Record<string, string | undefined> = { css: undefined, scss: `po
 export type Sweep = {
 	name: string,
 	corpus: [string, string][],
-	configs: { rule: string, primary: unknown, secondary?: object }[],
+	configs: { rule: string, primary: unknown, secondary?: object | undefined }[],
 	syntaxes?: string[],
 }
 

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -80,15 +80,22 @@ if (!file) {
 }
 
 let sweep: Sweep = await import(path.resolve(file))
-let sides = { base, head: `worktree` }
 
-/** Each side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
-let results: Record<string, {
+/** The two sides of a comparison. */
+type Side = `base` | `head`
+
+/** One side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
+type Result = {
 	digest: Record<string, string>,
 	rows: () => Record<string, object>,
-}> = {}
+}
 
-for (let [side, revision] of Object.entries(sides)) {
+let sides: Record<Side, string> = { base, head: `worktree` }
+let results: Partial<Record<Side, Result>> = {}
+
+for (let side of [`base`, `head`] as const) {
+	let revision = sides[side]
+
 	// A side is measured once by what it depends on — the rules, the sweep and the runner — and read back on every later run; the two are taken in turn, base first
 	let inputs = { sweep: hashAt(`worktree`, path.relative(ROOT, path.resolve(file))), lib: hashAt(revision, `lib`), harness: hashAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
 	let key = keyOf(inputs)
@@ -123,9 +130,13 @@ let out = path.join(ROOT, `tmp`, `sweeps`)
 
 mkdirSync(out, { recursive: true })
 
-let result = diff(results.base.digest, results.head.digest)
+let { base: baseResult, head: headResult } = results
+
+if (!baseResult || !headResult) throw new Error(`A side was neither read nor measured`)
+
+let result = diff(baseResult.digest, headResult.digest)
 let moved = result.changed.length + result.added.length + result.removed.length > 0
-let report = moved ? render(result, results.base.rows(), results.head.rows()) : render(result, {}, {})
+let report = moved ? render(result, baseResult.rows(), headResult.rows()) : render(result, {}, {})
 
 writeFileSync(path.join(out, `${sweep.name}.md`), `# ${sweep.name}: ${base} → worktree\n\n${report}`)
-stdout.write(`${Object.keys(results.head.digest).length} rows: ${result.same} same, ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed — tmp/sweeps/${sweep.name}.md\n`)
+stdout.write(`${Object.keys(headResult.digest).length} rows: ${result.same} same, ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed — tmp/sweeps/${sweep.name}.md\n`)

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -13,7 +13,7 @@ import path from "node:path"
 import { argv, exit, stderr, stdout } from "node:process"
 
 import { digestOf, hashAt, keyOf, read, readDigest, write } from "../harness/cache.ts"
-import { defaultBase, libAt, ROOT } from "../harness/checkout.ts"
+import { defaultBase, libAt, ROOT, type Side } from "../harness/checkout.ts"
 import { diff, render } from "../harness/diff.ts"
 import { lintDirect, loadRules, type Registry, type RuleSetting } from "../harness/lint.ts"
 
@@ -79,10 +79,8 @@ if (!file) {
 	exit(2)
 }
 
-let sweep: Sweep = await import(path.resolve(file))
-
-/** The two sides of a comparison. */
-type Side = `base` | `head`
+let sweepFile = path.resolve(file)
+let sweep: Sweep = await import(sweepFile)
 
 /** One side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
 type Result = {
@@ -91,20 +89,24 @@ type Result = {
 }
 
 let sides: Record<Side, string> = { base, head: `worktree` }
-let results: Partial<Record<Side, Result>> = {}
 
-for (let side of [`base`, `head`] as const) {
+/**
+ * Measures one side, or reads it back where the store holds it.
+ * @param side - The side.
+ * @returns Its digest, and its rows on demand.
+ */
+async function measureSide (side: Side): Promise<Result> {
 	let revision = sides[side]
 
 	// A side is measured once by what it depends on — the rules, the sweep and the runner — and read back on every later run; the two are taken in turn, base first
-	let inputs = { sweep: hashAt(`worktree`, path.relative(ROOT, path.resolve(file))), lib: hashAt(revision, `lib`), harness: hashAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
+	let inputs = { sweep: hashAt(`worktree`, path.relative(ROOT, sweepFile)), lib: hashAt(revision, `lib`), harness: hashAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
 	let key = keyOf(inputs)
 	let digest = readDigest(`sweeps`, sweep.name, key)
 
 	if (digest) {
 		let rows: Record<string, object> | undefined
 
-		results[side] = {
+		return {
 			digest,
 			rows: (): Record<string, object> => {
 				rows ??= read<Record<string, object>>(`sweeps`, sweep.name, key)
@@ -114,25 +116,22 @@ for (let side of [`base`, `head`] as const) {
 				return rows
 			},
 		}
-		continue
 	}
 
 	stdout.write(`\t🧹 ${sweep.name} over ${side} (${revision})\n`)
-	// eslint-disable-next-line no-await-in-loop
 	let rows = await measure(sweep, await loadRules(libAt(revision)))
 
 	digest = digestOf(rows)
 	write(`sweeps`, sweep.name, key, rows, { ...inputs, revision, root: ROOT }, digest)
-	results[side] = { digest, rows: (): Record<string, object> => rows }
+	return { digest, rows: (): Record<string, object> => rows }
 }
+
+let baseResult = await measureSide(`base`)
+let headResult = await measureSide(`head`)
 
 let out = path.join(ROOT, `tmp`, `sweeps`)
 
 mkdirSync(out, { recursive: true })
-
-let { base: baseResult, head: headResult } = results
-
-if (!baseResult || !headResult) throw new Error(`A side was neither read nor measured`)
 
 let result = diff(baseResult.digest, headResult.digest)
 let moved = result.changed.length + result.added.length + result.removed.length > 0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"esModuleInterop": true,
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
 		"strictNullChecks": true,
 		"noImplicitAny": true,
 		"forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"strictNullChecks": true,
 		"noImplicitAny": true,
 		"forceConsistentCasingInFileNames": true,

--- a/vitest.helpers.ts
+++ b/vitest.helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Takes one item out of a list a test knows to hold it, and says so where the list does not.
+ * @param list - The items.
+ * @param index - Which of them; the first where none is named.
+ * @returns That item.
+ */
+export function pick<T> (list: readonly T[], index = 0): T {
+	let item = list[index]
+
+	if (item === undefined) throw new Error(`The list holds no item at ${index}`)
+
+	return item
+}


### PR DESCRIPTION
The migration left two strict flags for later (#447): with `noUncheckedIndexedAccess` off, `list[i]` and `match[1]` are typed as if the index could not miss, and with `exactOptionalPropertyTypes` off, `fix?: () => void` also takes an explicit `undefined`. Each flag went on in a commit of its own, measured the way the `checkJs` step was:

- `noUncheckedIndexedAccess` — 124 errors, answered with tuple types, `charAt`, a bound regexp group, and a guard where a read really can miss. Two of them fixed a check that never fired: `number-leading-zero` and `number-no-trailing-zeros` compared a group against `null`.
- `exactOptionalPropertyTypes` — 45 errors, 21 of them a `fix: … : undefined` handed to Stylelint's `report`, rewritten as `...(isFixable && { fix })`; the plugin's own types say `| undefined` where a caller hands it through.

No `as` was added. On every commit `make verify` is green (9103 tests, 1 skipped), `make oracles` moves no row, `make harness-check` compares 52 160 runs with 0 disagreements, and the `printed-node` sweep keeps all 19 680 rows.

## What the review turned up

Two rounds, no behaviour defect. The first found the nineteen pasted `let [first] = list; if (!first) throw` guards, now `pick` in `vitest.helpers.ts`; two integration tests reading a missing result as zero warnings; two quiet `?? 0`/`?? ''` defaults where the code they replaced failed out loud; a dead guard in the sweep runner; and the `no-undefined` reason in `.oxlintrc.json` resting on the `report` calls this branch rewrote. The second found three more hand-rolled `pick`s, a `?? ''` that could not fire in `unit-case`, `Side` declared in two scripts, and a doubled `isString` guard in `indentation`.

Closes #447
