### PR TITLE
Take the `entryAt` probe out of the harness

### DIFF
--- a/scripts/harness/checkout.ts
+++ b/scripts/harness/checkout.ts
@@ -31,20 +31,6 @@ function libAt (revision: string): string {
 }
 
 /**
- * Names the entry file of a checkout's `lib/` under one name, in whichever of the two spellings the checkout keeps it.
- *
- * The migration to TypeScript renames every module of `lib/` from `.js` to `.ts`, and a base a branch is measured against keeps the spelling it was written with; a run asks both sides in one process, so the file has to be found rather than named. The probe goes once the base of every branch is on the far side of the migration.
- * @param lib - The path of the checkout's `lib/` directory.
- * @param name - The module, relative to `lib/` and without its extension.
- * @returns The absolute path of that module.
- */
-function entryAt (lib: string, name: string): string {
-	let typescript = path.join(lib, `${name}.ts`)
-
-	return existsSync(typescript) ? typescript : path.join(lib, `${name}.js`)
-}
-
-/**
  * Names the revision a branch is measured against: where it left `origin/main`.
  * @returns The commit.
  */
@@ -55,4 +41,4 @@ function defaultBase (): string {
 /** The two sides of a comparison: the revision a branch is measured against, and the branch. */
 export type Side = `base` | `head`
 
-export { defaultBase, entryAt, libAt, ROOT }
+export { defaultBase, libAt, ROOT }

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -12,7 +12,6 @@ import path from "node:path"
 import postcss, { type Document, type Root, type Syntax, type Warning as PostcssWarning } from "postcss"
 import type { PostcssResult, Rule, RuleMeta, RuleSeverity, StylelintPostcssResult } from "stylelint"
 
-import { entryAt } from "./checkout.ts"
 import { BREAK_AS_STYLELINT_READS_IT } from "./regexps.ts"
 
 /** The comment word Stylelint reads its configuration comments by, which no fixture carries and which a rule may still ask about. */
@@ -35,7 +34,7 @@ export type Warning = {
 /** A rule by its short name, with its primary option and, where there is one, its secondary options. */
 export type RuleSetting = [string, unknown, (object | undefined)?]
 
-/** The rules of one checkout by their short names, as `lib/rules/index.js` exports them. */
+/** The rules of one checkout by their short names, as `lib/rules/index.ts` exports them. */
 export type Registry = Record<string, Rule>
 
 /** What the rules said and wrote, or why the text could not be read. */
@@ -86,7 +85,7 @@ async function loadSyntax (syntax: string | Syntax | undefined): Promise<Syntax>
  * @returns The registry, keyed by the rule's short name.
  */
 async function loadRules (lib: string): Promise<Registry> {
-	let module = await import(entryAt(lib, `rules/index`))
+	let module = await import(path.join(lib, `rules`, `index.ts`))
 
 	return module.default
 }

--- a/scripts/oracles/runs.ts
+++ b/scripts/oracles/runs.ts
@@ -1,13 +1,13 @@
+import path from "node:path"
 import { env } from "node:process"
 
-import { entryAt } from "../harness/checkout.ts"
 import type { Config } from "../harness/lint.ts"
 
 import { FIXTURES, INLINE_FIXTURES } from "./fixtures.ts"
 import { RULE_OPTIONS } from "./options.ts"
 
 /** The plugin is loaded by its place on disk, so that an oracle runs the same from any directory — and from another checkout's `lib/` where `HARNESS_LIB` names one, which is how a base is measured with the branch's oracles without moving the working tree. */
-const PLUGIN = entryAt(env.HARNESS_LIB || new URL(`../../lib`, import.meta.url).pathname, `index`)
+const PLUGIN = path.join(env.HARNESS_LIB || new URL(`../../lib`, import.meta.url).pathname, `index.ts`)
 
 export type Run = {
 	rule: string,


### PR DESCRIPTION
`entryAt` in `scripts/harness/checkout.ts` found a checkout's entry module in whichever spelling the checkout kept — `lib/index.ts` where it lay, `lib/index.js` otherwise — so that a base written in JavaScript could be measured against a branch written in TypeScript in one process. Its own comment set the day it goes: when no branch is measured against a base older than the migration. That day is here — no open PR has such a base (the stale `deprecating`, `release` and `add-claude-github-actions-…` branches are not measured), and `make cache-gc` has collected the 28 results the store held for the older trees.

`loadRules` imports `lib/rules/index.ts`, the oracles' `PLUGIN` names `lib/index.ts`, and the probe goes with its comment. `make verify` is green, `make oracles`, `make harness-check` (52 160 runs, 0 disagreements) and the `printed-node` sweep answer as before, and `make oracles BASE=fa024f9` extracted and loaded a base through the new path.

## What the review turned up

One round: the `Registry` doc comment in `lint.ts` still named `lib/rules/index.js`; it names `index.ts` now.

Closes #448
