### PR TITLE
Ask the syntax where a stylesheet is embedded

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -69,7 +69,7 @@
 				"max-lines": [
 					"error",
 					{
-						"max": 427,
+						"max": 404,
 						"skipComments": true,
 						"skipBlankLines": true
 					}
@@ -77,7 +77,7 @@
 				"max-lines-per-function": [
 					"error",
 					{
-						"max": 253,
+						"max": 244,
 						"skipComments": true,
 						"skipBlankLines": true
 					}

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -11,8 +11,6 @@ import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
-import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration/index.ts"
-import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -50,11 +48,12 @@ type SecondaryOptions = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option: a number of spaces, or `tab`.
  * @param secondaryOptions - The secondary options: `baseIndentLevel`, `except`, `ignore`, `indentInsideParens` and `indentClosingBrace`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: number | `tab`, secondaryOptions: SecondaryOptions = {}): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: number | `tab`, secondaryOptions: SecondaryOptions = {}): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -105,7 +104,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 			}
 
 			let nodeLevel = indentationLevel(node)
-			let styledDeclarationLevel = isStyledSyntaxNode(node) ? getStyledDeclarationLevel(node) : 0
+			let hostLevel = Math.ceil(syntax.embedding(node).indent.length / indentChar.length)
 
 			// Cut out any * and _ hacks from `before`
 			let before = (node.raws.before || ``).replace(TRAILING_STAR_OR_UNDERSCORE, ``)
@@ -125,7 +124,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 			if ((beforeLines.length > 1 || (isFirstChild && (!getDocument(parent) || (parent.raws.codeBefore && TRAILING_LINE_BREAK.test(parent.raws.codeBefore))))) && indentationBefore !== expectedOpeningBraceIndentation) {
 				report({
 					message: messages.expected,
-					messageArgs: [legibleExpectation(nodeLevel - styledDeclarationLevel)],
+					messageArgs: [legibleExpectation(nodeLevel - hostLevel)],
 					node,
 					result,
 					ruleName,
@@ -147,7 +146,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 
 				report({
 					message: messages.expected,
-					messageArgs: [legibleExpectation(closingBraceLevel - styledDeclarationLevel)],
+					messageArgs: [legibleExpectation(closingBraceLevel - hostLevel)],
 					node,
 					index: problemIndex,
 					endIndex: problemIndex,
@@ -170,24 +169,6 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 		})
 
 		/**
-		 * Roughly calculates the indentation level of the line where styled expression starts. Required to format the error text relative to this level, not the beginning of a line.
-		 * @param node - The node to calculate level for.
-		 * @returns The calculated indentation level.
-		 */
-		function getStyledDeclarationLevel (node: Node): number {
-			let { parent } = node
-
-			if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
-
-			// Content of the line where styled expressions starts
-			let expressionStartLine = lineAt(parent.parent.source.input.css, parent.source.start.line)
-			// Indent characters (spaces/tabs) before the content of the line where the styled expressions starts
-			let indentCharacters = expressionStartLine.match(LEADING_SPACES_AND_TABS)?.[0] ?? ``
-
-			return Math.ceil(indentCharacters.length / indentChar.length)
-		}
-
-		/**
 		 * Calculates the indentation level for a node.
 		 * @param node - The node to calculate level for.
 		 * @param level - The current level.
@@ -198,13 +179,11 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 
 			let calculatedLevel = level
 
-			if (isStyledSyntaxNode(node)) {
-				let isMultilineDeclaration = !!node.parent.source && LINE_BREAK.test(node.parent.source.input.css)
+			let { indent: hostIndent, multiline } = syntax.embedding(node)
 
-				if (isMultilineDeclaration) calculatedLevel += 1
+			if (multiline) calculatedLevel += 1
 
-				calculatedLevel += getStyledDeclarationLevel(node)
-			}
+			calculatedLevel += Math.ceil(hostIndent.length / indentChar.length)
 
 			if (isRoot(node.parent)) return calculatedLevel + getRootBaseIndentLevel(node.parent, baseIndentLevel, primary)
 
@@ -225,7 +204,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 		function checkValue (decl: Declaration, declLevel: number): void {
 			if (!LINE_BREAK.test(decl.value)) return
 
-			if (isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`)) return
+			if (syntax.valueEmbedsHostCode(decl)) return
 
 			if (optionsMatches(secondaryOptions, `ignore`, `value`)) return
 
@@ -676,20 +655,6 @@ function inferRootIndentLevel (root: Root, baseIndentLevel: number | `auto` | un
 	if (indents.length > 0) return Math.max(...indents.map((indent) => getIndentLevel(indent))) + newBaseIndentLevel
 
 	return newBaseIndentLevel
-}
-
-/**
- * Reads one line of a text, counted from one as a source position counts them.
- * @param text - The text.
- * @param line - The number of the line.
- * @returns The line, without its break.
- */
-function lineAt (text: string, line: number): string {
-	let found = text.split(`\n`)[line - 1]
-
-	if (found === undefined) throw new Error(`A styled expression starts on a line its file does not hold`)
-
-	return found
 }
 
 /**

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -1,6 +1,39 @@
+import type { Declaration, Node } from "postcss"
+
+import { LEADING_SPACES_AND_TABS, LINE_BREAK } from "../../regexps.ts"
+import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration/index.ts"
+import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode/index.ts"
 import type { Syntax } from "../index.ts"
 
-/** The syntax of the core: plain CSS, which every rule of the plugin is written for. Until a custom syntax has a namespace of its own, the core reads it as well, so no root is refused yet. */
+/** The syntax of the core: plain CSS, which every rule of the plugin is written for. Until a custom syntax has a namespace of its own, the core reads it as well, so no root is refused yet, and the embedding of a styled template is still answered here rather than by a `styled` namespace. */
 export let css: Syntax = {
 	accepts: () => true,
+	embedding (node: Node): { indent: string, multiline: boolean } {
+		if (!isStyledSyntaxNode(node)) return { indent: ``, multiline: false }
+
+		let { parent } = node
+
+		if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
+
+		// The line of the host file the expression opens on carries the indentation the template hangs from, and a template broken over lines holds its content one level deeper than that line
+		return {
+			indent: lineAt(parent.parent.source.input.css, parent.source.start.line).match(LEADING_SPACES_AND_TABS)?.[0] ?? ``,
+			multiline: LINE_BREAK.test(parent.source.input.css),
+		}
+	},
+	valueEmbedsHostCode: (decl: Declaration) => isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`),
+}
+
+/**
+ * Reads one line of a text, counted from one as a source position counts them.
+ * @param text - The text.
+ * @param line - The number of the line.
+ * @returns The line, without its break.
+ */
+function lineAt (text: string, line: number): string {
+	let found = text.split(`\n`)[line - 1]
+
+	if (found === undefined) throw new Error(`A styled expression starts on a line its file does not hold`)
+
+	return found
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -1,4 +1,4 @@
-import type { Root } from "postcss"
+import type { Declaration, Node, Root } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 /**
@@ -18,6 +18,20 @@ export type Syntax = {
 	 * @returns True where the rules are written for it; a root refused here is answered by one warning naming the rule, and checked by nothing.
 	 */
 	accepts (root: Root, result: PostcssResult): boolean,
+
+	/**
+	 * Reads what the code around an embedded stylesheet gives a node of it: the indentation of the line the embedding expression opens on, and whether the expression is broken over lines, which puts what it holds one level deeper.
+	 * @param node - The node whose stylesheet may be embedded.
+	 * @returns The indentation and the spread; an empty indent, unbroken, for a stylesheet standing on its own.
+	 */
+	embedding (node: Node): { indent: string, multiline: boolean },
+
+	/**
+	 * Asks whether a declaration's value embeds an expression of the host language, whose lines are the host's rather than the stylesheet's.
+	 * @param decl - The declaration.
+	 * @returns True where the value holds such an expression.
+	 */
+	valueEmbedsHostCode (decl: Declaration): boolean,
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */

--- a/lib/utils/defineRule/index.test.ts
+++ b/lib/utils/defineRule/index.test.ts
@@ -2,6 +2,7 @@ import { parse } from "postcss"
 import stylelint, { type Config, type PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { css } from "../../syntaxes/css/index.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
 import type { RuleCheck } from "../ruleCheck/index.ts"
 
@@ -31,8 +32,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: stri
 
 let createRule = defineRule({ shortName: `property-found`, meta: { url: `https://example.test/property-found` }, messages: MESSAGES, rule })
 
-let core: Syntax = { accepts: () => true }
-let refusing: Syntax = { namespace: `never`, accepts: () => false }
+let core: Syntax = { ...css }
+let refusing: Syntax = { ...css, namespace: `never`, accepts: () => false }
 
 /**
  * Lints a text under the rules given, each registered as a plugin of its own and configured to look for `color`.
@@ -87,6 +88,7 @@ describe(`a rule built for a syntax`, () => {
 	it(`asks the syntax about the root a check was handed`, () => {
 		let seen: unknown[] = []
 		let asked: Syntax = {
+			...css,
 			accepts: (root) => {
 				seen.push(root)
 

--- a/lib/utils/defineRule/index.ts
+++ b/lib/utils/defineRule/index.ts
@@ -11,6 +11,7 @@ let { utils: { report, ruleMessages } } = stylelint
 export type RuleScope<M extends RuleMessages> = {
 	ruleName: string,
 	messages: M,
+	syntax: Syntax,
 }
 
 /** What a rule module defines once, whichever namespaces the rule is then registered under. */
@@ -55,7 +56,7 @@ export function defineRule<P, S, M extends RuleMessages> (definition: RuleDefini
 		 * @returns The check, run over every stylesheet the rule is configured for, unless the syntax refuses it.
 		 */
 		function scoped (primary: P, secondaryOptions: S): RuleCheck {
-			let check = rule({ ruleName, messages: scopedMessages }, primary, secondaryOptions)
+			let check = rule({ ruleName, messages: scopedMessages, syntax }, primary, secondaryOptions)
 
 			return (root, result) => {
 				if (syntax.accepts(root, result)) return check(root, result)

--- a/scripts/check-break-readings.ts
+++ b/scripts/check-break-readings.ts
@@ -75,10 +75,8 @@ const DEBT: Record<string, string[]> = {
 		`if (nextChar === \`\\n\`) return`,
 		`if (source.slice(index, index + 2) === \`\\r\\n\`) return`,
 	],
-	"lib/rules/indentation/index.ts": [
-		`let found = text.split(\`\\n\`)[line - 1]`,
-		`target: \`\\n\`,`,
-	],
+	"lib/rules/indentation/index.ts": [`target: \`\\n\`,`],
+	"lib/syntaxes/css/index.ts": [`let found = text.split(\`\\n\`)[line - 1]`],
 	"lib/rules/max-empty-lines/index.ts": [`target: CRLF.test(rootString) ? \`\\r\\n\` : \`\\n\`,`],
 	"lib/rules/max-line-length/index.ts": [
 		`styleSearch({ source: rootString, target: [\`\\n\`], comments: \`check\` }, (match) => checkNewline(match))`,


### PR DESCRIPTION
The `indentation` rule read a styled template itself, through `isStyledSyntaxNode` and `isStyledSyntaxDeclaration`. What it asked them it now asks the syntax it is built over: `embedding(node)` answers the indentation of the host line the embedding expression opens on and whether the expression is broken over lines, `valueEmbedsHostCode(decl)` answers whether a value holds an expression of the host language. The rule keeps its own unit — it divides the host's indentation by its `indentChar` — so the syntax says where the template stands and the rule says how many levels that is.

The answers themselves have not moved: the core's syntax still carries the styled reading until the next PR of the stack registers the `styled` namespace, so nothing changes in what any rule reports. The two ceilings over `lib/rules/indentation/index.ts` come down with the code, the file to 404 lines and `rule` to 244.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
