### PR TITLE
Register the styled namespace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # A unified diff puts its context marker in front of the indentation the patched file already has, which every whitespace check reads as a space before a tab.
 patches/*.patch -whitespace
+
+# A test fixture spells whatever whitespace its case is about, a space in front of a tab included, so the whitespace check of the pre-commit hook keeps out of the fixtures.
+*.test.ts whitespace=-space-before-tab

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -1,39 +1,9 @@
-import type { Declaration, Node } from "postcss"
-
-import { LEADING_SPACES_AND_TABS, LINE_BREAK } from "../../regexps.ts"
-import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration/index.ts"
-import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode/index.ts"
 import type { Syntax } from "../index.ts"
+import { styled } from "../styled/index.ts"
 
-/** The syntax of the core: plain CSS, which every rule of the plugin is written for. Until a custom syntax has a namespace of its own, the core reads it as well, so no root is refused yet, and the embedding of a styled template is still answered here rather than by a `styled` namespace. */
+/** The syntax of the core: plain CSS, which every rule of the plugin is written for. Until a custom syntax has a namespace of its own, the core reads it as well, so no root is refused yet — and the embedding of a styled template is still answered, borrowed from the `styled` namespace; the borrowing goes with the branch that turns the core away from styled templates. */
 export let css: Syntax = {
 	accepts: () => true,
-	embedding (node: Node): { indent: string, multiline: boolean } {
-		if (!isStyledSyntaxNode(node)) return { indent: ``, multiline: false }
-
-		let { parent } = node
-
-		if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
-
-		// The line of the host file the expression opens on carries the indentation the template hangs from, and a template broken over lines holds its content one level deeper than that line
-		return {
-			indent: lineAt(parent.parent.source.input.css, parent.source.start.line).match(LEADING_SPACES_AND_TABS)?.[0] ?? ``,
-			multiline: LINE_BREAK.test(parent.source.input.css),
-		}
-	},
-	valueEmbedsHostCode: (decl: Declaration) => isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`),
-}
-
-/**
- * Reads one line of a text, counted from one as a source position counts them.
- * @param text - The text.
- * @param line - The number of the line.
- * @returns The line, without its break.
- */
-function lineAt (text: string, line: number): string {
-	let found = text.split(`\n`)[line - 1]
-
-	if (found === undefined) throw new Error(`A styled expression starts on a line its file does not hold`)
-
-	return found
+	embedding: styled.embedding,
+	valueEmbedsHostCode: styled.valueEmbedsHostCode,
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -1,6 +1,8 @@
 import type { Declaration, Node, Root } from "postcss"
 import type { PostcssResult } from "stylelint"
 
+import { styled } from "./styled/index.ts"
+
 /**
  * How a family of the plugin's rules reads a stylesheet: the namespace the family is registered under, and the syntaxes it answers for.
  *
@@ -35,4 +37,4 @@ export type Syntax = {
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */
-export let namespaces: Syntax[] = []
+export let namespaces: Syntax[] = [styled]

--- a/lib/syntaxes/styled/README.md
+++ b/lib/syntaxes/styled/README.md
@@ -1,0 +1,22 @@
+# The `styled` namespace
+
+The rules of the core under `@stylistic/styled/<rule>`, for stylesheets embedded in JavaScript as styled templates and parsed with [`postcss-styled-syntax`](https://github.com/hudochenkov/postcss-styled-syntax). The core's rules do not read such a file — on one they report a single warning naming this namespace — so a project using styled templates lists these names for the files that carry them:
+
+```json
+{
+	"plugins": ["@stylistic/stylelint-plugin"],
+	"overrides": [
+		{
+			"files": ["**/*.{js,jsx,ts,tsx}"],
+			"customSyntax": "postcss-styled-syntax",
+			"rules": {
+				"@stylistic/styled/indentation": ["tab"]
+			}
+		}
+	]
+}
+```
+
+Every rule of the core is here, with the same options and the same documentation, and plain CSS is read exactly as the core reads it. One rule answers a styled template differently:
+
+- [`indentation`](../../rules/indentation/README.md) counts its levels from the line the template's expression opens on rather than from the start of the line, and a template broken over lines holds its content one level deeper; a declaration whose value embeds an expression of the host language (`${…}`) is not checked, since its lines are the host's rather than the stylesheet's.

--- a/lib/syntaxes/styled/index.ts
+++ b/lib/syntaxes/styled/index.ts
@@ -1,0 +1,42 @@
+import type { Declaration, Node, Root } from "postcss"
+import type { PostcssResult } from "stylelint"
+
+import { LEADING_SPACES_AND_TABS, LINE_BREAK } from "../../regexps.ts"
+import { isStyledSyntaxDeclaration } from "../../utils/isStyledSyntaxDeclaration/index.ts"
+import { isStyledSyntaxNode } from "../../utils/isStyledSyntaxNode/index.ts"
+import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
+import type { Syntax } from "../index.ts"
+
+/** The syntax of the `styled` namespace: a stylesheet embedded in JavaScript as a styled template, parsed with `postcss-styled-syntax`. The namespace is a superset of the core — plain CSS is read exactly as the core reads it — so a project holding both configures these rules alone for the files that carry templates. */
+export let styled: Syntax = {
+	namespace: `styled`,
+	accepts: (root: Root, result: PostcssResult) => root.raws.styledSyntaxRangeStart !== undefined || nodeSyntax(root, result) === undefined,
+	embedding (node: Node): { indent: string, multiline: boolean } {
+		if (!isStyledSyntaxNode(node)) return { indent: ``, multiline: false }
+
+		let { parent } = node
+
+		if (!parent?.parent?.source || !parent.source?.start) throw new Error(`A styled expression must stand inside a node with a source`)
+
+		// The line of the host file the expression opens on carries the indentation the template hangs from, and a template broken over lines holds its content one level deeper than that line
+		return {
+			indent: lineAt(parent.parent.source.input.css, parent.source.start.line).match(LEADING_SPACES_AND_TABS)?.[0] ?? ``,
+			multiline: LINE_BREAK.test(parent.source.input.css),
+		}
+	},
+	valueEmbedsHostCode: (decl: Declaration) => isStyledSyntaxDeclaration(decl) && decl.value.includes(`\${`),
+}
+
+/**
+ * Reads one line of a text, counted from one as a source position counts them.
+ * @param text - The text.
+ * @param line - The number of the line.
+ * @returns The line, without its break.
+ */
+function lineAt (text: string, line: number): string {
+	let found = text.split(`\n`)[line - 1]
+
+	if (found === undefined) throw new Error(`A styled expression starts on a line its file does not hold`)
+
+	return found
+}

--- a/lib/syntaxes/styled/rules/indentation/index.test.ts
+++ b/lib/syntaxes/styled/rules/indentation/index.test.ts
@@ -1,4 +1,7 @@
-import { messages, ruleName } from "./index.ts"
+import { createRule } from "../../../../rules/indentation/index.ts"
+import { styled } from "../../index.ts"
+
+let { ruleName, messages } = createRule(styled)
 
 let testRule = createTestRule({ ruleName })
 

--- a/scripts/check-break-readings.ts
+++ b/scripts/check-break-readings.ts
@@ -76,7 +76,7 @@ const DEBT: Record<string, string[]> = {
 		`if (source.slice(index, index + 2) === \`\\r\\n\`) return`,
 	],
 	"lib/rules/indentation/index.ts": [`target: \`\\n\`,`],
-	"lib/syntaxes/css/index.ts": [`let found = text.split(\`\\n\`)[line - 1]`],
+	"lib/syntaxes/styled/index.ts": [`let found = text.split(\`\\n\`)[line - 1]`],
 	"lib/rules/max-empty-lines/index.ts": [`target: CRLF.test(rootString) ? \`\\r\\n\` : \`\\n\`,`],
 	"lib/rules/max-line-length/index.ts": [
 		`styleSearch({ source: rootString, target: [\`\\n\`], comments: \`check\` }, (match) => checkNewline(match))`,


### PR DESCRIPTION
`lib/syntaxes/styled/` is the first syntax registered beside the core: every rule of the registry now also stands under `@stylistic/styled/<rule>` — all 79, since under `postcss-styled-syntax` every rule works today and only `indentation` reads the template itself. The adapter accepts a root by the mark that parser leaves on it, and plain CSS besides: a namespace is a superset of the core, so a file holding both is configured with its rules alone. The styled cases of `indentation` move into the namespace's directory and run under its own rule name; the core still reads styled templates in this PR — the turning away is the next one.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed (the oracles read css, scss and less; the styled reading is answered by the moved cases).
