### PR TITLE
Ask the syntax whether a construct is standard

### DIFF
--- a/lib/rules/at-rule-name-case/index.ts
+++ b/lib/rules/at-rule-name-case/index.ts
@@ -3,7 +3,6 @@ import stylelint from "stylelint"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -24,10 +23,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -39,7 +39,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		let expectation: `lower` | `upper` = primary
 
 		root.walkAtRules((atRule) => {
-			if (!isStandardSyntaxAtRule(atRule)) return
+			if (!syntax.isStandardAtRule(atRule)) return
 
 			let name = atRule.name
 

--- a/lib/rules/at-rule-name-newline-after/index.ts
+++ b/lib/rules/at-rule-name-newline-after/index.ts
@@ -24,10 +24,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `always-multi-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line`): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -41,6 +42,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		atRuleNameSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
 		})

--- a/lib/rules/at-rule-name-space-after/index.ts
+++ b/lib/rules/at-rule-name-space-after/index.ts
@@ -26,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `always-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		atRuleNameSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (atRule) => {

--- a/lib/rules/at-rule-semicolon-newline-after/index.ts
+++ b/lib/rules/at-rule-semicolon-newline-after/index.ts
@@ -5,7 +5,6 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
-import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
 import { nextNonCommentNode } from "../../utils/nextNonCommentNode/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { rawNodeString } from "../../utils/rawNodeString/index.ts"
@@ -30,11 +29,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `always`.
  * @param _secondary - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always`, _secondary: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always`, _secondary: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -52,7 +52,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			if (hasBlock(atRule)) return
 
-			if (!isStandardSyntaxAtRule(atRule)) return
+			if (!syntax.isStandardAtRule(atRule)) return
 
 			// Allow an end-of-line comment
 			let nodeToCheck = nextNonCommentNode(nextNode)

--- a/lib/rules/at-rule-semicolon-space-before/index.ts
+++ b/lib/rules/at-rule-semicolon-space-before/index.ts
@@ -4,7 +4,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
-import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
 import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
@@ -27,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -44,7 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		root.walkAtRules((atRule) => {
 			if (hasBlock(atRule)) return
 
-			if (!isStandardSyntaxAtRule(atRule)) return
+			if (!syntax.isStandardAtRule(atRule)) return
 
 			let atRuleString = rawNodeString(atRule, result)
 			let problemIndex = atRuleString.length - 1

--- a/lib/rules/declaration-colon-newline-after/index.ts
+++ b/lib/rules/declaration-colon-newline-after/index.ts
@@ -8,7 +8,6 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxDeclaration } from "../../utils/isStandardSyntaxDeclaration/index.ts"
 import { moveDeclarationValueHeadIntoBetween } from "../../utils/moveDeclarationValueHeadIntoBetween/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
@@ -34,11 +33,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `always-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -50,7 +50,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		if (!validOptions) return
 
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxDeclaration(decl)) return
+			if (!syntax.isStandardDeclaration(decl)) return
 
 			// A declaration the parser did not build has no text between its property and its value for either rule to read: PostCSS prints a colon and a space in place of the raw it lacks, and `declarationValueIndex` counts a colon alone, so the two disagree by the very character these rules are about. No syntax this plugin reads through leaves that raw empty; a declaration another plugin's fix built and put in the tree does.
 			if (!decl.raws.between) return

--- a/lib/rules/declaration-colon-space-after/index.ts
+++ b/lib/rules/declaration-colon-space-after/index.ts
@@ -32,10 +32,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never` and `always-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -49,6 +50,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		declarationColonSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (decl, index) => {

--- a/lib/rules/declaration-colon-space-before/index.ts
+++ b/lib/rules/declaration-colon-space-before/index.ts
@@ -46,10 +46,11 @@ function beforeColonString (decl: Declaration, index: number): string {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -63,6 +64,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		declarationColonSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The colon stands right after this part, so an inline comment ending it would swallow the colon

--- a/lib/rules/function-comma-newline-after/index.ts
+++ b/lib/rules/function-comma-newline-after/index.ts
@@ -30,11 +30,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param secondaryOptions - The secondary options: `ignoreFunctions`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -59,6 +60,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		functionCommaSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
 			fixPosition: `after`,

--- a/lib/rules/function-comma-newline-before/index.ts
+++ b/lib/rules/function-comma-newline-before/index.ts
@@ -30,11 +30,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param secondaryOptions - The secondary options: `ignoreFunctions`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -59,6 +60,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		functionCommaSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.beforeAllowingIndentation,
 			checkedRuleName: ruleName,
 			fixPosition: `before`,

--- a/lib/rules/function-comma-space-after/index.ts
+++ b/lib/rules/function-comma-space-after/index.ts
@@ -30,11 +30,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @param secondaryOptions - The secondary options: `ignoreFunctions`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -59,6 +60,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		functionCommaSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fixPosition: `after`,

--- a/lib/rules/function-comma-space-before/index.ts
+++ b/lib/rules/function-comma-space-before/index.ts
@@ -30,11 +30,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @param secondaryOptions - The secondary options: `ignoreFunctions`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`, secondaryOptions: { ignoreFunctions?: string | RegExp | (string | RegExp)[] }): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -59,6 +60,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		functionCommaSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			fixPosition: `before`,

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -3,6 +3,7 @@ import stylelint, { type FixCallback } from "stylelint"
 
 import { LEADING_WHITESPACE, LINE_BREAK } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { addEdit, applyEditsFromEnd, type Edit, toIndexBeforeEdits } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
@@ -11,7 +12,6 @@ import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
-import { isStandardSyntaxFunction } from "../../utils/isStandardSyntaxFunction/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -63,12 +63,13 @@ function findInlineCommentSpansAfterEdits (declValue: string, edits: Edit[], spe
  * Half the node is no answer, though the halves are not alike. The opening parenthesis of such a call is one the file really writes, and so is the whitespace behind it, so the opening half of an option could be read and fixed where it stands. The closing half could not: the parenthesis the file closes the call on is one the parser never hands over, so whether the option is satisfied there is a question the rule cannot put at all. Sometimes it already is — the last parenthesis of `f(1px // c) h(2px`, a break, `2px` and a break and `)` has the break an `always` option wants in front of it, the file reading `f(1px`, the break, `2px`, the break and `)` — and sometimes it is not, as in the same value without that second break. A rule keeping the opening half would write its whitespace and report the problem solved in both, and in the second it would hand back a value still violating the option at a parenthesis no run can ever reach, which is the shape #285 is about. Nothing the rule can see tells the two apart, so reporting nothing is the honest answer, and the warnings that costs are the price of a parse it cannot mend.
  *
  * The whole node is turned away rather than the closing half of it, warning and all: the parentheses the options are about are not where the parser puts them, and nothing read out of a value the parser has misread this way is worth reporting. A closed call standing inside such a function is reached by the walk as ever, and read and fixed where it stands. A bracket the file really leaves open never gets here — PostCSS throws on one of those before any rule sees the declaration — so a comment is the only thing the second question turns away.
+ * @param syntax - The syntax the rule is built over.
  * @param valueNode - The function the walk has reached.
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns True where the rule may read the function's parentheses and write between them.
  */
-function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
-	if (!isStandardSyntaxFunction(valueNode)) return false
+function isFunctionParsedAsWritten (syntax: Syntax, valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
+	if (!syntax.isStandardFunction(valueNode)) return false
 
 	if (valueNode.unclosed) return false
 
@@ -259,11 +260,12 @@ function getNeverFixability (read: {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -298,7 +300,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 				// A call standing in the text of an inline comment is no call of the value, and its parentheses are none of this rule's: leave it alone. A call nested inside it is still walked and asked the same question, since one opened inside such a comment reaches past the break that closes it and gathers code the file spells.
 				if (findInlineCommentSpanHolding(valueNode, inlineComments)) return
 
-				if (!isFunctionParsedAsWritten(valueNode, inlineComments)) return
+				if (!isFunctionParsedAsWritten(syntax, valueNode, inlineComments)) return
 
 				let functionString = valueParser.stringify(valueNode)
 				let isMultiLine = !isSingleLineString(functionString)

--- a/lib/rules/function-parentheses-space-inside/index.ts
+++ b/lib/rules/function-parentheses-space-inside/index.ts
@@ -2,6 +2,7 @@ import valueParser, { type FunctionNode } from "postcss-value-parser"
 import stylelint, { type FixCallback } from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
@@ -9,7 +10,6 @@ import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommen
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
-import { isStandardSyntaxFunction } from "../../utils/isStandardSyntaxFunction/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -50,12 +50,13 @@ const ARGUMENT_STAND_IN = `x`
  * Half the node is no answer, though the halves are not alike. The opening parenthesis of such a call is one the file really writes, and so is the whitespace behind it, so the opening half of an option could be read and fixed where it stands. The closing half could not: the parenthesis the file closes the call on is one the parser never hands over, so whether the option is satisfied there is a question the rule cannot put at all. Sometimes it already is — the last parenthesis of `f(1px // c) h( 2px`, a break, `2px )` has the space an `always` option wants in front of it, the file reading `f(1px` and the break and `2px )` — and sometimes it is not, as in `f(1px // c) h(2px`, a break and `2px)`. A rule keeping the opening half would write its whitespace and report the problem solved in both, and in the second it would hand back a value still violating the option at a parenthesis no run can ever reach, which is the shape #285 is about. Nothing the rule can see tells the two apart, so reporting nothing is the honest answer, and the warnings that costs are the price of a parse it cannot mend.
  *
  * The whole node is turned away rather than the closing half of it, warning and all: the parentheses the options are about are not where the parser puts them, and nothing read out of a value the parser has misread this way is worth reporting. A closed call standing inside such a function is reached by the walk as ever, and read and fixed where it stands. A bracket the file really leaves open never gets here — PostCSS throws on one of those before any rule sees the declaration — so a comment is the only thing the second question turns away.
+ * @param syntax - The syntax the rule is built over.
  * @param valueNode - The function the walk has reached.
  * @param inlineComments - The spans the inline comments of the value occupy in it.
  * @returns True where the rule may read the function's parentheses and write between them.
  */
-function isFunctionParsedAsWritten (valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
-	if (!isStandardSyntaxFunction(valueNode)) return false
+function isFunctionParsedAsWritten (syntax: Syntax, valueNode: FunctionNode, inlineComments: InlineCommentSpan[]): boolean {
+	if (!syntax.isStandardFunction(valueNode)) return false
 
 	if (valueNode.unclosed) return false
 
@@ -136,10 +137,11 @@ function closingEdit (valueNode: FunctionNode, text: string): Edit {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -170,7 +172,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 				// A call standing in the text of an inline comment is no call of the value, and its parentheses are none of this rule's: leave it alone. A call nested inside it is still walked and asked the same question, since one opened inside such a comment reaches past the break that closes it and gathers code the file spells.
 				if (findInlineCommentSpanHolding(valueNode, inlineComments)) return
 
-				if (!isFunctionParsedAsWritten(valueNode, inlineComments)) return
+				if (!isFunctionParsedAsWritten(syntax, valueNode, inlineComments)) return
 
 				// Ignore function without parameters
 				if (valueNode.nodes.length === 0) return

--- a/lib/rules/no-eol-whitespace/index.ts
+++ b/lib/rules/no-eol-whitespace/index.ts
@@ -9,7 +9,6 @@ import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import { isOnlyWhitespace } from "../../utils/isOnlyWhitespace/index.ts"
-import { isStandardSyntaxComment } from "../../utils/isStandardSyntaxComment/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
@@ -96,11 +95,12 @@ function findErrorStartIndex (lastEOLIndex: number, string: string, options: {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @param secondaryOptions - The secondary options: `ignore`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true, secondaryOptions: { ignore?: `empty-lines` | `empty-lines`[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true, secondaryOptions: { ignore?: `empty-lines` | `empty-lines`[] }): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -241,7 +241,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 						node.raws.left = fixed
 					})
 
-					if (isStandardSyntaxComment(node)) {
+					if (syntax.isStandardComment(node)) {
 						fixText(node.raws.right, (fixed) => {
 							node.raws.right = fixed
 						})

--- a/lib/rules/no-extra-semicolons/index.ts
+++ b/lib/rules/no-extra-semicolons/index.ts
@@ -5,8 +5,6 @@ import stylelint, { type FixCallback } from "stylelint"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
@@ -68,10 +66,11 @@ function getOffsetByNode (node: Node): number {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, { actual: primary })
 
@@ -98,9 +97,9 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 		}
 
 		root.walk((node) => {
-			if (isAtRule(node) && !isStandardSyntaxAtRule(node)) return
+			if (isAtRule(node) && !syntax.isStandardAtRule(node)) return
 
-			if (node.type === `rule` && !isStandardSyntaxRule(node)) return
+			if (node.type === `rule` && !syntax.isStandardRule(node)) return
 
 			if (node.raws.before && node.raws.before.trim().length > 0) {
 				let rawBeforeNode = node.raws.before
@@ -127,7 +126,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 				let rawAfterNode = node.raws.after
 
 				// Where the last child is a Less mixin followed by more than one semicolon, `node.raws.after` holds that semicolon. Less mixins are passed over, so this one is too
-				if (`last` in node && node.last && node.last.type === `atrule` && !isStandardSyntaxAtRule(node.last)) return
+				if (`last` in node && node.last && node.last.type === `atrule` && !syntax.isStandardAtRule(node.last)) return
 
 				let fixSemiIndices: number[] = []
 

--- a/lib/rules/property-case/index.ts
+++ b/lib/rules/property-case/index.ts
@@ -4,7 +4,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isCustomProperty } from "../../utils/isCustomProperty/index.ts"
-import { isStandardSyntaxProperty } from "../../utils/isStandardSyntaxProperty/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isRule } from "../../utils/typeGuards/index.ts"
@@ -28,11 +27,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @param secondaryOptions - The secondary options: `ignoreSelectors`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`, secondaryOptions: { ignoreSelectors?: string | RegExp | (string | RegExp)[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`, secondaryOptions: { ignoreSelectors?: string | RegExp | (string | RegExp)[] }): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -55,7 +55,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		root.walkDecls((decl) => {
 			let prop = decl.prop
 
-			if (!isStandardSyntaxProperty(prop)) return
+			if (!syntax.isStandardProperty(prop)) return
 
 			if (isCustomProperty(prop)) return
 

--- a/lib/rules/selector-attribute-brackets-space-inside/index.ts
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.ts
@@ -7,7 +7,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -35,10 +34,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -48,7 +48,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 

--- a/lib/rules/selector-attribute-operator-space-after/index.ts
+++ b/lib/rules/selector-attribute-operator-space-after/index.ts
@@ -27,10 +27,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let checker = whitespaceChecker(`space`, primary, messages)
 		let validOptions = validateOptions(result, ruleName, {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorAttributeOperatorSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			checkBeforeOperator: false,

--- a/lib/rules/selector-attribute-operator-space-before/index.ts
+++ b/lib/rules/selector-attribute-operator-space-before/index.ts
@@ -27,10 +27,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -44,6 +45,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorAttributeOperatorSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			checkBeforeOperator: true,

--- a/lib/rules/selector-combinator-space-after/index.ts
+++ b/lib/rules/selector-combinator-space-after/index.ts
@@ -26,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorCombinatorSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			locationType: `after`,
 			checkedRuleName: ruleName,

--- a/lib/rules/selector-combinator-space-before/index.ts
+++ b/lib/rules/selector-combinator-space-before/index.ts
@@ -26,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorCombinatorSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			locationType: `before`,
 			checkedRuleName: ruleName,

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.ts
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.ts
@@ -7,7 +7,6 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findSelectorBlockComments } from "../../utils/findSelectorBlockComments/index.ts"
 import { findSelectorInlineComments, type InlineComment } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -32,10 +31,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -44,7 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			let hasFixed = false
 

--- a/lib/rules/selector-list-comma-newline-after/index.ts
+++ b/lib/rules/selector-list-comma-newline-after/index.ts
@@ -7,7 +7,6 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
@@ -34,11 +33,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -50,7 +50,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			// The raw selector is what is read, so that an end-of-line comment is allowed, e.g.
 			//   a, /* comment */

--- a/lib/rules/selector-list-comma-newline-before/index.ts
+++ b/lib/rules/selector-list-comma-newline-before/index.ts
@@ -33,11 +33,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -53,6 +54,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.beforeAllowingIndentation,
 			checkedRuleName: ruleName,
 			// Under `never-multi-line` the whitespace in front of the comma is taken away, and it may hold the line break that closes an inline comment: without that break the comma, and the rest of the list, would land in the comment's text. The problem is reported and the code left as it was. `always` only adds a break in front of whatever whitespace stands there, and takes nothing.

--- a/lib/rules/selector-list-comma-space-after/index.ts
+++ b/lib/rules/selector-list-comma-space-after/index.ts
@@ -33,10 +33,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -52,6 +53,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (ruleNode, index) => {

--- a/lib/rules/selector-list-comma-space-before/index.ts
+++ b/lib/rules/selector-list-comma-space-before/index.ts
@@ -33,10 +33,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -52,6 +53,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		selectorListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The whitespace in front of the comma may hold the line break that closes an inline comment, and that break is nothing a fix may write over: taking it away or replacing it with the space `always` asks for would carry the comma, and the rest of the list, into the comment's text. The problem is reported and the code left as it was.

--- a/lib/rules/selector-pseudo-class-case/index.ts
+++ b/lib/rules/selector-pseudo-class-case/index.ts
@@ -5,8 +5,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
-import { isStandardSyntaxSelector } from "../../utils/isStandardSyntaxSelector/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -31,10 +29,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -44,7 +43,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
@@ -62,7 +61,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 			selectorTree.walkPseudos((pseudoNode) => {
 				let pseudo = pseudoNode.value
 
-				if (!isStandardSyntaxSelector(pseudo)) return
+				if (!syntax.isStandardSelector(pseudo)) return
 
 				if (pseudo.includes(`::`) || LEVEL_ONE_AND_TWO_PSEUDO_ELEMENTS.has(pseudo.toLowerCase().slice(1))) return
 

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
@@ -6,7 +6,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -42,10 +41,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -55,7 +55,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			if (!ruleNode.selector.includes(`(`)) return
 

--- a/lib/rules/selector-pseudo-element-case/index.ts
+++ b/lib/rules/selector-pseudo-element-case/index.ts
@@ -4,8 +4,6 @@ import { LEVEL_ONE_AND_TWO_PSEUDO_ELEMENTS } from "../../reference/selectors.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
-import { isStandardSyntaxSelector } from "../../utils/isStandardSyntaxSelector/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { transformSelector } from "../../utils/transformSelector/index.ts"
 
@@ -27,10 +25,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -40,7 +39,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		if (!validOptions) return
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			let selector = ruleNode.selector
 
@@ -50,7 +49,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 				selectorTree.walkPseudos((pseudoNode) => {
 					let pseudoElement = pseudoNode.value
 
-					if (!isStandardSyntaxSelector(pseudoElement)) return
+					if (!syntax.isStandardSelector(pseudoElement)) return
 
 					if (!pseudoElement.includes(`::`) && !LEVEL_ONE_AND_TWO_PSEUDO_ELEMENTS.has(pseudoElement.toLowerCase().slice(1))) return
 

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -12,7 +12,6 @@ import { findSelectorInlineComments } from "../../utils/findSelectorInlineCommen
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
 import { syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index.ts"
@@ -46,11 +45,12 @@ const DOUBLE_QUOTE = `"`
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `single` and `double`.
  * @param secondaryOptions - The secondary options: `avoidEscape`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `single` | `double`, secondaryOptions: { avoidEscape?: boolean }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `single` | `double`, secondaryOptions: { avoidEscape?: boolean }): RuleCheck {
 	let correctQuote: typeof SINGLE_QUOTE | typeof DOUBLE_QUOTE = primary === `single` ? SINGLE_QUOTE : DOUBLE_QUOTE
 
 	let erroneousQuote: typeof SINGLE_QUOTE | typeof DOUBLE_QUOTE = primary === `single` ? DOUBLE_QUOTE : SINGLE_QUOTE
@@ -79,7 +79,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `sin
 		// A double slash opens a comment only where the syntax says it does. Elsewhere it is part of a value — an address, most often — and reading it as a comment would silence every string behind it on the line. The two spellings are identical, so the text cannot answer this and the syntax has to. The question waits until a double slash turns up, since answering it costs two parses of a probe and most stylesheets never ask.
 		//
 		// A stylesheet embedded in a page carries the syntax of its own block, and it is that one the question belongs to: the syntax the file was opened with parses the page rather than the style, and one page may hold blocks written in several languages.
-		let syntax = nodeSyntax(root, result)
+		let blockSyntax = nodeSyntax(root, result)
 
 		root.walk((node) => {
 			switch (node.type) {
@@ -101,7 +101,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `sin
 		 * @param ruleNode - The rule node to check.
 		 */
 		function checkRule (ruleNode: Rule): void {
-			if (!isStandardSyntaxRule(ruleNode)) return
+			if (!syntax.isStandardRule(ruleNode)) return
 
 			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
 
@@ -291,7 +291,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `sin
 			if (!value.includes(`//`)) return []
 
 			// A double slash of a syntax that marks its comments in a copy of its own is code — part of an address, most often. Unless that copy has gone out of step with the value and left the scan to answer after all, and then the comments are the ones the text spells.
-			if (!(raws && raws.scss) && !syntaxKeepsInlineComments(syntax)) return []
+			if (!(raws && raws.scss) && !syntaxKeepsInlineComments(blockSyntax)) return []
 
 			return findInlineCommentSpans(value)
 		}

--- a/lib/rules/value-list-comma-newline-after/index.ts
+++ b/lib/rules/value-list-comma-newline-after/index.ts
@@ -33,11 +33,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -53,6 +54,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		valueListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
 			// Stylelint counts a fixer as applied whatever it does, so a rule that cannot repair a problem has to say so here rather than from inside the fixer.

--- a/lib/rules/value-list-comma-newline-before/index.ts
+++ b/lib/rules/value-list-comma-newline-before/index.ts
@@ -26,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		valueListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.beforeAllowingIndentation,
 			checkedRuleName: ruleName,
 		})

--- a/lib/rules/value-list-comma-space-after/index.ts
+++ b/lib/rules/value-list-comma-space-after/index.ts
@@ -33,10 +33,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -52,6 +53,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		valueListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			// Stylelint counts a fixer as applied whatever it does, so a rule that cannot repair a problem has to say so here rather than from inside the fixer.

--- a/lib/rules/value-list-comma-space-before/index.ts
+++ b/lib/rules/value-list-comma-space-before/index.ts
@@ -35,10 +35,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -54,6 +55,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		valueListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// Stylelint counts a fixer as applied whatever it does, so a rule that cannot repair a problem has to say so here rather than from inside the fixer. Two of them are such, and the comma has to clear both.

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -1,5 +1,14 @@
 import type { Root } from "postcss"
 
+import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
+import { isStandardSyntaxCombinator } from "../../utils/isStandardSyntaxCombinator/index.ts"
+import { isStandardSyntaxComment } from "../../utils/isStandardSyntaxComment/index.ts"
+import { isStandardSyntaxDeclaration } from "../../utils/isStandardSyntaxDeclaration/index.ts"
+import { isStandardSyntaxFunction } from "../../utils/isStandardSyntaxFunction/index.ts"
+import { isStandardSyntaxProperty } from "../../utils/isStandardSyntaxProperty/index.ts"
+import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
+import { isStandardSyntaxSelector } from "../../utils/isStandardSyntaxSelector/index.ts"
+import { isStandardSyntaxValue } from "../../utils/isStandardSyntaxValue/index.ts"
 import type { Syntax } from "../index.ts"
 
 /** The syntax of the core: plain CSS, which every rule of the plugin is written for. A styled template is the `styled` namespace's to read, so a root carrying that parser's mark is refused; every other root is still accepted, custom syntaxes without a namespace of their own included. */
@@ -7,4 +16,13 @@ export let css: Syntax = {
 	accepts: (root: Root) => root.raws.styledSyntaxRangeStart === undefined,
 	embedding: () => ({ indent: ``, multiline: false }),
 	valueEmbedsHostCode: () => false,
+	isStandardAtRule: isStandardSyntaxAtRule,
+	isStandardRule: isStandardSyntaxRule,
+	isStandardDeclaration: isStandardSyntaxDeclaration,
+	isStandardProperty: isStandardSyntaxProperty,
+	isStandardValue: isStandardSyntaxValue,
+	isStandardSelector: isStandardSyntaxSelector,
+	isStandardFunction: isStandardSyntaxFunction,
+	isStandardComment: isStandardSyntaxComment,
+	isStandardCombinator: isStandardSyntaxCombinator,
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -1,4 +1,6 @@
-import type { Declaration, Node, Root } from "postcss"
+import type { AtRule, Comment, Declaration, Node, Root, Rule as PostcssRule } from "postcss"
+import type { Node as SelectorNode } from "postcss-selector-parser"
+import type { FunctionNode } from "postcss-value-parser"
 import type { PostcssResult } from "stylelint"
 
 import { styled } from "./styled/index.ts"
@@ -34,6 +36,69 @@ export type Syntax = {
 	 * @returns True where the value holds such an expression.
 	 */
 	valueEmbedsHostCode (decl: Declaration): boolean,
+
+	/**
+	 * Asks whether an at-rule is standard CSS rather than a construct of a preprocessor.
+	 * @param atRule - The at-rule.
+	 * @returns True where it is standard.
+	 */
+	isStandardAtRule (atRule: AtRule): boolean,
+
+	/**
+	 * Asks whether a rule is standard CSS rather than a construct of a preprocessor.
+	 * @param rule - The rule.
+	 * @returns True where it is standard.
+	 */
+	isStandardRule (rule: PostcssRule): boolean,
+
+	/**
+	 * Asks whether a declaration is standard CSS rather than a construct of a preprocessor.
+	 * @param decl - The declaration.
+	 * @returns True where it is standard.
+	 */
+	isStandardDeclaration (decl: Declaration): boolean,
+
+	/**
+	 * Asks whether a property is standard CSS rather than a variable or an interpolation.
+	 * @param property - The property's text.
+	 * @returns True where it is standard.
+	 */
+	isStandardProperty (property: string): boolean,
+
+	/**
+	 * Asks whether a value is standard CSS rather than a variable, an interpolation or an operation.
+	 * @param value - The value's text.
+	 * @returns True where it is standard.
+	 */
+	isStandardValue (value: string): boolean,
+
+	/**
+	 * Asks whether a selector is standard CSS rather than a construct of a preprocessor.
+	 * @param selector - The selector's text.
+	 * @returns True where it is standard.
+	 */
+	isStandardSelector (selector: string): boolean,
+
+	/**
+	 * Asks whether a function of a value is standard CSS rather than a list of Sass or an interpolation.
+	 * @param fn - The function node, as the value parser hands it over.
+	 * @returns True where it is standard.
+	 */
+	isStandardFunction (fn: FunctionNode): boolean,
+
+	/**
+	 * Asks whether a comment is one CSS spells, rather than an inline comment of a preprocessor.
+	 * @param comment - The comment.
+	 * @returns True where it is standard.
+	 */
+	isStandardComment (comment: Comment): boolean,
+
+	/**
+	 * Asks whether a combinator of a parsed selector is standard CSS.
+	 * @param combinator - The combinator node, as the selector parser hands it over.
+	 * @returns True where it is standard.
+	 */
+	isStandardCombinator (combinator: SelectorNode): boolean,
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */

--- a/lib/syntaxes/styled/index.ts
+++ b/lib/syntaxes/styled/index.ts
@@ -2,10 +2,12 @@ import type { Container, Declaration, Document, Node, Root } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 import { EVERY_JS_LINE_TERMINATOR, LEADING_SPACES_AND_TABS } from "../../regexps.ts"
+import { css } from "../css/index.ts"
 import type { Syntax } from "../index.ts"
 
 /** The syntax of the `styled` namespace: a stylesheet embedded in JavaScript as a styled template, parsed with `postcss-styled-syntax`. The namespace is a superset of the core — plain CSS is read exactly as the core reads it — so a project holding both configures these rules alone for the files that carry templates. */
 export let styled: Syntax = {
+	...css,
 	namespace: `styled`,
 	// A styled root carries the parser's mark, and plain CSS is a file opened with no custom syntax at all: `opts.syntax` cannot answer that, since Stylelint hands PostCSS a syntax of its own for plain CSS too, so the configuration is what is asked
 	accepts: (root: Root, result: PostcssResult) => root.raws.styledSyntaxRangeStart !== undefined || result.stylelint?.config?.customSyntax === undefined,

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -1,7 +1,7 @@
 import type { AtRule, Root } from "postcss"
 import stylelint, { type PostcssResult } from "stylelint"
 
-import { isStandardSyntaxAtRule } from "../isStandardSyntaxAtRule/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -18,11 +18,12 @@ export function atRuleNameSpaceChecker (options: {
 		errTarget: string,
 	}) => void,
 	result: PostcssResult,
+	syntax: Syntax,
 	checkedRuleName: string,
 	fix?: ((atRule: AtRule) => void) | null,
 }): void {
 	options.root.walkAtRules((atRule) => {
-		if (!isStandardSyntaxAtRule(atRule)) return
+		if (!options.syntax.isStandardAtRule(atRule)) return
 
 		checkColon(
 			`@${atRule.name}${atRule.raws.afterName || ``}${atRule.params}`,

--- a/lib/utils/declarationColonSpaceChecker/index.ts
+++ b/lib/utils/declarationColonSpaceChecker/index.ts
@@ -2,9 +2,9 @@ import type { Declaration, Root } from "postcss"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { declarationColonSource } from "../declarationColonSource/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { isStandardSyntaxDeclaration } from "../isStandardSyntaxDeclaration/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -26,12 +26,13 @@ export function declarationColonSpaceChecker (opts: {
 	fix?: ((decl: Declaration, index: number) => void),
 	isFixable?: ((decl: Declaration, index: number) => boolean),
 	result: PostcssResult,
+	syntax: Syntax,
 	checkedRuleName: string,
 }): void {
 	let { fix } = opts
 
 	opts.root.walkDecls((decl) => {
-		if (!isStandardSyntaxDeclaration(decl)) return
+		if (!opts.syntax.isStandardDeclaration(decl)) return
 
 		// A declaration the parser did not build has no text between its property and its value for either rule to read: PostCSS prints a colon and a space in place of the raw it lacks, and `declarationValueIndex` counts a colon alone, so the two disagree by the very character these rules are about. No syntax this plugin reads through leaves that raw empty; a declaration another plugin's fix built and put in the tree does.
 		if (!decl.raws.between) return

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -2,13 +2,13 @@ import type { Root } from "postcss"
 import valueParser, { type DivNode as ValueParserDivNode, type FunctionNode as ValueParserFunctionNode } from "postcss-value-parser"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../findCommentSpans/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 import { hideFalseInlineComments } from "../hideFalseInlineComments/index.ts"
-import { isStandardSyntaxFunction } from "../isStandardSyntaxFunction/index.ts"
 import { opensAnAddress } from "../opensAnAddress/index.ts"
 import { optionsMatches } from "../optionsMatches/index.ts"
 import { inlineCommentReading } from "../readsInlineComments/index.ts"
@@ -34,6 +34,7 @@ export function functionCommaSpaceChecker (opts: {
 	locationChecker: LocationChecker,
 	fix?: ((node: ValueParserDivNode, index: number, functionNode: ValueParserFunctionNode) => Edit[]),
 	result: PostcssResult,
+	syntax: Syntax,
 	checkedRuleName: string,
 	fixPosition?: `before` | `after`,
 	ignoreFunctions?: string | RegExp | Array<string | RegExp> | undefined,
@@ -58,7 +59,7 @@ export function functionCommaSpaceChecker (opts: {
 			// The node narrowed to a call, under a name the closures below can read it by: a narrowing made in this callback is not carried into a function created inside it
 			let functionNode = valueNode
 
-			if (!isStandardSyntaxFunction(valueNode)) return
+			if (!opts.syntax.isStandardFunction(valueNode)) return
 
 			// The arguments of an address are no list of arguments at all — a data URI, a query string, whatever the address holds — so a comma standing there is none of this checker's. The name is read rather than matched against four characters, so that `u\rl(`, `\75 rl(` and `URL(` are the token `url(` is here as they are to the scan that finds the comments.
 			if (opensAnAddress(valueNode, at, siblings)) return

--- a/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
+++ b/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
@@ -3,8 +3,8 @@ import type { Attribute } from "postcss-selector-parser"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
-import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
@@ -19,6 +19,7 @@ let { utils: { report } } = stylelint
 export function selectorAttributeOperatorSpaceChecker (options: {
 	root: Root,
 	result: PostcssResult,
+	syntax: Syntax,
 	locationChecker: (opts: {
 		source: string,
 		index: number,
@@ -31,7 +32,7 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 	let { fix } = options
 
 	options.root.walkRules((rule) => {
-		if (!isStandardSyntaxRule(rule)) return
+		if (!options.syntax.isStandardRule(rule)) return
 
 		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector

--- a/lib/utils/selectorCombinatorSpaceChecker/index.ts
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.ts
@@ -3,9 +3,8 @@ import type { Combinator, Node as SelectorParserNode } from "postcss-selector-pa
 import stylelint, { type PostcssResult } from "stylelint"
 
 import { WHITESPACE } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
-import { isStandardSyntaxCombinator } from "../isStandardSyntaxCombinator/index.ts"
-import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
 import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
@@ -41,6 +40,7 @@ function prevNonComment (node: SelectorParserNode): SelectorParserNode | undefin
 export function selectorCombinatorSpaceChecker (opts: {
 	root: Root,
 	result: PostcssResult,
+	syntax: Syntax,
 	locationChecker: LocationChecker,
 	locationType: `before` | `after`,
 	checkedRuleName: string,
@@ -50,7 +50,7 @@ export function selectorCombinatorSpaceChecker (opts: {
 	let hasFixed
 
 	opts.root.walkRules((rule) => {
-		if (!isStandardSyntaxRule(rule)) return
+		if (!opts.syntax.isStandardRule(rule)) return
 
 		hasFixed = false
 
@@ -64,7 +64,7 @@ export function selectorCombinatorSpaceChecker (opts: {
 
 		selectorTree.walkCombinators((node) => {
 			// Ignore non-standard combinators
-			if (!isStandardSyntaxCombinator(node)) return
+			if (!opts.syntax.isStandardCombinator(node)) return
 
 			// Ignore spaced descendant combinator
 			if (WHITESPACE.test(node.value)) return

--- a/lib/utils/selectorListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/selectorListCommaWhitespaceChecker/index.ts
@@ -2,8 +2,8 @@ import type { Root, Rule } from "postcss"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { findSelectorInlineComments, type InlineComment } from "../findSelectorInlineComments/index.ts"
-import { isStandardSyntaxRule } from "../isStandardSyntaxRule/index.ts"
 import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
 import type { SyntaxRaw } from "../typeGuards/index.ts"
 
@@ -16,6 +16,9 @@ export interface SelectorListCommaWhitespaceCheckerOptions {
 
 	/** The Stylelint result. */
 	result: PostcssResult,
+
+	/** The syntax the rule is built over. */
+	syntax: Syntax,
 
 	/** The location checker function. */
 	locationChecker: (opts: {
@@ -42,7 +45,7 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 	let { fix } = opts
 
 	opts.root.walkRules((rule) => {
-		if (!isStandardSyntaxRule(rule)) return
+		if (!opts.syntax.isStandardRule(rule)) return
 
 		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -2,9 +2,8 @@ import type { Declaration, Root } from "postcss"
 import styleSearch, { type StyleSearchMatch } from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { declarationString } from "../declarationString/index.ts"
-import { isStandardSyntaxDeclaration } from "../isStandardSyntaxDeclaration/index.ts"
-import { isStandardSyntaxProperty } from "../isStandardSyntaxProperty/index.ts"
 import { searchCopy } from "../searchCopy/index.ts"
 
 let { utils: { report } } = stylelint
@@ -16,6 +15,9 @@ export interface ValueListCommaWhitespaceCheckerOptions {
 
 	/** The Stylelint result. */
 	result: PostcssResult,
+
+	/** The syntax the rule is built over. */
+	syntax: Syntax,
 
 	/** The location checker function. */
 	locationChecker: (opts: {
@@ -45,7 +47,7 @@ export function valueListCommaWhitespaceChecker (opts: ValueListCommaWhitespaceC
 	let { fix } = opts
 
 	opts.root.walkDecls((decl) => {
-		if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxProperty(decl.prop)) return
+		if (!opts.syntax.isStandardDeclaration(decl) || !opts.syntax.isStandardProperty(decl.prop)) return
 
 		let declString = declarationString(decl)
 		let { searchString } = searchCopy(declString, decl, opts.result)


### PR DESCRIPTION
Phase B of the namespace split: the seam. A rule stops asking about the stylesheet's language itself and asks the syntax it is built over; five layers route every such question through the `Syntax` contract, and this first one carries the `isStandardSyntax*` family. Nine guard methods land on the contract, the seven shared checkers take the syntax as an option, and the guard utils stay untouched underneath — the core's adapter maps each method onto them, so every answer is exactly what it was. The Less and SCSS phases will strip the core adapter rather than the rules.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
