### PR TITLE
Ask the syntax for the text of a node

### DIFF
--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -9,11 +9,9 @@ import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isBoolean } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -36,11 +34,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `ratio`, `number-where-possible` and `as-written`.
  * @param secondaryOptions - The secondary options: `smallestIntegers`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `ratio` | `number-where-possible` | `as-written`, secondaryOptions: { smallestIntegers?: boolean } = {}): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `ratio` | `number-where-possible` | `as-written`, secondaryOptions: { smallestIntegers?: boolean } = {}): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -66,7 +65,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `rat
 		if (primary === `as-written` && !smallestIntegers) return
 
 		root.walkDecls(ASPECT_RATIO_PROPERTY, (decl) => {
-			check(decl, getDeclarationValue(decl), declarationValueIndex(decl), (fixed) => setDeclarationValue(decl, fixed))
+			check(decl, syntax.read(decl), declarationValueIndex(decl), (fixed) => syntax.write(decl, fixed))
 		})
 
 		/**

--- a/lib/rules/color-hex-case/index.ts
+++ b/lib/rules/color-hex-case/index.ts
@@ -7,12 +7,10 @@ import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/inde
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -32,10 +30,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -47,7 +46,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		root.walkDecls((decl) => {
 			if (!CONTAINS_HEX_COLOR.test(decl.value)) return
 
-			let declValue = getDeclarationValue(decl)
+			let declValue = syntax.read(decl)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
 			let inlineComments = findInlineCommentSpans(declValue, readsInlineComments(decl, result))
 			let parsedValue = valueParser(declValue)
@@ -86,7 +85,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 				})
 			})
 
-			if (edits.length > 0) setDeclarationValue(decl, applyEditsFromEnd(declValue, edits))
+			if (edits.length > 0) syntax.write(decl, applyEditsFromEnd(declValue, edits))
 		})
 	}
 }

--- a/lib/rules/declaration-bang-space-after/index.ts
+++ b/lib/rules/declaration-bang-space-after/index.ts
@@ -27,10 +27,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -44,6 +45,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		declarationBangSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (target) => {

--- a/lib/rules/declaration-bang-space-before/index.ts
+++ b/lib/rules/declaration-bang-space-before/index.ts
@@ -30,10 +30,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -47,10 +48,11 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		declarationBangSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The bang goes right after this text, and the whitespace run the fix cuts into ends it. Where an inline comment stands there, the line break that run begins with is what closes the comment, so either option would take the bang, and the semicolon behind it, into the comment's text: neither can be satisfied, so leave the code alone and let the warning stand
-			isFixable: (decl, index) => !endsWithInlineComment(declarationString(decl).slice(0, index), inlineCommentReading(decl, result)),
+			isFixable: (decl, index) => !endsWithInlineComment(declarationString(syntax, decl).slice(0, index), inlineCommentReading(decl, result)),
 			fix: (target) => {
 				// The whitespace run in front of the bang is what either option writes over, and it is a run of the declaration as the file prints it rather than of the one text the bang stands in: where the bang opens that print, the run is empty and the write is an insertion
 				let start = target.text.slice(0, target.index).replace(TRAILING_WHITESPACE, ``).length

--- a/lib/rules/declaration-block-semicolon-newline-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.ts
@@ -5,14 +5,12 @@ import { css } from "../../syntaxes/css/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { declarationString } from "../../utils/declarationString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isCustomProperty } from "../../utils/isCustomProperty/index.ts"
 import { isInlineStyleAttribute } from "../../utils/isInlineStyleAttribute/index.ts"
 import { isLastDeclarationWithoutSemicolon } from "../../utils/isLastDeclarationWithoutSemicolon/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
@@ -37,11 +35,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -61,13 +60,13 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			if (isLastDeclarationWithoutSemicolon(decl)) return
 
-			let value = getDeclarationValue(decl)
+			let value = syntax.read(decl)
 			let isCustomPropertyWithOnlyHorizontalSpaces = isCustomProperty(decl.prop) && SPACES_AND_TABS_ONLY.test(value)
 
 			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/50
 			if (primary.startsWith(`never`) && value === ` `) return
 
-			let declString = declarationString(decl)
+			let declString = declarationString(syntax, decl)
 			let problemIndex = declString.length - 1
 			// The semicolon goes right after the declaration's text, and where an inline comment ends that text, the line break the trailing whitespace opens with is what closes the comment: taking it away, as `never-multi-line` does, would take the semicolon into the comment's text. Nothing can be written there, so the declaration is left alone and the warning stands. The `always` options are in no such danger, since the break they write is what closes such a comment anyway
 			let isFixable = primary.startsWith(`always`) || !writesIntoInlineComment(decl, result)
@@ -89,7 +88,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 								if (primary.startsWith(`always`)) {
 									// The semicolon stands behind `!important`, so wherever the declaration carries the flag, the raw holding it is the text the break goes into, and PostCSS keeps that raw only where the flag is spelled some other way than ` !important`. The raw is kept rather than written anew, so that a comment, and any other layout standing in front of the flag, survives the fix
 									if (decl.important) decl.raws.important = (decl.raws.important || ` !important`).replace(TRAILING_WHITESPACE, getLineBreak(root, result))
-									else setDeclarationValue(decl, value.replace(TRAILING_WHITESPACE, getLineBreak(root, result)))
+									else syntax.write(decl, value.replace(TRAILING_WHITESPACE, getLineBreak(root, result)))
 
 									return
 								}
@@ -103,7 +102,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 											? ` `
 											: value.replace(TRAILING_WHITESPACE, ``)
 
-										setDeclarationValue(decl, newValue)
+										syntax.write(decl, newValue)
 									}
 								}
 							},

--- a/lib/rules/declaration-block-semicolon-space-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-space-before/index.ts
@@ -5,13 +5,11 @@ import { css } from "../../syntaxes/css/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { declarationString } from "../../utils/declarationString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isCustomProperty } from "../../utils/isCustomProperty/index.ts"
 import { isInlineStyleAttribute } from "../../utils/isInlineStyleAttribute/index.ts"
 import { isLastDeclarationWithoutSemicolon } from "../../utils/isLastDeclarationWithoutSemicolon/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
@@ -37,10 +35,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -60,7 +59,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			if (isLastDeclarationWithoutSemicolon(decl)) return
 
-			let value = getDeclarationValue(decl)
+			let value = syntax.read(decl)
 			let isCustomPropertyWithOnlySpaces = false
 
 			if (isCustomProperty(decl.prop)) {
@@ -71,7 +70,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 				if (primary.startsWith(`never`) && value === ` `) return
 			}
 
-			let declString = declarationString(decl)
+			let declString = declarationString(syntax, decl)
 			let problemIndex = declString.length - 1
 			// The semicolon goes right after the declaration's text, and the whitespace run the fix cuts into ends it. Where an inline comment stands there, the line break that run begins with is what closes the comment, so either option would take the semicolon into the comment's text: neither can be satisfied, so leave the declaration alone and let the warning stand
 			let isFixable = !writesIntoInlineComment(decl, result)
@@ -93,7 +92,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 								if (primary.startsWith(`always`)) {
 									// The raw is kept rather than written anew, so that a comment, and any other layout standing in front of the flag, survives the fix
 									if (decl.important) decl.raws.important = (decl.raws.important || ` !important`).replace(TRAILING_WHITESPACE, ` `)
-									else setDeclarationValue(decl, value.replace(TRAILING_WHITESPACE, ` `))
+									else syntax.write(decl, value.replace(TRAILING_WHITESPACE, ` `))
 
 									return
 								}
@@ -105,7 +104,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 											? ` `
 											: value.replace(TRAILING_WHITESPACE, ``)
 
-										setDeclarationValue(decl, newValue)
+										syntax.write(decl, newValue)
 									}
 								}
 							},

--- a/lib/rules/declaration-colon-newline-after/index.ts
+++ b/lib/rules/declaration-colon-newline-after/index.ts
@@ -5,12 +5,10 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationColonSource } from "../../utils/declarationColonSource/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { moveDeclarationValueHeadIntoBetween } from "../../utils/moveDeclarationValueHeadIntoBetween/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { assertString } from "../../utils/validateTypes/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -56,7 +54,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (!decl.raws.between) return
 
 			// The declaration down to the end of its value, as the file prints it: whatever the shape of that value, the run standing behind the colon is in this text wherever the declaration keeps it.
-			let source = declarationColonSource(decl)
+			let source = declarationColonSource(syntax, decl)
 
 			// The declaration's own colon is the one PostCSS filed in `raws.between`, that raw holding everything the file spells between the property and the value, so the walk is over that raw's span and no further.
 			// A colon standing anywhere else opens no declaration: the value may spell one, a data URI's, and the property may spell one of its own, an escaped `\:`, and reading either as the declaration's sends the check and the fix to a character they are not about.
@@ -107,11 +105,11 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								}
 
 								// Only what stands in front of the break is taken over, so that the run behind it is left in the value for whichever rule is asked about the run in front of the semicolon
-								moveDeclarationValueHeadIntoBetween(decl, headLength)
+								moveDeclarationValueHeadIntoBetween(syntax, decl, headLength)
 
-								let valueAfter = getDeclarationValue(decl)
+								let valueAfter = syntax.read(decl)
 
-								if (OPENS_WITH_LINE_BREAK.test(valueAfter)) setDeclarationValue(decl, valueAfter.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``))
+								if (OPENS_WITH_LINE_BREAK.test(valueAfter)) syntax.write(decl, valueAfter.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``))
 								else decl.raws.between += getLineBreak(root, result)
 							},
 						})

--- a/lib/rules/declaration-colon-space-after/index.ts
+++ b/lib/rules/declaration-colon-space-after/index.ts
@@ -5,7 +5,6 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationColonSpaceChecker } from "../../utils/declarationColonSpaceChecker/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { moveDeclarationValueHeadIntoBetween } from "../../utils/moveDeclarationValueHeadIntoBetween/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -65,7 +64,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				// Where `between` ends at the colon, whatever run stands behind it stands at the head of the value instead, and there is no writing over it in place
 				// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/109
 				// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/371
-				if (colonIndex === between.length - 1) moveDeclarationValueHeadIntoBetween(decl, (getDeclarationValue(decl).match(LEADING_WHITESPACE) as RegExpMatchArray)[0].length)
+				if (colonIndex === between.length - 1) moveDeclarationValueHeadIntoBetween(syntax, decl, (syntax.read(decl).match(LEADING_WHITESPACE) as RegExpMatchArray)[0].length)
 
 				let { raws } = decl
 

--- a/lib/rules/function-max-empty-lines/index.ts
+++ b/lib/rules/function-max-empty-lines/index.ts
@@ -5,11 +5,9 @@ import stylelint from "stylelint"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { assertString, isNumber } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -41,10 +39,11 @@ function placeIndexOnValueStart (decl: Declaration): number {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, a number.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
 	let maxAdjacentNewlines = primary + 1
 
 	return (root, result) => {
@@ -63,7 +62,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 		root.walkDecls((decl) => {
 			if (!decl.value.includes(`(`)) return
 
-			let stringValue = getDeclarationValue(decl)
+			let stringValue = syntax.read(decl)
 
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
 			let inlineComments = findInlineCommentSpans(stringValue, readsInlineComments(decl, result))
@@ -115,7 +114,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 			if (splittedValue.length > 0) {
 				let updatedValue = splittedValue.reduce((acc, curr) => acc + curr[0] + curr[1], ``) + stringValue.slice(sourceIndexStart)
 
-				setDeclarationValue(decl, updatedValue)
+				syntax.write(decl, updatedValue)
 			}
 		})
 	}

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -8,14 +8,12 @@ import { addEdit, applyEditsFromEnd, type Edit, toIndexBeforeEdits } from "../..
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -280,7 +278,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let fix: FixCallback | undefined
 			// What a fix changed, and nothing else: the value is edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a value would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
-			let declValue = getDeclarationValue(decl)
+			let declValue = syntax.read(decl)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
 			let reading = inlineCommentReading(decl, result)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary nodes
@@ -347,7 +345,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				}
 			})
 
-			if (edits.length > 0) setDeclarationValue(decl, applyEditsFromEnd(declValue, edits))
+			if (edits.length > 0) syntax.write(decl, applyEditsFromEnd(declValue, edits))
 
 			/**
 			 * Hands `report` a fix that adds the spans a write changes to the list the value is edited by.

--- a/lib/rules/function-parentheses-space-inside/index.ts
+++ b/lib/rules/function-parentheses-space-inside/index.ts
@@ -7,13 +7,11 @@ import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/inde
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -156,7 +154,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let fix: FixCallback | undefined
 			// What a fix changed, and nothing else: the value is edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a value would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []
-			let declValue = getDeclarationValue(decl)
+			let declValue = syntax.read(decl)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
 			let reading = inlineCommentReading(decl, result)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
@@ -251,7 +249,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				}
 			})
 
-			if (edits.length > 0) setDeclarationValue(decl, applyEditsFromEnd(declValue, edits))
+			if (edits.length > 0) syntax.write(decl, applyEditsFromEnd(declValue, edits))
 
 			/**
 			 * Hands `report` the fix for a write, or nothing at all where the guard standing in front of that write has turned it down.

--- a/lib/rules/function-whitespace-after/index.ts
+++ b/lib/rules/function-whitespace-after/index.ts
@@ -7,15 +7,11 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findFunctionArgumentSpans } from "../../utils/findFunctionArgumentSpans/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isWhitespace } from "../../utils/isWhitespace/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { searchCopy } from "../../utils/searchCopy/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -38,10 +34,11 @@ const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([`)`, `,`, `}`, `:`, `/`, undefin
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -184,22 +181,22 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		}
 
 		root.walkAtRules(IMPORT_AT_RULE, (atRule) => {
-			let param = getAtRuleParams(atRule)
+			let param = syntax.read(atRule)
 			let { searchString } = searchCopy(param, atRule, result)
 			let fixer = createFixer(param)
 
 			check(atRule, param, searchString, atRuleParamIndex(atRule), fixer.applyFix)
 
-			if (fixer.hasFixed) setAtRuleParams(atRule, fixer.fixed)
+			if (fixer.hasFixed) syntax.write(atRule, fixer.fixed)
 		})
 		root.walkDecls((decl) => {
-			let value = getDeclarationValue(decl)
+			let value = syntax.read(decl)
 			let { searchString } = searchCopy(value, decl, result)
 			let fixer = createFixer(value)
 
 			check(decl, value, searchString, declarationValueIndex(decl), fixer.applyFix)
 
-			if (fixer.hasFixed) setDeclarationValue(decl, fixer.fixed)
+			if (fixer.hasFixed) syntax.write(decl, fixer.fixed)
 		})
 	}
 }

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -6,18 +6,12 @@ import { CRLF, EVERY_LINE_BREAK, EVERY_LINE_BREAK_AND_INDENT, EVERY_LINE_INDENT,
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationString } from "../../utils/declarationString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { searchCopy } from "../../utils/searchCopy/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
-import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
 import { isAtRule, isDeclaration, isRoot, isRule } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean, isNumber, isString } from "../../utils/validateTypes/index.ts"
 
@@ -208,7 +202,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			if (optionsMatches(secondaryOptions, `ignore`, `value`)) return
 
-			let declString = declarationString(decl)
+			let declString = declarationString(syntax, decl)
 			let valueLevel = optionsMatches(secondaryOptions, `except`, `value`) ? declLevel : declLevel + 1
 
 			checkMultilineBit(declString, valueLevel, decl, declLevel)
@@ -226,7 +220,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (`params` in ruleNode && ruleNode.params) level += 1
 
 			// The lines are measured in the copy the file spells, since that is the text the positions of a warning are counted in and the text a fix is written to
-			checkMultilineBit(getRuleSelector(ruleNode), level, ruleNode, ruleLevel)
+			checkMultilineBit(syntax.read(ruleNode), level, ruleNode, ruleLevel)
 		}
 
 		/**
@@ -240,7 +234,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			// @nest and SCSS's @at-root rules should be treated like regular rules, not expected to have their params (selectors) indented
 			let paramLevel = optionsMatches(secondaryOptions, `except`, `param`) || atRule.name === `nest` || atRule.name === `at-root` ? ruleLevel : ruleLevel + 1
 
-			checkMultilineBit(`@${atRule.name}${atRule.raws.afterName || ``}${getAtRuleParams(atRule)}${atRule.raws.between || ``}`.trim(), paramLevel, atRule, ruleLevel)
+			checkMultilineBit(`@${atRule.name}${atRule.raws.afterName || ``}${syntax.read(atRule)}${atRule.raws.between || ``}`.trim(), paramLevel, atRule, ruleLevel)
 		}
 
 		/**
@@ -367,7 +361,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			if (fixPositions.length > 0) {
 				if (isRule(node)) {
-					let fixedSelector = getRuleSelector(node)
+					let fixedSelector = syntax.read(node)
 
 					for (let fixPosition of fixPositions) {
 						fixedSelector = replaceIndentation(
@@ -378,13 +372,13 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						)
 					}
 
-					setRuleSelector(node, fixedSelector)
+					syntax.write(node, fixedSelector)
 				}
 
 				if (isDeclaration(node)) {
 					let declProp = node.prop
 					let declBetween = node.raws.between
-					let declValue = getDeclarationValue(node)
+					let declValue = syntax.read(node)
 
 					if (!isString(declBetween)) throw new TypeError(`The \`between\` property must be a string`)
 
@@ -405,7 +399,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								fixPosition.startIndex - declProp.length - declBetween.length,
 							)
 
-							setDeclarationValue(node, declValue)
+							syntax.write(node, declValue)
 						}
 					}
 				}
@@ -413,7 +407,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				if (isAtRule(node)) {
 					let atRuleName = node.name
 					let atRuleAfterName = node.raws.afterName
-					let atRuleParams = getAtRuleParams(node)
+					let atRuleParams = syntax.read(node)
 
 					if (!isString(atRuleAfterName)) throw new TypeError(`The \`afterName\` property must be a string`)
 
@@ -440,7 +434,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								fixPosition.startIndex - paramsStartIndex,
 							)
 
-							setAtRuleParams(node, atRuleParams)
+							syntax.write(node, atRuleParams)
 						}
 					}
 				}

--- a/lib/rules/linebreaks/index.ts
+++ b/lib/rules/linebreaks/index.ts
@@ -4,14 +4,8 @@ import stylelint from "stylelint"
 import { CRLF, EVERY_LINE_BREAK, EVERY_LINE_WITH_BREAK, LINE_BREAK } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
-import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
 import { isAtRule, isComment, isDeclaration, isRule } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -32,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `unix` and `windows`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `unix` | `windows`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `unix` | `windows`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -57,16 +52,16 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `uni
 		 */
 		function fix (): void {
 			root.walk((node) => {
-				if (isRule(node)) setRuleSelector(node, fixData(getRuleSelector(node)))
+				if (isRule(node)) syntax.write(node, fixData(syntax.read(node)))
 
 				if (isAtRule(node)) {
-					setAtRuleParams(node, fixData(getAtRuleParams(node)))
+					syntax.write(node, fixData(syntax.read(node)))
 
 					if (node.raws.afterName) node.raws.afterName = fixData(node.raws.afterName)
 				}
 
 				if (isDeclaration(node)) {
-					setDeclarationValue(node, fixData(getDeclarationValue(node)))
+					syntax.write(node, fixData(syntax.read(node)))
 
 					if (node.raws.important) node.raws.important = fixData(node.raws.important)
 				}

--- a/lib/rules/media-feature-colon-space-after/index.ts
+++ b/lib/rules/media-feature-colon-space-after/index.ts
@@ -5,11 +5,9 @@ import { LEADING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaFeatureColonSpaceChecker } from "../../utils/mediaFeatureColonSpaceChecker/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -31,10 +29,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -50,6 +49,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaFeatureColonSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (atRule, index) => {
@@ -68,7 +68,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 		if (fixData) {
 			for (let [atRule, colonIndices] of fixData.entries()) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of colonIndices.toSorted((a, b) => b - a)) {
 					let beforeColon = params.slice(0, index + 1)
@@ -78,7 +78,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary === `never`) params = beforeColon + afterColon.replace(LEADING_WHITESPACE, ``)
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		}
 	}

--- a/lib/rules/media-feature-colon-space-before/index.ts
+++ b/lib/rules/media-feature-colon-space-before/index.ts
@@ -5,11 +5,9 @@ import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaFeatureColonSpaceChecker } from "../../utils/mediaFeatureColonSpaceChecker/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -31,10 +29,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -50,6 +49,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaFeatureColonSpaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			fix: (atRule, index) => {
@@ -68,7 +68,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 		if (fixData) {
 			for (let [atRule, colonIndices] of fixData.entries()) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of colonIndices.toSorted((a, b) => b - a)) {
 					let beforeColon = params.slice(0, index)
@@ -78,7 +78,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary === `never`) params = beforeColon.replace(TRAILING_WHITESPACE, ``) + afterColon
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		}
 	}

--- a/lib/rules/media-feature-name-case/index.ts
+++ b/lib/rules/media-feature-name-case/index.ts
@@ -6,11 +6,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findMediaFeatureNames } from "../../utils/findMediaFeatureNames/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isCustomMediaQuery } from "../../utils/isCustomMediaQuery/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -30,10 +28,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -43,7 +42,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		if (!validOptions) return
 
 		root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
-			let mediaRule = getAtRuleParams(atRule)
+			let mediaRule = syntax.read(atRule)
 
 			let hasFixes = false
 
@@ -73,7 +72,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 				})
 			}).stringify()
 
-			if (hasFixes) setAtRuleParams(atRule, mediaRule)
+			if (hasFixes) syntax.write(atRule, mediaRule)
 		})
 	}
 }

--- a/lib/rules/media-feature-parentheses-space-inside/index.ts
+++ b/lib/rules/media-feature-parentheses-space-inside/index.ts
@@ -8,11 +8,9 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -66,10 +64,11 @@ function closingEdit (node: FunctionNode, text: string, params: string): Edit {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -79,7 +78,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		if (!validOptions) return
 
 		root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
-			let params = getAtRuleParams(atRule)
+			let params = syntax.read(atRule)
 			let indexBoost = atRuleParamIndex(atRule)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence every feature standing behind it on the line
 			let reading = inlineCommentReading(atRule, result)
@@ -157,7 +156,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					})
 				}
 
-				if (edits.length > 0) setAtRuleParams(atRule, applyEditsFromEnd(params, edits))
+				if (edits.length > 0) syntax.write(atRule, applyEditsFromEnd(params, edits))
 			}
 		})
 	}

--- a/lib/rules/media-feature-range-operator-space-after/index.ts
+++ b/lib/rules/media-feature-range-operator-space-after/index.ts
@@ -5,10 +5,8 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findMediaOperator } from "../../utils/findMediaOperator/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -30,10 +28,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -47,7 +46,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
 			let fixOperatorIndices: number[] = []
 
-			findMediaOperator(atRule, result, (match, params, node) => {
+			findMediaOperator(syntax, atRule, result, (match, params, node) => {
 				let endIndex = match.startIndex + match.target.length - 1
 				let problemIndex = endIndex + atRuleParamIndex(node) + 1
 
@@ -71,7 +70,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 			})
 
 			if (fixOperatorIndices.length > 0) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of fixOperatorIndices.toSorted((a, b) => b - a)) {
 					let beforeOperator = params.slice(0, index + 1)
@@ -81,7 +80,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary === `never`) params = beforeOperator + afterOperator.replace(LEADING_WHITESPACE, ``)
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		})
 	}

--- a/lib/rules/media-feature-range-operator-space-before/index.ts
+++ b/lib/rules/media-feature-range-operator-space-before/index.ts
@@ -5,10 +5,8 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findMediaOperator } from "../../utils/findMediaOperator/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -30,10 +28,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -47,7 +46,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
 			let fixOperatorIndices: number[] = []
 
-			findMediaOperator(atRule, result, (match, params, node) => {
+			findMediaOperator(syntax, atRule, result, (match, params, node) => {
 				let problemIndex = match.startIndex - 1 + atRuleParamIndex(node)
 
 				// The extra `+ 1` is because the match itself contains the character before the operator
@@ -71,7 +70,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 			})
 
 			if (fixOperatorIndices.length > 0) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of fixOperatorIndices.toSorted((a, b) => b - a)) {
 					let beforeOperator = params.slice(0, index)
@@ -81,7 +80,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary === `never`) params = beforeOperator.replace(TRAILING_WHITESPACE, ``) + afterOperator
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		})
 	}

--- a/lib/rules/media-query-list-comma-newline-after/index.ts
+++ b/lib/rules/media-query-list-comma-newline-after/index.ts
@@ -5,12 +5,10 @@ import { LEADING_WHITESPACE, LEADING_WHITESPACE_WITHOUT_BREAK, OPENS_WITH_LINE_B
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaQueryListCommaWhitespaceChecker } from "../../utils/mediaQueryListCommaWhitespaceChecker/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -33,11 +31,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -54,6 +53,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaQueryListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
 			allowTrailingComments: primary.startsWith(`always`),
@@ -73,7 +73,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 		if (fixData) {
 			for (let [atRule, commaIndices] of fixData.entries()) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeComma = params.slice(0, index + 1)
@@ -84,7 +84,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary.startsWith(`never`)) params = beforeComma + afterComma.replace(LEADING_WHITESPACE, ``)
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		}
 	}

--- a/lib/rules/media-query-list-comma-newline-before/index.ts
+++ b/lib/rules/media-query-list-comma-newline-before/index.ts
@@ -26,10 +26,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -43,6 +44,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaQueryListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.beforeAllowingIndentation,
 			checkedRuleName: ruleName,
 		})

--- a/lib/rules/media-query-list-comma-space-after/index.ts
+++ b/lib/rules/media-query-list-comma-space-after/index.ts
@@ -5,11 +5,9 @@ import { LEADING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaQueryListCommaWhitespaceChecker } from "../../utils/mediaQueryListCommaWhitespaceChecker/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -33,10 +31,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -52,6 +51,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaQueryListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.after,
 			checkedRuleName: ruleName,
 			fix: (atRule, index) => {
@@ -70,7 +70,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 		if (fixData) {
 			for (let [atRule, commaIndices] of fixData.entries()) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeComma = params.slice(0, index + 1)
@@ -80,7 +80,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary.startsWith(`never`)) params = beforeComma + afterComma.replace(LEADING_WHITESPACE, ``)
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		}
 	}

--- a/lib/rules/media-query-list-comma-space-before/index.ts
+++ b/lib/rules/media-query-list-comma-space-before/index.ts
@@ -6,12 +6,10 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaQueryListCommaWhitespaceChecker } from "../../utils/mediaQueryListCommaWhitespaceChecker/index.ts"
 import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -35,10 +33,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line` and `never-single-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -54,6 +53,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		mediaQueryListCommaWhitespaceChecker({
 			root,
 			result,
+			syntax,
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The comma goes right after this text, and the whitespace run the fix writes ends it. Where an inline comment stands there, the line break that run holds is what closes the comment, so either option would take the comma, and the whole query behind it, into the comment's text: leave the parameters alone and let the warning stand
@@ -74,7 +74,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 		if (fixData) {
 			for (let [atRule, commaIndices] of fixData.entries()) {
-				let params = getAtRuleParams(atRule)
+				let params = syntax.read(atRule)
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeComma = params.slice(0, index)
@@ -84,7 +84,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					else if (primary.startsWith(`never`)) params = beforeComma.replace(TRAILING_WHITESPACE, ``) + afterComma
 				}
 
-				setAtRuleParams(atRule, params)
+				syntax.write(atRule, params)
 			}
 		}
 	}

--- a/lib/rules/named-grid-areas-alignment/index.ts
+++ b/lib/rules/named-grid-areas-alignment/index.ts
@@ -6,11 +6,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpans, findInlineCommentSpanTouching, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isBoolean, isNumber } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -43,11 +41,12 @@ function isGridRow (node: Node, inlineComments: InlineCommentSpan[]): node is St
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @param secondaryOptions - The secondary options: `gap` and `alignQuotes`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true, secondaryOptions: {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true, secondaryOptions: {
 	gap?: number,
 	alignQuotes?: boolean,
 } = {}): RuleCheck {
@@ -74,7 +73,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 		let referenceGap = ` `.repeat(gap)
 
 		root.walkDecls(`grid-template-areas`, (declaration) => {
-			let declarationValue = getDeclarationValue(declaration)
+			let declarationValue = syntax.read(declaration)
 			let parsedValue = valueParser(declarationValue)
 			let isMultilineDeclaration = declarationValue.includes(`\n`)
 			let inlineComments = findInlineCommentSpans(declarationValue, readsInlineComments(declaration, result))
@@ -163,7 +162,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 					}
 					let formattedValue = acc.join(``)
 
-					setDeclarationValue(declaration, formattedValue)
+					syntax.write(declaration, formattedValue)
 				},
 			})
 		})

--- a/lib/rules/no-eol-whitespace/index.ts
+++ b/lib/rules/no-eol-whitespace/index.ts
@@ -4,16 +4,10 @@ import stylelint from "stylelint"
 import { EVERY_LINE_BREAK, LINE_BREAK, TRAILING_SPACES_AND_TABS } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import { isOnlyWhitespace } from "../../utils/isOnlyWhitespace/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
-import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
 import { isAtRule, isComment, isDeclaration, isRule } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -212,15 +206,15 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						node.raws.afterName = fixed
 					})
 
-					fixText(getAtRuleParams(node), (fixed) => {
-						setAtRuleParams(node, fixed)
+					fixText(syntax.read(node), (fixed) => {
+						syntax.write(node, fixed)
 					})
 				}
 
 				// The whitespace this rule takes away may stand in the text of an inline comment the selector carries — `.a // c ` ends in a space the file holds and the raw hides two characters further along — so the selector is read and written through the pair, which works on the copy the file spells and refills the raw beside it.
 				if (isRule(node)) {
-					fixText(getRuleSelector(node), (fixed) => {
-						setRuleSelector(node, fixed)
+					fixText(syntax.read(node), (fixed) => {
+						syntax.write(node, fixed)
 					})
 				}
 
@@ -231,8 +225,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				}
 
 				if (isDeclaration(node)) {
-					fixText(getDeclarationValue(node), (fixed) => {
-						setDeclarationValue(node, fixed)
+					fixText(syntax.read(node), (fixed) => {
+						syntax.write(node, fixed)
 					})
 				}
 

--- a/lib/rules/no-multiple-whitespaces/index.ts
+++ b/lib/rules/no-multiple-whitespaces/index.ts
@@ -3,11 +3,9 @@ import stylelint from "stylelint"
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isWhitespace } from "../../utils/isWhitespace/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -111,10 +109,11 @@ function fixWhitespaceErrors (value: string, errors: {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -123,7 +122,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 		if (!validOptions) return
 
 		root.walkDecls((decl) => {
-			let value = getDeclarationValue(decl)
+			let value = syntax.read(decl)
 			let valueIndex = declarationValueIndex(decl)
 			let inString = false
 			let stringChar = ``
@@ -184,7 +183,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 					result,
 					ruleName,
 					fix () {
-						setDeclarationValue(decl, fixWhitespaceErrors(value, errors))
+						syntax.write(decl, fixWhitespaceErrors(value, errors))
 					},
 				})
 			}

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -8,14 +8,10 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -37,10 +33,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -54,10 +51,10 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 		root.walkAtRules((atRule) => {
 			if (atRule.name.toLowerCase() === `import`) return
 
-			check(atRule, getAtRuleParams(atRule))
+			check(atRule, syntax.read(atRule))
 		})
 
-		root.walkDecls((decl) => check(decl, getDeclarationValue(decl)))
+		root.walkDecls((decl) => check(decl, syntax.read(decl)))
 
 		/**
 		 * Checks a node for leading zero violations.
@@ -139,8 +136,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 				for (let fixPosition of alwaysFixPositions) {
 					let index = fixPosition.index
 
-					if (isAtRule(node)) setAtRuleParams(node, addLeadingZero(getAtRuleParams(node), index))
-					else setDeclarationValue(node, addLeadingZero(getDeclarationValue(node), index))
+					if (isAtRule(node)) syntax.write(node, addLeadingZero(syntax.read(node), index))
+					else syntax.write(node, addLeadingZero(syntax.read(node), index))
 				}
 			}
 
@@ -149,8 +146,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					let startIndex = fixPosition.startIndex
 					let endIndex = fixPosition.endIndex
 
-					if (isAtRule(node)) setAtRuleParams(node, removeLeadingZeros(getAtRuleParams(node), startIndex, endIndex))
-					else setDeclarationValue(node, removeLeadingZeros(getDeclarationValue(node), startIndex, endIndex))
+					if (isAtRule(node)) syntax.write(node, removeLeadingZeros(syntax.read(node), startIndex, endIndex))
+					else syntax.write(node, removeLeadingZeros(syntax.read(node), startIndex, endIndex))
 				}
 			}
 		}

--- a/lib/rules/number-no-trailing-zeros/index.ts
+++ b/lib/rules/number-no-trailing-zeros/index.ts
@@ -8,14 +8,10 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -36,10 +32,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, { actual: primary })
 
@@ -48,10 +45,10 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 		root.walkAtRules((atRule) => {
 			if (atRule.name.toLowerCase() === `import`) return
 
-			check(atRule, getAtRuleParams(atRule))
+			check(atRule, syntax.read(atRule))
 		})
 
-		root.walkDecls((decl) => check(decl, getDeclarationValue(decl)))
+		root.walkDecls((decl) => check(decl, syntax.read(decl)))
 
 		/**
 		 * Checks a node for trailing zeros violations.
@@ -125,8 +122,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 					let startIndex = fixPosition.startIndex
 					let endIndex = fixPosition.endIndex
 
-					if (isAtRule(node)) setAtRuleParams(node, removeTrailingZeros(getAtRuleParams(node), startIndex, endIndex))
-					else setDeclarationValue(node, removeTrailingZeros(getDeclarationValue(node), startIndex, endIndex))
+					if (isAtRule(node)) syntax.write(node, removeTrailingZeros(syntax.read(node), startIndex, endIndex))
+					else syntax.write(node, removeTrailingZeros(syntax.read(node), startIndex, endIndex))
 				}
 			}
 		}

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -9,8 +9,6 @@ import { declarationValueIndex } from "../../utils/declarationValueIndex/index.t
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
@@ -18,8 +16,6 @@ import { syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
 import { isAtRule, type SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean } from "../../utils/validateTypes/index.ts"
@@ -84,10 +80,10 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		root.walk((node) => {
 			switch (node.type) {
 				case `atrule`:
-					checkDeclOrAtRule(node, getAtRuleParams(node), atRuleParamIndex)
+					checkDeclOrAtRule(node, syntax.read(node), atRuleParamIndex)
 					break
 				case `decl`:
-					checkDeclOrAtRule(node, getDeclarationValue(node), declarationValueIndex)
+					checkDeclOrAtRule(node, syntax.read(node), declarationValueIndex)
 					break
 				case `rule`:
 					checkRule(node)
@@ -277,8 +273,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			let fixed = replaceQuotes(value, fixPositions)
 
-			if (isAtRule(node)) setAtRuleParams(node, fixed)
-			else setDeclarationValue(node, fixed)
+			if (isAtRule(node)) syntax.write(node, fixed)
+			else syntax.write(node, fixed)
 		}
 
 		/**

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -12,15 +12,11 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
 import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { findInterpolationSpans, findInterpolationSpanTouching } from "../../utils/findInterpolationSpans/index.ts"
-import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getDimension } from "../../utils/getDimension/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
 import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -49,10 +45,11 @@ type Problem = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `lower` and `upper`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `lower` | `upper`): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -195,8 +192,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 				if (hasFixed) {
 					let fixedValue = applyEditsFromEnd(checkedValue, edits)
 
-					if (isAtRule(node)) setAtRuleParams(node, fixedValue)
-					else setDeclarationValue(node, fixedValue)
+					if (isAtRule(node)) syntax.write(node, fixedValue)
+					else syntax.write(node, fixedValue)
 				}
 			}
 		}
@@ -204,9 +201,9 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `low
 		root.walkAtRules((atRule) => {
 			if (!MEDIA_AT_RULE.test(atRule.name) && !(`variable` in atRule)) return
 
-			check(atRule, getAtRuleParams(atRule), atRuleParamIndex)
+			check(atRule, syntax.read(atRule), atRuleParamIndex)
 		})
-		root.walkDecls((decl) => check(decl, getDeclarationValue(decl), declarationValueIndex))
+		root.walkDecls((decl) => check(decl, syntax.read(decl), declarationValueIndex))
 	}
 }
 

--- a/lib/rules/value-list-comma-newline-after/index.ts
+++ b/lib/rules/value-list-comma-newline-after/index.ts
@@ -5,11 +5,9 @@ import { LEADING_WHITESPACE, SPACES_THEN_BLOCK_COMMENT, SPACES_THEN_INLINE_COMME
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { valueListCommaWhitespaceChecker } from "../../utils/valueListCommaWhitespaceChecker/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -82,7 +80,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		if (fixData) {
 			for (let [decl, commaIndices] of fixData.entries()) {
 				for (let index of commaIndices.toSorted((a, b) => a - b).toReversed()) {
-					let value = getDeclarationValue(decl)
+					let value = syntax.read(decl)
 					let valueIndex = index - declarationValueIndex(decl)
 					let beforeValue = value.slice(0, valueIndex + 1)
 					let afterValue = value.slice(valueIndex + 1)
@@ -90,7 +88,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					if (primary.startsWith(`always`)) afterValue = getLineBreak(root, result) + afterValue
 					else if (primary.startsWith(`never-multi-line`)) afterValue = afterValue.replace(LEADING_WHITESPACE, ``)
 
-					setDeclarationValue(decl, beforeValue + afterValue)
+					syntax.write(decl, beforeValue + afterValue)
 				}
 			}
 		}

--- a/lib/rules/value-list-comma-space-after/index.ts
+++ b/lib/rules/value-list-comma-space-after/index.ts
@@ -5,10 +5,8 @@ import { LEADING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { valueListCommaWhitespaceChecker } from "../../utils/valueListCommaWhitespaceChecker/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -72,7 +70,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		if (fixData) {
 			for (let [decl, commaIndices] of fixData.entries()) {
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
-					let value = getDeclarationValue(decl)
+					let value = syntax.read(decl)
 					let valueIndex = index - declarationValueIndex(decl)
 					let beforeValue = value.slice(0, valueIndex + 1)
 					let afterValue = value.slice(valueIndex + 1)
@@ -80,7 +78,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					if (primary.startsWith(`always`)) afterValue = afterValue.replace(LEADING_WHITESPACE, ` `)
 					else if (primary.startsWith(`never`)) afterValue = afterValue.replace(LEADING_WHITESPACE, ``)
 
-					setDeclarationValue(decl, beforeValue + afterValue)
+					syntax.write(decl, beforeValue + afterValue)
 				}
 			}
 		}

--- a/lib/rules/value-list-comma-space-before/index.ts
+++ b/lib/rules/value-list-comma-space-before/index.ts
@@ -6,11 +6,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { valueListCommaWhitespaceChecker } from "../../utils/valueListCommaWhitespaceChecker/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -87,14 +85,14 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						continue
 					}
 
-					let value = getDeclarationValue(decl)
+					let value = syntax.read(decl)
 					let beforeValue = value.slice(0, valueIndex)
 					let afterValue = value.slice(valueIndex)
 
 					if (primary.startsWith(`always`)) beforeValue = beforeValue.replace(TRAILING_WHITESPACE, ` `)
 					else if (primary.startsWith(`never`)) beforeValue = beforeValue.replace(TRAILING_WHITESPACE, ``)
 
-					setDeclarationValue(decl, beforeValue + afterValue)
+					syntax.write(decl, beforeValue + afterValue)
 				}
 			}
 		}

--- a/lib/rules/value-list-max-empty-lines/index.ts
+++ b/lib/rules/value-list-max-empty-lines/index.ts
@@ -2,10 +2,8 @@ import stylelint from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { isNumber } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -26,10 +24,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, a number.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
 	let maxAdjacentNewlines = primary + 1
 
 	return (root, result) => {
@@ -46,7 +45,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 		let allowedCRLFNewLinesString = `\r\n`.repeat(maxAdjacentNewlines)
 
 		root.walkDecls((decl) => {
-			let value = getDeclarationValue(decl)
+			let value = syntax.read(decl)
 
 			if (violatedLFNewLinesRegex.test(value) || violatedCRLFNewLinesRegex.test(value)) {
 				report({
@@ -62,7 +61,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 							.replaceAll(new RegExp(violatedLFNewLinesRegex, `gmu`), allowedLFNewLinesString)
 							.replaceAll(new RegExp(violatedCRLFNewLinesRegex, `gmu`), allowedCRLFNewLinesString)
 
-						setDeclarationValue(decl, newValueString)
+						syntax.write(decl, newValueString)
 					},
 				})
 			}

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -1,5 +1,8 @@
-import type { Root } from "postcss"
+import type { AtRule, Declaration, Root, Rule as PostcssRule } from "postcss"
 
+import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
+import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
+import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
 import { isStandardSyntaxAtRule } from "../../utils/isStandardSyntaxAtRule/index.ts"
 import { isStandardSyntaxCombinator } from "../../utils/isStandardSyntaxCombinator/index.ts"
 import { isStandardSyntaxComment } from "../../utils/isStandardSyntaxComment/index.ts"
@@ -9,6 +12,10 @@ import { isStandardSyntaxProperty } from "../../utils/isStandardSyntaxProperty/i
 import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { isStandardSyntaxSelector } from "../../utils/isStandardSyntaxSelector/index.ts"
 import { isStandardSyntaxValue } from "../../utils/isStandardSyntaxValue/index.ts"
+import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
+import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
+import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
+import { isDeclaration, isRule } from "../../utils/typeGuards/index.ts"
 import type { Syntax } from "../index.ts"
 
 /** The syntax of the core: plain CSS, which every rule of the plugin is written for. A styled template is the `styled` namespace's to read, so a root carrying that parser's mark is refused; every other root is still accepted, custom syntaxes without a namespace of their own included. */
@@ -25,4 +32,14 @@ export let css: Syntax = {
 	isStandardFunction: isStandardSyntaxFunction,
 	isStandardComment: isStandardSyntaxComment,
 	isStandardCombinator: isStandardSyntaxCombinator,
+	read (node: AtRule | Declaration | PostcssRule): string {
+		if (isDeclaration(node)) return getDeclarationValue(node)
+
+		return isRule(node) ? getRuleSelector(node) : getAtRuleParams(node)
+	},
+	write (node: AtRule | Declaration | PostcssRule, text: string): void {
+		if (isDeclaration(node)) setDeclarationValue(node, text)
+		else if (isRule(node)) setRuleSelector(node, text)
+		else setAtRuleParams(node, text)
+	},
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -99,6 +99,20 @@ export type Syntax = {
 	 * @returns True where it is standard.
 	 */
 	isStandardCombinator (combinator: SelectorNode): boolean,
+
+	/**
+	 * Reads the text of a node as the file spells it — a declaration's value, a rule's selector, an at-rule's params — whichever copies the syntax keeps of it.
+	 * @param node - The declaration, rule or at-rule.
+	 * @returns The text, in the file's own spelling.
+	 */
+	read (node: AtRule | Declaration | PostcssRule): string,
+
+	/**
+	 * Writes the text of a node into the copy of it the syntax prints, keeping whatever other copies it holds in step.
+	 * @param node - The declaration, rule or at-rule.
+	 * @param text - The text to write.
+	 */
+	write (node: AtRule | Declaration | PostcssRule, text: string): void,
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */

--- a/lib/utils/declarationBangSpaceChecker/index.ts
+++ b/lib/utils/declarationBangSpaceChecker/index.ts
@@ -2,12 +2,11 @@ import type { Declaration, Root } from "postcss"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationString } from "../declarationString/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 import { searchCopy } from "../searchCopy/index.ts"
-import { setDeclarationValue } from "../setDeclarationValue/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -64,6 +63,7 @@ export function declarationBangSpaceChecker (opts: {
 	root: Root,
 	locationChecker: LocationChecker,
 	result: PostcssResult,
+	syntax: Syntax,
 	checkedRuleName: string,
 	fix?: ((target: BangTarget) => Edit[]),
 	isFixable?: ((decl: Declaration, index: number) => boolean),
@@ -72,19 +72,19 @@ export function declarationBangSpaceChecker (opts: {
 
 	opts.root.walkDecls((decl) => {
 		let indexOffset = declarationValueIndex(decl)
-		let declString = declarationString(decl)
+		let declString = declarationString(opts.syntax, decl)
 		let { searchString } = searchCopy(declString, decl, opts.result)
 		let valueString = searchString.slice(indexOffset)
 
 		if (!valueString.includes(`!`)) return
 
 		let between = decl.raws.between || `:`
-		let value = getDeclarationValue(decl)
+		let value = opts.syntax.read(decl)
 
 		// A declaration is printed from four texts laid end to end — the property, what stands between it and the value, the value, and the raw of the flag — and where PostCSS puts the whitespace standing in front of a bang depends on what stands in front of that: it reaches the raw of the flag only where the value has a word of its own to leave behind, it stays at the tail of the value where the value is nothing but comments and whitespace, and it stays at the tail of `raws.between` where the flag is not `!important` and is no raw at all. The colon `raws.between` always carries is where any such run stops, so the property is never written into and the three texts behind it are all a fix needs. Where each of them opens follows from `declarationValueIndex`, which counts the property and that one raw and nothing else, since no syntax this plugin reads through spells a prefix in front of a value
 		let parts: DeclarationPart[] = [
 			{ start: indexOffset - between.length, text: between, write: (text) => { decl.raws.between = text }, edits: [] },
-			{ start: indexOffset, text: value, write: (text) => { setDeclarationValue(decl, text) }, edits: [] },
+			{ start: indexOffset, text: value, write: (text) => { opts.syntax.write(decl, text) }, edits: [] },
 		]
 
 		// A declaration carrying no flag has no third text: `raws.important` is printed behind the flag and nowhere else, so a write into it there would be dropped without a trace

--- a/lib/utils/declarationColonSource/index.test.ts
+++ b/lib/utils/declarationColonSource/index.test.ts
@@ -3,6 +3,8 @@ import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { css as syntax } from "../../syntaxes/css/index.ts"
+
 import { declarationColonSource } from "./index.ts"
 
 /**
@@ -14,7 +16,7 @@ import { declarationColonSource } from "./index.ts"
 function source (parser: { parse: Parser }, css: string): string {
 	let rule = parser.parse(css).first as Rule
 
-	return declarationColonSource(rule.first as Declaration)
+	return declarationColonSource(syntax, rule.first as Declaration)
 }
 
 describe(`declarationColonSource`, () => {

--- a/lib/utils/declarationColonSource/index.ts
+++ b/lib/utils/declarationColonSource/index.ts
@@ -1,7 +1,7 @@
 import type { Declaration } from "postcss"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 
 /**
  * Builds the text a rule reads to see what a declaration prints behind its colon.
@@ -11,9 +11,10 @@ import { getDeclarationValue } from "../getDeclarationValue/index.ts"
  * The characters tacked onto the end give the checker something that is not whitespace to read behind the colon. Either caller reads two at the most — one asks about a space and the other about one character only — and the third stands against the branch of the checker that reads a character further than that, which neither of them reaches. A declaration with no value at all — `a { color:; }` — ends at the colon, and both halves of the checker return without a word where the character they ask about is not there, so `always` would pass such a declaration over in silence.
  *
  * `declarationString` lays out the same property, raw and value; behind them it prints the flag — the raw of it where PostCSS kept one, and a spelling of its own where it did not — since what it is written for is to give the declaration back as the file spells it, for a position to be counted in. This text is written to be read past the colon instead, and where the file spells nothing behind the value there has to be something there to read.
+ * @param syntax - The syntax the rule is built over.
  * @param decl - The CSS declaration node.
  * @returns The declaration as the file prints it, up to the end of the value, with a sentinel behind it.
  */
-export function declarationColonSource (decl: Declaration): string {
-	return `${decl.toString().slice(0, declarationValueIndex(decl))}${getDeclarationValue(decl)}xxx`
+export function declarationColonSource (syntax: Syntax, decl: Declaration): string {
+	return `${decl.toString().slice(0, declarationValueIndex(decl))}${syntax.read(decl)}xxx`
 }

--- a/lib/utils/declarationColonSpaceChecker/index.ts
+++ b/lib/utils/declarationColonSpaceChecker/index.ts
@@ -38,7 +38,7 @@ export function declarationColonSpaceChecker (opts: {
 		if (!decl.raws.between) return
 
 		// The declaration down to the end of its value, as the file prints it: whatever the shape of that value, the run standing behind the colon is in this text wherever the declaration keeps it.
-		let source = declarationColonSource(decl)
+		let source = declarationColonSource(opts.syntax, decl)
 
 		// The declaration's own colon is the one PostCSS filed in `raws.between`, that raw holding everything the file spells between the property and the value, so the search is over that raw's span and no further.
 		// A colon standing anywhere else opens no declaration: the value may spell one, a data URI's, and the property may spell one of its own, an escaped `\:`, and reading either as the declaration's sends the check and the fix to a character they are not about.

--- a/lib/utils/declarationString/index.test.ts
+++ b/lib/utils/declarationString/index.test.ts
@@ -3,28 +3,29 @@ import { parse as parseScss } from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
 import { pick } from "../../../vitest.helpers.ts"
+import { css as syntax } from "../../syntaxes/css/index.ts"
 
 import { declarationString } from "./index.ts"
 
 describe(`declarationString`, () => {
 	it(`has no comment in the value`, () => {
-		expect(declarationString(decl(`a { color: pink }`))).toBe(`color: pink`)
+		expect(declarationString(syntax, decl(`a { color: pink }`))).toBe(`color: pink`)
 	})
 
 	it(`has a bang`, () => {
-		expect(declarationString(decl(`a { color: pink !important }`))).toBe(`color: pink !important`)
+		expect(declarationString(syntax, decl(`a { color: pink !important }`))).toBe(`color: pink !important`)
 	})
 
 	it(`has a bang spelled its own way`, () => {
-		expect(declarationString(decl(`a { color: pink  ! important }`))).toBe(`color: pink  ! important`)
+		expect(declarationString(syntax, decl(`a { color: pink  ! important }`))).toBe(`color: pink  ! important`)
 	})
 
 	it(`has a comment inside the value`, () => {
-		expect(declarationString(decl(`a { margin: 0 /* c */ 1px }`))).toBe(`margin: 0 /* c */ 1px`)
+		expect(declarationString(syntax, decl(`a { margin: 0 /* c */ 1px }`))).toBe(`margin: 0 /* c */ 1px`)
 	})
 
 	it(`has an inline comment inside the value, which the syntax spells in a copy of its own`, () => {
-		expect(declarationString(scssDecl(`a { margin: 0 // c\n  1px !important }`))).toBe(`margin: 0 // c\n  1px !important`)
+		expect(declarationString(syntax, scssDecl(`a { margin: 0 // c\n  1px !important }`))).toBe(`margin: 0 // c\n  1px !important`)
 	})
 })
 

--- a/lib/utils/declarationString/index.ts
+++ b/lib/utils/declarationString/index.ts
@@ -1,7 +1,7 @@
 import type { Declaration } from "postcss"
 
+import type { Syntax } from "../../syntaxes/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 
 /**
  * Prints a declaration as the file spells it.
@@ -9,12 +9,13 @@ import { getDeclarationValue } from "../getDeclarationValue/index.ts"
  * `decl.toString()` prints it through the stringifier of PostCSS itself, which knows nothing of the second copy `postcss-scss` keeps of a value carrying an inline comment and prints the raw one, with every `//` comment rewritten into a block comment. A position counted in that string therefore stands two characters further along per comment than the file spells it, and a fix reading the value through {@link getDeclarationValue} and cutting it at that position cuts it in the wrong place.
  *
  * This is not {@link nodeString} on a declaration, and the two answer different questions. A Sass nested property is a declaration carrying a block, and `postcss-scss` prints that block where PostCSS prints nothing at all, so `nodeString` hands back `font: 12px { family: serif; }` where this hands back `font: 12px`. What the callers here read is the text a bang, a comma or the semicolon of **that** declaration stands in, and every position they write is counted in it: a block behind the value holds none of the three, and taking one in would put a second copy of everything the block's own declarations carry in front of the checker, and every fix at the wrong end of the text. `indentation` reads none of the three and asks only how wide the declaration is, which is the same question one line further out.
+ * @param syntax - The syntax the rule is built over.
  * @param decl - The declaration to print.
  * @returns The declaration, from its property to the end of its bang, if it has one.
  */
-export function declarationString (decl: Declaration): string {
+export function declarationString (syntax: Syntax, decl: Declaration): string {
 	let important = decl.important ? (decl.raws.important || ` !important`) : ``
 
 	// Only the value is spelled in two copies: the property and everything between it and the value are printed as they stand, so the string PostCSS prints holds them exactly as the file does
-	return decl.toString().slice(0, declarationValueIndex(decl)) + getDeclarationValue(decl) + important
+	return decl.toString().slice(0, declarationValueIndex(decl)) + syntax.read(decl) + important
 }

--- a/lib/utils/findMediaOperator/index.ts
+++ b/lib/utils/findMediaOperator/index.ts
@@ -3,8 +3,8 @@ import styleSearch, { type StyleSearchMatch } from "style-search"
 import type { PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { getAtRuleParams } from "../getAtRuleParams/index.ts"
 import { searchCopy } from "../searchCopy/index.ts"
 
 // `styleSearch` tries the targets in the order they are given and reports the first that matches, so the two-character operators stand in front of the one-character ones and `>=` is read whole rather than as a `>` with an `=` behind it
@@ -12,14 +12,15 @@ const RANGE_OPERATORS = [`>=`, `<=`, `>`, `<`, `=`]
 
 /**
  * Finds media operator matches in an at-rule and invokes a callback for each.
+ * @param syntax - The syntax the rule is built over.
  * @param atRule - The at-rule to search.
  * @param result - The Stylelint result, which the syntax of the file is read from.
  * @param cb - The callback to invoke for each match.
  */
-export function findMediaOperator<T extends AtRule> (atRule: T, result: PostcssResult, cb: (match: StyleSearchMatch, params: string, atRule: T) => void): void {
+export function findMediaOperator<T extends AtRule> (syntax: Syntax, atRule: T, result: PostcssResult, cb: (match: StyleSearchMatch, params: string, atRule: T) => void): void {
 	if (atRule.name.toLowerCase() !== `media`) return
 
-	let params = getAtRuleParams(atRule)
+	let params = syntax.read(atRule)
 	let { searchString } = searchCopy(params, atRule, result)
 
 	// An operator standing inside the arguments of a function belongs to those arguments and to no media feature, so the one in `url(a>=b)` is passed over as a comma there is

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -7,12 +7,10 @@ import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../findCommentSpans/index.ts"
-import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 import { hideFalseInlineComments } from "../hideFalseInlineComments/index.ts"
 import { opensAnAddress } from "../opensAnAddress/index.ts"
 import { optionsMatches } from "../optionsMatches/index.ts"
 import { inlineCommentReading } from "../readsInlineComments/index.ts"
-import { setDeclarationValue } from "../setDeclarationValue/index.ts"
 import { isValueFunction } from "../typeGuards/index.ts"
 import { commentsRemovedBefore, withoutComments } from "../withoutComments/index.ts"
 
@@ -42,7 +40,7 @@ export function functionCommaSpaceChecker (opts: {
 	let { fix } = opts
 
 	opts.root.walkDecls((decl) => {
-		let declValue = getDeclarationValue(decl)
+		let declValue = opts.syntax.read(decl)
 		// A double slash opens a comment that runs to the end of its line, and `postcss-value-parser` knows nothing of the kind: it reads the text of such a comment as code of the value, and every comma standing in that text as a comma of the value
 		// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
 		let reading = inlineCommentReading(decl, opts.result)
@@ -184,6 +182,6 @@ export function functionCommaSpaceChecker (opts: {
 			}
 		})
 
-		if (edits.length > 0) setDeclarationValue(decl, applyEditsFromEnd(declValue, edits))
+		if (edits.length > 0) opts.syntax.write(decl, applyEditsFromEnd(declValue, edits))
 	})
 }

--- a/lib/utils/mediaFeatureColonSpaceChecker/index.ts
+++ b/lib/utils/mediaFeatureColonSpaceChecker/index.ts
@@ -4,9 +4,9 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import { MEDIA_AT_RULE } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { atRuleParamIndex } from "../atRuleParamIndex/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { getAtRuleParams } from "../getAtRuleParams/index.ts"
 import { searchCopy } from "../searchCopy/index.ts"
 
 let { utils: { report } } = stylelint
@@ -24,12 +24,13 @@ export function mediaFeatureColonSpaceChecker (opts: {
 	}) => void,
 	fix?: ((node: AtRule, index: number) => void),
 	result: PostcssResult,
+	syntax: Syntax,
 	checkedRuleName: string,
 }): void {
 	let { fix } = opts
 
 	opts.root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
-		let params = getAtRuleParams(atRule)
+		let params = opts.syntax.read(atRule)
 		let { searchString } = searchCopy(params, atRule, opts.result)
 
 		// A colon standing inside the arguments of a function belongs to those arguments and to no media feature: the one in `url(http://x)` is part of the protocol, and a space written beside it names no resource at all

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
@@ -4,9 +4,9 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import { LEADING_BLOCK_COMMENT, MEDIA_AT_RULE, OPENS_WITH_INLINE_COMMENT } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { atRuleParamIndex } from "../atRuleParamIndex/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { getAtRuleParams } from "../getAtRuleParams/index.ts"
 import { searchCopy } from "../searchCopy/index.ts"
 import { assertString } from "../validateTypes/index.ts"
 
@@ -19,6 +19,7 @@ let { utils: { report } } = stylelint
 export function mediaQueryListCommaWhitespaceChecker (opts: {
 	root: Root,
 	result: PostcssResult,
+	syntax: Syntax,
 	locationChecker: (args: {
 		source: string,
 		index: number,
@@ -32,7 +33,7 @@ export function mediaQueryListCommaWhitespaceChecker (opts: {
 	let { fix } = opts
 
 	opts.root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
-		let params = getAtRuleParams(atRule)
+		let params = opts.syntax.read(atRule)
 		let { searchString, commentSpans } = searchCopy(params, atRule, opts.result)
 
 		// A comma standing inside the arguments of a function is a comma of those arguments and of no list: the one in `url(x/a,b.png)` names the file as surely as the letters around it do, and whitespace written beside it would name another file. `valueListCommaWhitespaceChecker` has asked the search itself to pass such a comma over since it was written; the search cannot be asked here, since it reads the parenthesis a set of media parameters opens on as the opening of a call and would pass over the whole of the first query.

--- a/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
+++ b/lib/utils/moveDeclarationValueHeadIntoBetween/index.test.ts
@@ -3,6 +3,7 @@ import less from "postcss-less"
 import scss from "postcss-scss"
 import { describe, expect, it } from "vitest"
 
+import { css as syntax } from "../../syntaxes/css/index.ts"
 import { getDeclarationValue } from "../getDeclarationValue/index.ts"
 
 import { moveDeclarationValueHeadIntoBetween } from "./index.ts"
@@ -22,7 +23,7 @@ function move (parser: { parse: Parser }, css: string, length: number): {
 	let rule = parser.parse(css).first as Rule
 	let decl = rule.first as Declaration
 
-	moveDeclarationValueHeadIntoBetween(decl, length)
+	moveDeclarationValueHeadIntoBetween(syntax, decl, length)
 
 	return { printed: rule.root().toResult({ syntax: parser }).css, value: getDeclarationValue(decl), between: decl.raws.between }
 }

--- a/lib/utils/moveDeclarationValueHeadIntoBetween/index.ts
+++ b/lib/utils/moveDeclarationValueHeadIntoBetween/index.ts
@@ -1,7 +1,6 @@
 import type { Declaration } from "postcss"
 
-import { getDeclarationValue } from "../getDeclarationValue/index.ts"
-import { setDeclarationValue } from "../setDeclarationValue/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 
 /**
  * Moves the head of a declaration's value into `raws.between`, so that a fix writing behind the colon can reach it.
@@ -13,12 +12,12 @@ import { setDeclarationValue } from "../setDeclarationValue/index.ts"
  * What becomes of `decl.value` goes three ways. Where PostCSS keeps a raw beside the value and the move leaves something in it, the copy is left as the parser wrote it, which is what {@link setDeclarationValue} does wherever it is called: that copy is the one saying the raw may still be printed, and leaving it untouched is what keeps the two standing for each other. It goes stale by what the move took, and that costs nothing — {@link getDeclarationValue} hands out the raw, so a rule reading a value through the pair reads the text the file prints, and the few that read `decl.value` for themselves read what they would have read had no fix run at all.
  *
  * Where the move empties that raw, the copy cannot be left: an empty raw is read as no raw at all, and `decl.value` would then be handed out for text that is no longer in the file. The raw goes with the head it held and the value is emptied to match, which is what PostCSS itself writes for a declaration whose value is nothing. Where PostCSS keeps no raw beside the value at all — a custom property whose value is nothing but whitespace — the value is the printed text itself, and the move writes it.
+ * @param syntax - The syntax the rule is built over.
  * @param decl - The CSS declaration node, whose `raws.between` the parser filled: both rules pass over one whose it did not.
  * @param length - How many characters of the printed value to move, never more than that value holds. Both rules hand over nothing at all where no run stands at its head — a value opening on the word it holds, and a value that is empty.
- * @returns The declaration that was passed in.
  */
-export function moveDeclarationValueHeadIntoBetween (decl: Declaration, length: number): Declaration {
-	let value = getDeclarationValue(decl)
+export function moveDeclarationValueHeadIntoBetween (syntax: Syntax, decl: Declaration, length: number): void {
+	let value = syntax.read(decl)
 	let tail = value.slice(length)
 
 	decl.raws.between += value.slice(0, length)
@@ -28,8 +27,8 @@ export function moveDeclarationValueHeadIntoBetween (decl: Declaration, length: 
 		delete decl.raws.value
 		decl.value = ``
 
-		return decl
+		return
 	}
 
-	return setDeclarationValue(decl, tail)
+	syntax.write(decl, tail)
 }

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -49,7 +49,7 @@ export function valueListCommaWhitespaceChecker (opts: ValueListCommaWhitespaceC
 	opts.root.walkDecls((decl) => {
 		if (!opts.syntax.isStandardDeclaration(decl) || !opts.syntax.isStandardProperty(decl.prop)) return
 
-		let declString = declarationString(decl)
+		let declString = declarationString(opts.syntax, decl)
 		let { searchString } = searchCopy(declString, decl, opts.result)
 
 		styleSearch(


### PR DESCRIPTION
The second layer of the seam: what a rule reads and writes of a node — a declaration's value, a rule's selector, an at-rule's params — goes through `syntax.read(node)` and `syntax.write(node, text)`, and no rule imports the six `get`/`set` utils any more. The utils keep the copies a syntax holds in step exactly as before; the core's adapter dispatches the pair by the node's type, and the intermediary readers built over them — `declarationString`, `declarationColonSource`, `findMediaOperator`, `moveDeclarationValueHeadIntoBetween`, the checkers — take the syntax as a parameter or an option.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
