### PR TITLE
Ask the syntax about the comments of a text

### DIFF
--- a/lib/rules/aspect-ratio-notation/index.ts
+++ b/lib/rules/aspect-ratio-notation/index.ts
@@ -8,9 +8,7 @@ import { applyEditsFromEnd } from "../../utils/applyEditsFromEnd/index.ts"
 import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isBoolean } from "../../utils/validateTypes/index.ts"
 
@@ -78,7 +76,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		 * @param write - Writes the fixed text back to the node.
 		 */
 		function check (node: Node, text: string, textIndex: number, write: (fixed: string) => void): void {
-			let comments = findCommentSpans(text, readsInlineComments(node, result))
+			let comments = syntax.commentSpans(text, node, result)
 			// The value parser has a node for a block comment and none for a comment opened by a double slash, whose text comes back as ordinary words and divs. Blanking every comment out answers both at once: the copy spells the text character for character everywhere else, so every position below counts in the text itself, and what the parse holds is code the file spells and nothing else.
 			let ratio = findRatio(valueParser(blankComments(text, comments)).nodes)
 

--- a/lib/rules/block-closing-brace-newline-before/index.ts
+++ b/lib/rules/block-closing-brace-newline-before/index.ts
@@ -15,7 +15,6 @@ import { lastNodeHoldsTheBlockAfter } from "../../utils/lastNodeHoldsTheBlockAft
 import { nodeString } from "../../utils/nodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setBlockAfter } from "../../utils/setBlockAfter/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -37,11 +36,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -81,7 +81,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			if (!last) throw new Error(`The block must hold a node`)
 
-			let isFixable = primary.startsWith(`always`) || !writesIntoInlineComment(last, result, lastNodeHoldsTheBlockAfter(statement) ? undefined : blockAfter.replaceAll(EVERY_WHITESPACE, ``))
+			let isFixable = primary.startsWith(`always`) || !syntax.writesIntoInlineComment(last, result, lastNodeHoldsTheBlockAfter(statement) ? undefined : blockAfter.replaceAll(EVERY_WHITESPACE, ``))
 
 			// What is checked is whether a break *starts* the block's final space — the run between the last declaration and the closing brace. The rest of that whitespace is the indentation rule's business, which is why the question is asked with `LEADING_LINE_BREAK` rather than with `OPENS_WITH_LINE_BREAK`: whitespace in front of the break is the very thing this rule reports.
 			if (!LEADING_LINE_BREAK.test(after)) {

--- a/lib/rules/block-closing-brace-space-before/index.ts
+++ b/lib/rules/block-closing-brace-space-before/index.ts
@@ -14,7 +14,6 @@ import { nodeString } from "../../utils/nodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setBlockAfter } from "../../utils/setBlockAfter/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -39,10 +38,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line`, `never-single-line`, `always-multi-line` and `never-multi-line`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -87,7 +87,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			if (!last) throw new Error(`The block must hold a node`)
 
-			let isFixable = !writesIntoInlineComment(last, result, lastNodeHoldsTheBlockAfter(statement) ? undefined : blockAfter.replace(TRAILING_WHITESPACE, ``))
+			let isFixable = !syntax.writesIntoInlineComment(last, result, lastNodeHoldsTheBlockAfter(statement) ? undefined : blockAfter.replace(TRAILING_WHITESPACE, ``))
 
 			checker.before({
 				source,

--- a/lib/rules/block-opening-brace-newline-after/index.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.ts
@@ -3,6 +3,7 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { EVERY_LINE_BREAK, LINE_BREAK } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { beforeBlockString } from "../../utils/beforeBlockString/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
@@ -15,7 +16,6 @@ import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -38,14 +38,15 @@ export let meta = {
  * That fix takes every line break out of the whitespace standing in front of each node of the run the block opens with, from the first one up to the node being checked, so every node of that run is asked rather than the last alone: a block comment standing between an inline one and the declaration is carried into the inline comment along with everything behind it, and the declaration with it.
  *
  * Each node of the run is asked about the text standing behind it, since the break taken away is the one the whitespace in front of the node that follows opens with. The opening brace is asked about nothing: the only whitespace it stands behind is the one in front of the first node, and a brace inside an inline comment opens no block at all, so taking that break away can comment nothing out.
+ * @param syntax - The syntax the rule is built over.
  * @param statement - The statement whose block the run stands at the head of.
  * @param nodeToCheck - The first node of the block that is not a comment, which the run ends in front of.
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where any node of that run leaves an inline comment open behind it.
  */
-function fixWouldCommentOutTheBlock (statement: Rule | AtRule, nodeToCheck: Node, result: PostcssResult): boolean {
+function fixWouldCommentOutTheBlock (syntax: Syntax, statement: Rule | AtRule, nodeToCheck: Node, result: PostcssResult): boolean {
 	for (let node = statement.first; node && node !== nodeToCheck; node = node.next()) {
-		if (writesIntoInlineComment(node, result)) return true
+		if (syntax.writesIntoInlineComment(node, result)) return true
 	}
 
 	return false
@@ -56,11 +57,12 @@ function fixWouldCommentOutTheBlock (statement: Rule | AtRule, nodeToCheck: Node
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param secondaryOptions - The secondary options: `ignore`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignore?: `rules` | `rules`[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignore?: `rules` | `rules`[] }): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -123,7 +125,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 
 			let problemIndex = beforeBlockString(statement, result, { noRawBefore: true }).length + 1
 			// The line break the `never-multi-line` fix takes away is the one that closes an inline comment standing in front of it, so taking it away would put the rest of the block inside that comment's text, and the declarations it holds out of the stylesheet altogether. Nothing can be written there, so the block is left alone and the warning stands. The `always` options are in no such danger, since the break they keep or write is what closes such a comment anyway — and nothing arrives at that half of the question here: an inline comment is closed by a break, so the whitespace in front of the node behind it always opens with one, and these options never report such a block at all. It is written for the symmetry with `declaration-block-semicolon-newline-after`, where the same short-circuit is reached and pinned
-			let isFixable = primary.startsWith(`always`) || !fixWouldCommentOutTheBlock(statement, nodeToCheck, result)
+			let isFixable = primary.startsWith(`always`) || !fixWouldCommentOutTheBlock(syntax, statement, nodeToCheck, result)
 
 			checker.afterOneOnly({
 				source: rawNodeString(nodeToCheck, result),

--- a/lib/rules/block-opening-brace-newline-before/index.ts
+++ b/lib/rules/block-opening-brace-newline-before/index.ts
@@ -6,12 +6,10 @@ import { css } from "../../syntaxes/css/index.ts"
 import { beforeBlockString } from "../../utils/beforeBlockString/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { hasEmptyBlock } from "../../utils/hasEmptyBlock/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -37,11 +35,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-single-line`, `never-single-line`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -86,7 +85,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 				err: (m) => {
 					let between = typeof statement.raws.between === `string` ? statement.raws.between : ``
 					// The brace stands right after `between`, so an inline comment ending it would swallow the brace, and `never` demands that the brace joins the comment's line, which nothing can grant
-					let isFixable = !(primary.startsWith(`never`) && endsWithInlineComment(between, inlineCommentReading(statement, result)))
+					let isFixable = !(primary.startsWith(`never`) && syntax.endsWithInlineComment(between, syntax.inlineComments(statement, result)))
 
 					report({
 						message: m,

--- a/lib/rules/block-opening-brace-space-before/index.ts
+++ b/lib/rules/block-opening-brace-space-before/index.ts
@@ -6,12 +6,10 @@ import { css } from "../../syntaxes/css/index.ts"
 import { beforeBlockString } from "../../utils/beforeBlockString/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { hasEmptyBlock } from "../../utils/hasEmptyBlock/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isRegExp, isString } from "../../utils/validateTypes/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
@@ -39,11 +37,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `never`, `always-single-line`, `never-single-line`, `always-multi-line` and `never-multi-line`.
  * @param secondaryOptions - The secondary options: `ignoreAtRules` and `ignoreSelectors`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: {
 	ignoreAtRules?: string | RegExp | (string | RegExp)[],
 	ignoreSelectors?: string | RegExp | (string | RegExp)[],
 }): RuleCheck {
@@ -112,7 +111,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					// Only the whitespace run right before the brace may be replaced, so that comments survive
 					let beforeWhitespace = between.replace(TRAILING_WHITESPACE, ``)
 					// An inline comment ends only with a line break, so the brace can never join its line, and neither option is satisfiable there: leave the code alone and let the warning stand
-					let isFixable = !endsWithInlineComment(between, inlineCommentReading(statement, result))
+					let isFixable = !syntax.endsWithInlineComment(between, syntax.inlineComments(statement, result))
 
 					report({
 						message: m,

--- a/lib/rules/color-hex-case/index.ts
+++ b/lib/rules/color-hex-case/index.ts
@@ -6,10 +6,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -48,7 +47,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			let declValue = syntax.read(decl)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
-			let inlineComments = findInlineCommentSpans(declValue, readsInlineComments(decl, result))
+			let inlineComments = syntax.inlineCommentSpans(declValue, decl, result)
 			let parsedValue = valueParser(declValue)
 			// What a fix changed, and nothing else: the value is edited at the positions the fixes name rather than printed anew from the parsed tree, since `postcss-value-parser` does not always give back the text it was handed — a comment opening `/*/` comes back as `/**/` — and a fix made anywhere in such a value would rewrite a comment standing elsewhere in it
 			let edits: Edit[] = []

--- a/lib/rules/declaration-bang-space-before/index.ts
+++ b/lib/rules/declaration-bang-space-before/index.ts
@@ -5,9 +5,7 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationBangSpaceChecker } from "../../utils/declarationBangSpaceChecker/index.ts"
 import { declarationString } from "../../utils/declarationString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -52,7 +50,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The bang goes right after this text, and the whitespace run the fix cuts into ends it. Where an inline comment stands there, the line break that run begins with is what closes the comment, so either option would take the bang, and the semicolon behind it, into the comment's text: neither can be satisfied, so leave the code alone and let the warning stand
-			isFixable: (decl, index) => !endsWithInlineComment(declarationString(syntax, decl).slice(0, index), inlineCommentReading(decl, result)),
+			isFixable: (decl, index) => !syntax.endsWithInlineComment(declarationString(syntax, decl).slice(0, index), syntax.inlineComments(decl, result)),
 			fix: (target) => {
 				// The whitespace run in front of the bang is what either option writes over, and it is a run of the declaration as the file prints it rather than of the one text the bang stands in: where the bang opens that print, the run is empty and the write is an insertion
 				let start = target.text.slice(0, target.index).replace(TRAILING_WHITESPACE, ``).length

--- a/lib/rules/declaration-block-semicolon-newline-after/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.ts
@@ -15,7 +15,6 @@ import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -37,11 +36,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-multi-line` and `never-multi-line`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-multi-line` | `never-multi-line`, _secondaryOptions: unknown): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -75,7 +75,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 			// Under `never-multi-line` the fix takes away the whitespace standing in front of the node it checks, and where an inline comment stands in front of that whitespace, the line break the whitespace opens with is what closes the comment: taking it away would put the node inside the comment's text, and the declaration it holds out of the stylesheet altogether. Nothing can be written there, so the block is left alone and the warning stands. The `always` options are in no such danger, since the break they keep or write is what closes such a comment anyway
 			//
 			// The semicolon stands between the declaration and that whitespace, so it is handed in with the declaration: a value ending in the break that closes its own comment is asked about with the semicolon behind it, which is where the write lands. Where a comment node stands between the two instead, the semicolon is in front of that comment rather than behind it, and there is nothing to hand in
-			let isFixable = primary.startsWith(`always`) || !writesIntoInlineComment(previousNode, result, previousNode === decl ? `;` : ``)
+			let isFixable = primary.startsWith(`always`) || !syntax.writesIntoInlineComment(previousNode, result, previousNode === decl ? `;` : ``)
 
 			checker.afterOneOnly({
 				source: rawNodeString(nodeToCheck, result),

--- a/lib/rules/declaration-block-semicolon-newline-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.ts
@@ -13,7 +13,6 @@ import { isLastDeclarationWithoutSemicolon } from "../../utils/isLastDeclaration
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -69,7 +68,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let declString = declarationString(syntax, decl)
 			let problemIndex = declString.length - 1
 			// The semicolon goes right after the declaration's text, and where an inline comment ends that text, the line break the trailing whitespace opens with is what closes the comment: taking it away, as `never-multi-line` does, would take the semicolon into the comment's text. Nothing can be written there, so the declaration is left alone and the warning stands. The `always` options are in no such danger, since the break they write is what closes such a comment anyway
-			let isFixable = primary.startsWith(`always`) || !writesIntoInlineComment(decl, result)
+			let isFixable = primary.startsWith(`always`) || !syntax.writesIntoInlineComment(decl, result)
 
 			checker.beforeAllowingIndentation({
 				source: declString,

--- a/lib/rules/declaration-block-semicolon-space-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-space-before/index.ts
@@ -12,7 +12,6 @@ import { isLastDeclarationWithoutSemicolon } from "../../utils/isLastDeclaration
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -73,7 +72,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let declString = declarationString(syntax, decl)
 			let problemIndex = declString.length - 1
 			// The semicolon goes right after the declaration's text, and the whitespace run the fix cuts into ends it. Where an inline comment stands there, the line break that run begins with is what closes the comment, so either option would take the semicolon into the comment's text: neither can be satisfied, so leave the declaration alone and let the warning stand
-			let isFixable = !writesIntoInlineComment(decl, result)
+			let isFixable = !syntax.writesIntoInlineComment(decl, result)
 
 			checker.before({
 				source: declString,

--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -3,6 +3,7 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
@@ -15,7 +16,6 @@ import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import { requiresTrailingSemicolon } from "../../utils/requiresTrailingSemicolon/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule, isDeclaration, isRoot } from "../../utils/typeGuards/index.ts"
-import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -186,16 +186,17 @@ function takeTheTrailingSemicolonsAway (node: ChildNode): void {
  * Under `never` nothing is written, and two other things stand in the way instead. The first is the one semicolon PostCSS keeps writing whatever the flag is set to. The second is the one the language will not part with: Less reads an at-rule carrying no block of its own as running to its semicolon, so taking that semicolon away leaves a file its compiler refuses, whatever the parser makes of the output.
  *
  * Where any of them holds, the option cannot be satisfied over that node at all, and the warning stands over code the fix leaves alone rather than being called fixed over a write that never lands or one that breaks the file.
+ * @param syntax - The syntax the rule is built over.
  * @param node - The node the semicolon stands behind.
  * @param primary - The primary option.
  * @param spelledBetween - The run that will stand between the node and an `always` write once the fix has run, where that write does not land on the whitespace the node ends with.
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns True where the fix may be written.
  */
-function isFixable (node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult): boolean {
+function isFixable (syntax: Syntax, node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult): boolean {
 	if (primary === `never`) return !semicolonOutlivesTheFlag(node) && !requiresTrailingSemicolon(node, result)
 
-	return !hasBlock(node) && !writesIntoInlineComment(node, result, spelledBetween)
+	return !hasBlock(node) && !syntax.writesIntoInlineComment(node, result, spelledBetween)
 }
 
 /**
@@ -203,11 +204,12 @@ function isFixable (node: ChildNode, primary: `always` | `never`, spelledBetween
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always` and `never`.
  * @param secondaryOptions - The secondary options: `ignore`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `never`, secondaryOptions: { ignore?: `single-declaration` | `single-declaration`[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `never`, secondaryOptions: { ignore?: `single-declaration` | `single-declaration`[] }): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -285,7 +287,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 					endIndex: problemIndex,
 					result,
 					ruleName,
-					...(isFixable(node, primary, spelledBetween, result) && {
+					...(isFixable(syntax, node, primary, spelledBetween, result) && {
 						fix: (): void => {
 							if (primary === `always` && !hasSemicolon) {
 								parent.raws.semicolon = true

--- a/lib/rules/declaration-colon-space-before/index.ts
+++ b/lib/rules/declaration-colon-space-before/index.ts
@@ -6,9 +6,7 @@ import { css } from "../../syntaxes/css/index.ts"
 import { declarationColonSpaceChecker } from "../../utils/declarationColonSpaceChecker/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { assertString } from "../../utils/validateTypes/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
@@ -68,7 +66,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The colon stands right after this part, so an inline comment ending it would swallow the colon
-			isFixable: (decl, index) => !endsWithInlineComment(beforeColonString(decl, index), inlineCommentReading(decl, result)),
+			isFixable: (decl, index) => !syntax.endsWithInlineComment(beforeColonString(decl, index), syntax.inlineComments(decl, result)),
 			fix: (decl, index) => {
 				let beforeColon = beforeColonString(decl, index)
 

--- a/lib/rules/function-max-empty-lines/index.ts
+++ b/lib/rules/function-max-empty-lines/index.ts
@@ -4,9 +4,8 @@ import stylelint from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { assertString, isNumber } from "../../utils/validateTypes/index.ts"
 
@@ -65,7 +64,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let stringValue = syntax.read(decl)
 
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
-			let inlineComments = findInlineCommentSpans(stringValue, readsInlineComments(decl, result))
+			let inlineComments = syntax.inlineCommentSpans(stringValue, decl, result)
 
 			let splittedValue: Array<[string, string]> = []
 			let sourceIndexStart = 0

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -11,8 +11,7 @@ import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommen
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
-import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
-import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
+import type { InlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -119,16 +118,17 @@ function mergeRanges (lists: [number, number][][]): [number, number][] {
  * The text the character ends is cut out of the value, and what the fixes would leave of it is spelled out rather than measured: closing a gap up can bring a slash against a comment's own and open a comment that was never there. What they would leave behind is the stretches they empty and nothing besides — taking out more than that, every character JavaScript calls whitespace between the last node and the parenthesis, which is what the closing guard used to do, closes a block comment early wherever a break is written inside its own text and holds back a fix nothing is at risk from.
  *
  * The two separators of Unicode need no reading of their own. A fix here writes over whitespace, and the value parser counts as space only what stands below the blank, so a separator survives every fix this guard stands in front of — whatever a reading makes of it, it makes the same of it before the fix and after, and it can never be what carries a parenthesis or an argument into a comment.
+ * @param syntax - The syntax the rule is built over.
  * @param declValue - The value the rule has read and parsed, which the positions count in.
  * @param characterIndex - Where the character the question is about stands.
  * @param emptied - The stretches the fixes empty, in ascending order and none of them overlapping.
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the character move into a comment.
  */
-function movesIntoComment (declValue: string, characterIndex: number, emptied: [number, number][], reading: InlineCommentReading): boolean {
+function movesIntoComment (syntax: Syntax, declValue: string, characterIndex: number, emptied: [number, number][], reading: InlineCommentReading): boolean {
 	let standingText = declValue.slice(0, characterIndex + 1)
 
-	return movesEndIntoInlineComment(standingText, withoutRanges(standingText, emptied), reading)
+	return syntax.movesEndIntoInlineComment(standingText, withoutRanges(standingText, emptied), reading)
 }
 
 /**
@@ -213,10 +213,11 @@ function getFixEmptiedAfter (valueNode: FunctionNode): [number, number][] {
  * The two are written in one pass over one value, and each of them is guarded by the question whether it would carry a character of the function into an inline comment: the opening one asks about the first significant thing the function holds, the closing one about the parenthesis itself. A function holding nothing but comments and whitespace has no significant node at all, so the first question is about that same parenthesis, and both fixes empty whitespace standing in front of it.
  *
  * Each fix has to be safe on its own, and the two have to be safe together. A fix that is not safe on its own is never written, and the other is then asked about the value as it alone would leave it: weighing it against a stretch nothing empties would decline a fix nothing is at risk from. Where both are safe on their own, the two questions are put again over the union of what either empties, since that union is the text the pass really leaves behind — putting them over two texts, each of which still holds the other fix's whitespace, is what let two writes safe apart destroy the value together (#312). Neither is written where that union carries a character into a comment: both problems are reported and nothing goes into the file.
+ * @param syntax - The syntax the rule is built over.
  * @param read - What the walk has read of the function, and the value it was read from.
  * @returns Whether each of the two fixes may be written.
  */
-function getNeverFixability (read: {
+function getNeverFixability (syntax: Syntax, read: {
 	declValue: string,
 	valueNode: FunctionNode,
 	openingIndex: number,
@@ -240,12 +241,12 @@ function getNeverFixability (read: {
 	// Asking it over either answers the same, and by a shorter road than it used to be given here: with the question above answered yes, the two are not two lists at all. Both walks push the whitespace nodes of the function, stepping over the block comments among them, and the fix stops at the node the parser files an inline comment's first slash under — so a stretch the walk measures past that node is one the fix does not reach, and the question is never asked where there is one. Everything in front of that node is walked alike by both.
 	//
 	// The reason given before was that the two differ only by whitespace standing inside a comment's span, and that no such whitespace can hold the break closing that comment, the span ending at that break. The second half is not true of every span the rule reads: a span the scan of this value cuts does end in front of a break, but one found again over what the fixes collected so far would leave behind is mapped back, and an end standing inside text a fix wrote maps to the index that text was written at (#288). `bar(foo(// c))` under `postcss-less` and `always` hands the walk a span ending on a closing parenthesis. Nothing here rests on that reading any longer, and a walk widened to reach past an inline comment would want the argument above rather than that one.
-	let isOpeningFixable = checkBefore !== `` && measured.every(([start, end]) => emptiedBefore.some(([from, to]) => from <= start && to >= end)) && !movesIntoComment(declValue, firstCharacterIndex, emptiedBefore, reading)
-	let isClosingFixable = checkAfter !== `` && !movesIntoComment(declValue, closingParenthesisIndex, emptiedAfter, reading)
+	let isOpeningFixable = checkBefore !== `` && measured.every(([start, end]) => emptiedBefore.some(([from, to]) => from <= start && to >= end)) && !movesIntoComment(syntax, declValue, firstCharacterIndex, emptiedBefore, reading)
+	let isClosingFixable = checkAfter !== `` && !movesIntoComment(syntax, declValue, closingParenthesisIndex, emptiedAfter, reading)
 
 	if (isOpeningFixable && isClosingFixable) {
 		let emptied = mergeRanges([emptiedBefore, emptiedAfter])
-		let movesTogether = movesIntoComment(declValue, firstCharacterIndex, emptied, reading) || movesIntoComment(declValue, closingParenthesisIndex, emptied, reading)
+		let movesTogether = movesIntoComment(syntax, declValue, firstCharacterIndex, emptied, reading) || movesIntoComment(syntax, declValue, closingParenthesisIndex, emptied, reading)
 
 		if (movesTogether) return { isOpeningFixable: false, isClosingFixable: false }
 	}
@@ -280,7 +281,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let edits: Edit[] = []
 			let declValue = syntax.read(decl)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
-			let reading = inlineCommentReading(decl, result)
+			let reading = syntax.inlineComments(decl, result)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary nodes
 			let inlineComments = findInlineCommentSpans(declValue, reading.spells)
 			// A break this rule writes closes such a comment where the file left one open, so the spans above describe a value the functions behind that write no longer stand in. They are found again before the next function is read, and only there: a value nothing has been written into holds the comments it was scanned for, and a run without `--fix` writes nothing at all.
@@ -309,7 +310,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				let closingIndex = valueNode.sourceIndex + functionString.length - 2
 				let checkAfter = getCheckAfter(valueNode)
 				let { isOpeningFixable, isClosingFixable } = isMultiLine && primary === `never-multi-line`
-					? getNeverFixability({ declValue, valueNode, openingIndex, checkBefore, checkAfter, firstIndex, measured, reading })
+					? getNeverFixability(syntax, { declValue, valueNode, openingIndex, checkBefore, checkAfter, firstIndex, measured, reading })
 					: { isOpeningFixable: false, isClosingFixable: false }
 
 				// Check opening ...

--- a/lib/rules/function-parentheses-space-inside/index.ts
+++ b/lib/rules/function-parentheses-space-inside/index.ts
@@ -9,8 +9,7 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findInlineCommentSpanAt, findInlineCommentSpanHolding, findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isSingleLineString } from "../../utils/isSingleLineString/index.ts"
-import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
-import { type InlineCommentReading, inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
+import type { InlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -68,38 +67,40 @@ function isFunctionParsedAsWritten (syntax: Syntax, valueNode: FunctionNode, inl
  * The fix writes the whitespace the function keeps behind its opening parenthesis and nothing else, so everything in front of that parenthesis stays where it is written and the argument closes up against it. Where an inline comment stands in front of the whitespace, the line break that whitespace holds is what closes the comment, so taking the break away leaves the argument, and everything the declaration has behind it, inside the comment's text.
  *
  * The stand-in stands where the argument's first character does, since {@link movesEndIntoInlineComment} asks about the character a text ends with.
+ * @param syntax - The syntax the rule is built over.
  * @param declValue - The value the rule has read and parsed, which the node's positions count in.
  * @param valueNode - The function whose opening parenthesis is being fixed.
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the argument move into a comment.
  */
-function movesOpeningIntoComment (declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
+function movesOpeningIntoComment (syntax: Syntax, declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
 	let openingIndex = valueNode.sourceIndex + valueNode.value.length + 1
 	let firstIndex = openingIndex + valueNode.before.length
 	let standingText = declValue.slice(0, firstIndex)
 	// The fix writes the whitespace behind the parenthesis and nothing else, so everything in front of that parenthesis stays where it is written and the argument closes up against it. A single space is all the `always` options put there, and a space closes no comment, so both options leave the argument standing behind the same text.
 	let fixedText = declValue.slice(0, openingIndex)
 
-	return movesEndIntoInlineComment(`${standingText}${ARGUMENT_STAND_IN}`, `${fixedText}${ARGUMENT_STAND_IN}`, reading)
+	return syntax.movesEndIntoInlineComment(`${standingText}${ARGUMENT_STAND_IN}`, `${fixedText}${ARGUMENT_STAND_IN}`, reading)
 }
 
 /**
  * Asks whether the fix would take a function's closing parenthesis from outside an inline comment into one.
  *
  * The fix writes the whitespace the function keeps in front of that parenthesis and nothing else, so the line break standing in that whitespace — the one closing a comment the value left open — is exactly what it takes away.
+ * @param syntax - The syntax the rule is built over.
  * @param declValue - The value the rule has read and parsed, which the node's positions count in.
  * @param valueNode - The function whose closing parenthesis is being fixed.
  * @param reading - What the syntax the value was spelled in makes of a comment opened by a double slash.
  * @returns True where a reading has the parenthesis move into a comment.
  */
-function movesClosingIntoComment (declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
+function movesClosingIntoComment (syntax: Syntax, declValue: string, valueNode: FunctionNode, reading: InlineCommentReading): boolean {
 	let closingIndex = valueNode.sourceEndIndex - 1
 	let standingText = declValue.slice(0, closingIndex)
 	// The fix writes the whitespace the function keeps in front of the parenthesis and nothing else, so everything behind that whitespace stays on the line it is written on, and only the parenthesis moves. A single space is all the `always` options put there, and a space closes no comment, so both options leave the parenthesis standing behind the same text.
 	let fixedText = declValue.slice(0, closingIndex - valueNode.after.length)
 
 	// The parenthesis is written back on the end of each text, since it is the character the fix moves
-	return movesEndIntoInlineComment(`${standingText})`, `${fixedText})`, reading)
+	return syntax.movesEndIntoInlineComment(`${standingText})`, `${fixedText})`, reading)
 }
 
 /**
@@ -156,7 +157,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let edits: Edit[] = []
 			let declValue = syntax.read(decl)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
-			let reading = inlineCommentReading(decl, result)
+			let reading = syntax.inlineComments(decl, result)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
 			let inlineComments = findInlineCommentSpans(declValue, reading.spells)
 			let parsedValue = valueParser(declValue)
@@ -190,7 +191,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				 * @returns True if the fix can write without commenting the first argument out.
 				 */
 				function isOpeningFixable (): boolean {
-					return !movesOpeningIntoComment(declValue, functionNode, reading)
+					return !movesOpeningIntoComment(syntax, declValue, functionNode, reading)
 				}
 
 				if (primary === `always` && valueNode.before !== ` `) {
@@ -225,7 +226,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				 * @returns True if the fix can write without commenting the parenthesis out.
 				 */
 				function isClosingFixable (): boolean {
-					return !movesClosingIntoComment(declValue, functionNode, reading)
+					return !movesClosingIntoComment(syntax, declValue, functionNode, reading)
 				}
 
 				if (primary === `always` && valueNode.after !== ` `) {

--- a/lib/rules/function-whitespace-after/index.ts
+++ b/lib/rules/function-whitespace-after/index.ts
@@ -9,9 +9,7 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findFunctionArgumentSpans } from "../../utils/findFunctionArgumentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { isWhitespace } from "../../utils/isWhitespace/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { searchCopy } from "../../utils/searchCopy/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -59,7 +57,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		 * @returns True where the syntax that spelled that node spells arithmetic of its own.
 		 */
 		function readsOwnArithmetic (node: Node): boolean {
-			return readsInlineComments(node, result)
+			return syntax.readsInlineComments(node, result)
 		}
 
 		/**
@@ -182,7 +180,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		root.walkAtRules(IMPORT_AT_RULE, (atRule) => {
 			let param = syntax.read(atRule)
-			let { searchString } = searchCopy(param, atRule, result)
+			let { searchString } = syntax.searchCopy(param, atRule, result)
 			let fixer = createFixer(param)
 
 			check(atRule, param, searchString, atRuleParamIndex(atRule), fixer.applyFix)
@@ -191,7 +189,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		})
 		root.walkDecls((decl) => {
 			let value = syntax.read(decl)
-			let { searchString } = searchCopy(value, decl, result)
+			let { searchString } = syntax.searchCopy(value, decl, result)
 			let fixer = createFixer(value)
 
 			check(decl, value, searchString, declarationValueIndex(decl), fixer.applyFix)

--- a/lib/rules/indentation/index.ts
+++ b/lib/rules/indentation/index.ts
@@ -11,7 +11,6 @@ import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { searchCopy } from "../../utils/searchCopy/index.ts"
 import { isAtRule, isDeclaration, isRoot, isRule } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean, isNumber, isString } from "../../utils/validateTypes/index.ts"
 
@@ -250,7 +249,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			// The search is handed a copy with every comment blanked out of it rather than the text itself, since `style-search` reads the line break that closes an inline comment as part of that comment and never hands the position over — so every line standing behind such a comment went unmeasured, which is #236. The copy is as long as the text and spells it character for character everywhere else, so the positions of the search are the positions of the file, which is the text a warning is counted in and the text a fix is written to.
 			//
 			// Nothing else below is handed the copy, save the one test whose pattern already spells a block comment out for itself: a reader that stops at a comment stops at both kinds of it today, and handing it the copy would teach it to look past the block kind as well — a reading of its own, which no comment of this issue's kind is needed to see.
-			let { searchString } = searchCopy(source, node, result)
+			let { searchString } = syntax.searchCopy(source, node, result)
 
 			// Data for current node fixing
 			let fixPositions: Array<{

--- a/lib/rules/media-feature-parentheses-space-inside/index.ts
+++ b/lib/rules/media-feature-parentheses-space-inside/index.ts
@@ -6,10 +6,8 @@ import { css } from "../../syntaxes/css/index.ts"
 import { addEdit, applyEditsFromEnd, type Edit } from "../../utils/applyEditsFromEnd/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -81,7 +79,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let params = syntax.read(atRule)
 			let indexBoost = atRuleParamIndex(atRule)
 			// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence every feature standing behind it on the line
-			let reading = inlineCommentReading(atRule, result)
+			let reading = syntax.inlineComments(atRule, result)
 			// A double slash opens a comment that runs to the end of its line, and `postcss-value-parser` knows nothing of the kind: a parenthesis standing in the text of one opens a media feature as far as that parser is concerned, and the fix then writes inside the comment
 			let inlineComments = findInlineCommentSpans(params, reading.spells)
 
@@ -114,7 +112,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 						if (SPACE_OR_TAB.test(node.after)) {
 							// The parenthesis goes right after this text, and the whitespace the fix empties ends it. Where an inline comment stands there, the line break that whitespace holds is what closes the comment, so the option cannot be satisfied without taking the parenthesis, and the whole query behind it, into the comment's text: leave the parameters alone and let the warning stand.
-							let isFixable = !endsWithInlineComment(params.slice(0, node.sourceEndIndex - 1 - node.after.length), reading)
+							let isFixable = !syntax.endsWithInlineComment(params.slice(0, node.sourceEndIndex - 1 - node.after.length), reading)
 
 							problems.push({
 								message: messages.rejectedClosing,

--- a/lib/rules/media-query-list-comma-space-before/index.ts
+++ b/lib/rules/media-query-list-comma-space-before/index.ts
@@ -5,10 +5,8 @@ import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { mediaQueryListCommaWhitespaceChecker } from "../../utils/mediaQueryListCommaWhitespaceChecker/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -57,7 +55,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			locationChecker: checker.before,
 			checkedRuleName: ruleName,
 			// The comma goes right after this text, and the whitespace run the fix writes ends it. Where an inline comment stands there, the line break that run holds is what closes the comment, so either option would take the comma, and the whole query behind it, into the comment's text: leave the parameters alone and let the warning stand
-			isFixable: (params, index, atRule) => !endsWithInlineComment(params.slice(0, index), inlineCommentReading(atRule, result)),
+			isFixable: (params, index, atRule) => !syntax.endsWithInlineComment(params.slice(0, index), syntax.inlineComments(atRule, result)),
 			fix: (atRule, index) => {
 				let paramCommaIndex = index - atRuleParamIndex(atRule)
 

--- a/lib/rules/named-grid-areas-alignment/index.ts
+++ b/lib/rules/named-grid-areas-alignment/index.ts
@@ -5,9 +5,8 @@ import { EVERY_LINE_BREAK_RUN, EVERY_WHITESPACE_RUN, LAST_LINE } from "../../reg
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpans, findInlineCommentSpanTouching, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanTouching, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isBoolean, isNumber } from "../../utils/validateTypes/index.ts"
 
@@ -76,7 +75,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let declarationValue = syntax.read(declaration)
 			let parsedValue = valueParser(declarationValue)
 			let isMultilineDeclaration = declarationValue.includes(`\n`)
-			let inlineComments = findInlineCommentSpans(declarationValue, readsInlineComments(declaration, result))
+			let inlineComments = syntax.inlineCommentSpans(declarationValue, declaration, result)
 
 			let gridRows = parsedValue.nodes.filter((node) => isGridRow(node, inlineComments))
 

--- a/lib/rules/number-leading-zero/index.ts
+++ b/lib/rules/number-leading-zero/index.ts
@@ -7,10 +7,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
@@ -73,7 +72,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (!value.includes(`.`)) return
 
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
-			let inlineComments = findInlineCommentSpans(value, readsInlineComments(node, result))
+			let inlineComments = syntax.inlineCommentSpans(value, node, result)
 
 			valueParser(value).walk((valueNode, at, siblings) => {
 				// A call opening an address holds a URL and no arguments of its own, so it is passed over whole. The name is read rather than matched against four characters, so that `u\rl(`, `\75 rl(` and `URL(` are the token `url(` is here as they are to the scan that finds the comments — and to Sass, and to `lightningcss`.

--- a/lib/rules/number-no-trailing-zeros/index.ts
+++ b/lib/rules/number-no-trailing-zeros/index.ts
@@ -7,10 +7,9 @@ import { css } from "../../syntaxes/css/index.ts"
 import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpanHolding, findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
@@ -65,7 +64,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (!value.includes(`.`)) return
 
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
-			let inlineComments = findInlineCommentSpans(value, readsInlineComments(node, result))
+			let inlineComments = syntax.inlineCommentSpans(value, node, result)
 
 			valueParser(value).walk((valueNode, at, siblings) => {
 				// A call opening an address holds a URL and no arguments of its own, so it is passed over whole. The name is read rather than matched against four characters, so that `u\rl(`, `\75 rl(` and `URL(` are the token `url(` is here as they are to the scan that finds the comments — and to Sass, and to `lightningcss`.

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -10,9 +10,7 @@ import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRu
 import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -71,11 +69,6 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		if (!validOptions) return
 
 		let avoidEscape = secondaryOptions && secondaryOptions.avoidEscape !== undefined ? secondaryOptions.avoidEscape : true
-
-		// A double slash opens a comment only where the syntax says it does. Elsewhere it is part of a value — an address, most often — and reading it as a comment would silence every string behind it on the line. The two spellings are identical, so the text cannot answer this and the syntax has to. The question waits until a double slash turns up, since answering it costs two parses of a probe and most stylesheets never ask.
-		//
-		// A stylesheet embedded in a page carries the syntax of its own block, and it is that one the question belongs to: the syntax the file was opened with parses the page rather than the style, and one page may hold blocks written in several languages.
-		let blockSyntax = nodeSyntax(root, result)
 
 		root.walk((node) => {
 			switch (node.type) {
@@ -287,7 +280,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (!value.includes(`//`)) return []
 
 			// A double slash of a syntax that marks its comments in a copy of its own is code — part of an address, most often. Unless that copy has gone out of step with the value and left the scan to answer after all, and then the comments are the ones the text spells.
-			if (!(raws && raws.scss) && !syntaxKeepsInlineComments(blockSyntax)) return []
+			if (!(raws && raws.scss) && !syntax.keepsInlineComments(root, result)) return []
 
 			return findInlineCommentSpans(value)
 		}

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -9,13 +9,11 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
 import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
 import { findInterpolationSpans, findInterpolationSpanTouching } from "../../utils/findInterpolationSpans/index.ts"
 import { getDimension } from "../../utils/getDimension/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
-import { readsInlineComments } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule } from "../../utils/typeGuards/index.ts"
 
@@ -72,7 +70,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let hasFixed = false
 
 			// Every comment of the value, both kinds: one of the two readings below wants the inline ones and the other wants them all. The inline ones are taken out of this list rather than asked of `findInlineCommentSpans`, since that helper is this very scan with the filter below already applied, and asking it as well would read one text twice over for one answer
-			let comments = findCommentSpans(checkedValue, readsInlineComments(node, result))
+			let comments = syntax.commentSpans(checkedValue, node, result)
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
 			let inlineComments = comments.filter(({ isInline }) => isInline)
 			// An interpolation is written in a language of its own, and the compiler expanding it settles what the text beside it means, so nothing a value spells next to one is a dimension this rule can read. The interpolations are found in the value once, and every node of the walk is measured against them. They are sought in a copy with every comment blanked out, since a brace written in a comment closes no interpolation and the code standing behind such a brace is code the file spells

--- a/lib/rules/value-list-comma-space-before/index.ts
+++ b/lib/rules/value-list-comma-space-before/index.ts
@@ -5,9 +5,7 @@ import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { inlineCommentReading } from "../../utils/readsInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { valueListCommaWhitespaceChecker } from "../../utils/valueListCommaWhitespaceChecker/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
@@ -59,7 +57,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			// Stylelint counts a fixer as applied whatever it does, so a rule that cannot repair a problem has to say so here rather than from inside the fixer. Two of them are such, and the comma has to clear both.
 			// A comma standing before the value belongs to the property name, and nothing this rule could write would reach it.
 			// A comma standing behind an inline comment cannot be moved either: the comma goes right after the whitespace the fix writes, and the line break that whitespace holds is what closes the comment, so either option would take the comma, and everything the declaration has left, into the comment's text.
-			isFixable: (declNode, index, declString) => index >= declarationValueIndex(declNode) && !endsWithInlineComment(declString.slice(0, index), inlineCommentReading(declNode, result)),
+			isFixable: (declNode, index, declString) => index >= declarationValueIndex(declNode) && !syntax.endsWithInlineComment(declString.slice(0, index), syntax.inlineComments(declNode, result)),
 			fix: (declNode, index) => {
 				fixData = fixData || (new Map())
 

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -1,5 +1,8 @@
 import type { AtRule, Declaration, Root, Rule as PostcssRule } from "postcss"
 
+import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
+import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
+import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
@@ -12,10 +15,15 @@ import { isStandardSyntaxProperty } from "../../utils/isStandardSyntaxProperty/i
 import { isStandardSyntaxRule } from "../../utils/isStandardSyntaxRule/index.ts"
 import { isStandardSyntaxSelector } from "../../utils/isStandardSyntaxSelector/index.ts"
 import { isStandardSyntaxValue } from "../../utils/isStandardSyntaxValue/index.ts"
+import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
+import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
+import { inlineCommentReading, readsInlineComments, syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index.ts"
+import { searchCopy } from "../../utils/searchCopy/index.ts"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
 import { isDeclaration, isRule } from "../../utils/typeGuards/index.ts"
+import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
 import type { Syntax } from "../index.ts"
 
 /** The syntax of the core: plain CSS, which every rule of the plugin is written for. A styled template is the `styled` namespace's to read, so a root carrying that parser's mark is refused; every other root is still accepted, custom syntaxes without a namespace of their own included. */
@@ -42,4 +50,13 @@ export let css: Syntax = {
 		else if (isRule(node)) setRuleSelector(node, text)
 		else setAtRuleParams(node, text)
 	},
+	inlineComments: inlineCommentReading,
+	readsInlineComments,
+	keepsInlineComments: (node, result) => syntaxKeepsInlineComments(nodeSyntax(node, result)),
+	commentSpans: (text, node, result) => findCommentSpans(text, readsInlineComments(node, result)),
+	inlineCommentSpans: (text, node, result) => findInlineCommentSpans(text, readsInlineComments(node, result)),
+	endsWithInlineComment,
+	movesEndIntoInlineComment,
+	writesIntoInlineComment,
+	searchCopy,
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -3,6 +3,10 @@ import type { Node as SelectorNode } from "postcss-selector-parser"
 import type { FunctionNode } from "postcss-value-parser"
 import type { PostcssResult } from "stylelint"
 
+import type { CommentSpan } from "../utils/findCommentSpans/index.ts"
+import type { InlineCommentSpan } from "../utils/findInlineCommentSpans/index.ts"
+import type { InlineCommentReading } from "../utils/readsInlineComments/index.ts"
+
 import { styled } from "./styled/index.ts"
 
 /**
@@ -113,6 +117,83 @@ export type Syntax = {
 	 * @param text - The text to write.
 	 */
 	write (node: AtRule | Declaration | PostcssRule, text: string): void,
+
+	/**
+	 * Reads what the node's own syntax makes of a comment opened by a double slash: whether it opens one at all, and whether such a comment survives in the text the rule reads.
+	 * @param node - The node whose stylesheet's syntax is asked.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns The reading.
+	 */
+	inlineComments (node: Node, result: PostcssResult): InlineCommentReading,
+
+	/**
+	 * Asks whether the text a rule reads of the node spells inline comments — whether the syntax both opens one on a double slash and keeps it in that text.
+	 * @param node - The node whose stylesheet's syntax is asked.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns True where it does.
+	 */
+	readsInlineComments (node: Node, result: PostcssResult): boolean,
+
+	/**
+	 * Asks whether the node's own syntax keeps an inline comment in the text a rule reads, whatever it does about opening one.
+	 * @param node - The node whose stylesheet's syntax is asked.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns True where it keeps them.
+	 */
+	keepsInlineComments (node: Node, result: PostcssResult): boolean,
+
+	/**
+	 * Finds the spans every comment occupies in a text of the node's stylesheet — the block comments, and the inline ones where the node's syntax reads them there.
+	 * @param text - The text, as the rule reads it.
+	 * @param node - The node the text belongs to.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns The spans, in the text's own coordinates.
+	 */
+	commentSpans (text: string, node: Node, result: PostcssResult): CommentSpan[],
+
+	/**
+	 * Finds the spans the inline comments alone occupy in a text of the node's stylesheet, where the node's syntax reads them there.
+	 * @param text - The text, as the rule reads it.
+	 * @param node - The node the text belongs to.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns The spans, in the text's own coordinates.
+	 */
+	inlineCommentSpans (text: string, node: Node, result: PostcssResult): InlineCommentSpan[],
+
+	/**
+	 * Asks whether a text ends inside an inline comment, under the reading given.
+	 * @param text - The text.
+	 * @param [reading] - What the syntax makes of a double slash; nothing read where none is given.
+	 * @returns True where the end of the text stands inside such a comment.
+	 */
+	endsWithInlineComment (text: string, reading?: InlineCommentReading): boolean,
+
+	/**
+	 * Asks whether a fix would take the end of a text from outside an inline comment into one, under the reading given.
+	 * @param standingText - The text as it stands, up to and including the character the fix moves.
+	 * @param fixedText - The same text as the fix would leave it.
+	 * @param reading - What the syntax makes of a double slash.
+	 * @returns True where the end moves into a comment.
+	 */
+	movesEndIntoInlineComment (standingText: string, fixedText: string, reading: InlineCommentReading): boolean,
+
+	/**
+	 * Asks whether a write onto the whitespace the node ends with would land inside an inline comment.
+	 * @param node - The node the write is about.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @param [spelledBetween] - The run that will stand between the node and the write once the fix has run, where the write does not land on the node's own trailing whitespace.
+	 * @returns True where such a write would land inside an inline comment.
+	 */
+	writesIntoInlineComment (node: Node, result: PostcssResult, spelledBetween?: string): boolean,
+
+	/**
+	 * Builds the copy of a text a search runs over: the double slashes the node's syntax reads as code are hidden, so a scan finds only the comments the syntax reads.
+	 * @param text - The text, as the rule reads it.
+	 * @param node - The node the text belongs to.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns The copy, with the spans of the comments the syntax reads.
+	 */
+	searchCopy (text: string, node: Node, result: PostcssResult): { searchString: string, commentSpans: CommentSpan[] },
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */

--- a/lib/utils/declarationBangSpaceChecker/index.ts
+++ b/lib/utils/declarationBangSpaceChecker/index.ts
@@ -6,7 +6,6 @@ import type { Syntax } from "../../syntaxes/index.ts"
 import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationString } from "../declarationString/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { searchCopy } from "../searchCopy/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -73,7 +72,7 @@ export function declarationBangSpaceChecker (opts: {
 	opts.root.walkDecls((decl) => {
 		let indexOffset = declarationValueIndex(decl)
 		let declString = declarationString(opts.syntax, decl)
-		let { searchString } = searchCopy(declString, decl, opts.result)
+		let { searchString } = opts.syntax.searchCopy(declString, decl, opts.result)
 		let valueString = searchString.slice(indexOffset)
 
 		if (!valueString.includes(`!`)) return

--- a/lib/utils/findMediaOperator/index.ts
+++ b/lib/utils/findMediaOperator/index.ts
@@ -5,7 +5,6 @@ import type { PostcssResult } from "stylelint"
 import { MEDIA_QUERY_COMBINATORS } from "../../reference/mediaQueries.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { searchCopy } from "../searchCopy/index.ts"
 
 // `styleSearch` tries the targets in the order they are given and reports the first that matches, so the two-character operators stand in front of the one-character ones and `>=` is read whole rather than as a `>` with an `=` behind it
 const RANGE_OPERATORS = [`>=`, `<=`, `>`, `<`, `=`]
@@ -21,7 +20,7 @@ export function findMediaOperator<T extends AtRule> (syntax: Syntax, atRule: T, 
 	if (atRule.name.toLowerCase() !== `media`) return
 
 	let params = syntax.read(atRule)
-	let { searchString } = searchCopy(params, atRule, result)
+	let { searchString } = syntax.searchCopy(params, atRule, result)
 
 	// An operator standing inside the arguments of a function belongs to those arguments and to no media feature, so the one in `url(a>=b)` is passed over as a comma there is
 	let functionArguments = findFunctionArgumentSpans(searchString).filter(({ name }) => !MEDIA_QUERY_COMBINATORS.has(name))

--- a/lib/utils/functionCommaSpaceChecker/index.ts
+++ b/lib/utils/functionCommaSpaceChecker/index.ts
@@ -5,12 +5,10 @@ import stylelint, { type PostcssResult } from "stylelint"
 import type { Syntax } from "../../syntaxes/index.ts"
 import { applyEditsFromEnd, type Edit } from "../applyEditsFromEnd/index.ts"
 import { declarationValueIndex } from "../declarationValueIndex/index.ts"
-import { endsWithInlineComment } from "../endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../findCommentSpans/index.ts"
 import { hideFalseInlineComments } from "../hideFalseInlineComments/index.ts"
 import { opensAnAddress } from "../opensAnAddress/index.ts"
 import { optionsMatches } from "../optionsMatches/index.ts"
-import { inlineCommentReading } from "../readsInlineComments/index.ts"
 import { isValueFunction } from "../typeGuards/index.ts"
 import { commentsRemovedBefore, withoutComments } from "../withoutComments/index.ts"
 
@@ -43,7 +41,7 @@ export function functionCommaSpaceChecker (opts: {
 		let declValue = opts.syntax.read(decl)
 		// A double slash opens a comment that runs to the end of its line, and `postcss-value-parser` knows nothing of the kind: it reads the text of such a comment as code of the value, and every comma standing in that text as a comma of the value
 		// A double slash spells a comment only where the syntax says one, and a file of plain CSS spells none: the pair in `myurl(//a)` is code there, and taking it for a comment would silence everything standing behind it on the line
-		let reading = inlineCommentReading(decl, opts.result)
+		let reading = opts.syntax.inlineComments(decl, opts.result)
 		// Every comment the file spells, and not the inline ones alone. `postcss-value-parser` has a node for a block comment, but looks for the closing delimiter from the opening slash itself, so the star of the opening serves as the star of that delimiter: it reads `/*/` as a comment entire where CSS reads an opening and goes on looking for a `*/` behind it. The rest of what the file spells as the text of that comment then comes back out of the parser as ordinary nodes of the value, the commas standing in it among them as `div` nodes (#275)
 		let valueCommentSpans = findCommentSpans(declValue, reading.spells)
 
@@ -144,7 +142,7 @@ export function functionCommaSpaceChecker (opts: {
 			function isFixable (commaNode: ValueParserDivNode): boolean {
 				if (opts.fixPosition !== `before`) return true
 
-				return !endsWithInlineComment(declValue.slice(0, commaNode.sourceIndex), reading)
+				return !opts.syntax.endsWithInlineComment(declValue.slice(0, commaNode.sourceIndex), reading)
 			}
 
 			/**

--- a/lib/utils/mediaFeatureColonSpaceChecker/index.ts
+++ b/lib/utils/mediaFeatureColonSpaceChecker/index.ts
@@ -7,7 +7,6 @@ import { MEDIA_AT_RULE } from "../../regexps.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
 import { atRuleParamIndex } from "../atRuleParamIndex/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { searchCopy } from "../searchCopy/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -31,7 +30,7 @@ export function mediaFeatureColonSpaceChecker (opts: {
 
 	opts.root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
 		let params = opts.syntax.read(atRule)
-		let { searchString } = searchCopy(params, atRule, opts.result)
+		let { searchString } = opts.syntax.searchCopy(params, atRule, opts.result)
 
 		// A colon standing inside the arguments of a function belongs to those arguments and to no media feature: the one in `url(http://x)` is part of the protocol, and a space written beside it names no resource at all
 		let functionArguments = findFunctionArgumentSpans(searchString).filter(({ name }) => !MEDIA_QUERY_COMBINATORS.has(name))

--- a/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/mediaQueryListCommaWhitespaceChecker/index.ts
@@ -7,7 +7,6 @@ import { LEADING_BLOCK_COMMENT, MEDIA_AT_RULE, OPENS_WITH_INLINE_COMMENT } from 
 import type { Syntax } from "../../syntaxes/index.ts"
 import { atRuleParamIndex } from "../atRuleParamIndex/index.ts"
 import { findFunctionArgumentSpans } from "../findFunctionArgumentSpans/index.ts"
-import { searchCopy } from "../searchCopy/index.ts"
 import { assertString } from "../validateTypes/index.ts"
 
 let { utils: { report } } = stylelint
@@ -34,7 +33,7 @@ export function mediaQueryListCommaWhitespaceChecker (opts: {
 
 	opts.root.walkAtRules(MEDIA_AT_RULE, (atRule) => {
 		let params = opts.syntax.read(atRule)
-		let { searchString, commentSpans } = searchCopy(params, atRule, opts.result)
+		let { searchString, commentSpans } = opts.syntax.searchCopy(params, atRule, opts.result)
 
 		// A comma standing inside the arguments of a function is a comma of those arguments and of no list: the one in `url(x/a,b.png)` names the file as surely as the letters around it do, and whitespace written beside it would name another file. `valueListCommaWhitespaceChecker` has asked the search itself to pass such a comma over since it was written; the search cannot be asked here, since it reads the parenthesis a set of media parameters opens on as the opening of a call and would pass over the whole of the first query.
 		let functionArguments = findFunctionArgumentSpans(searchString).filter(({ name }) => !MEDIA_QUERY_COMBINATORS.has(name))

--- a/lib/utils/valueListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/valueListCommaWhitespaceChecker/index.ts
@@ -4,7 +4,6 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import type { Syntax } from "../../syntaxes/index.ts"
 import { declarationString } from "../declarationString/index.ts"
-import { searchCopy } from "../searchCopy/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -50,7 +49,7 @@ export function valueListCommaWhitespaceChecker (opts: ValueListCommaWhitespaceC
 		if (!opts.syntax.isStandardDeclaration(decl) || !opts.syntax.isStandardProperty(decl.prop)) return
 
 		let declString = declarationString(opts.syntax, decl)
-		let { searchString } = searchCopy(declString, decl, opts.result)
+		let { searchString } = opts.syntax.searchCopy(declString, decl, opts.result)
 
 		styleSearch(
 			{


### PR DESCRIPTION
The third layer of the seam, the one the preprocessor machinery hangs on: every question a rule put to the `//`-comment utils it now puts to the syntax — the reading of a double slash, the spans of a text's comments, the reader's and the writer's end-of-text questions, `writesIntoInlineComment` and `searchCopy` whole. The span scanners stay importable where a rule passes an explicit reading of its own: the two `function-parentheses-*-inside` rules scan by `spells` alone and `string-quotes` scans a drifted copy by what the text spells — those sites name their question themselves, and folding them in would erase the distinction #163 and #298 rest on.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
