### PR TITLE
Ask the syntax to open a rule's selector

### DIFF
--- a/lib/rules/selector-attribute-brackets-space-inside/index.ts
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.ts
@@ -5,13 +5,9 @@ import stylelint, { type FixCallback } from "stylelint"
 import { LEADING_WHITESPACE, TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -50,14 +46,11 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		root.walkRules((ruleNode) => {
 			if (!syntax.isStandardRule(ruleNode)) return
 
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
+			let copies = syntax.selectorCopies(ruleNode)
 
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
+			let { selector } = copies
 
 			if (!selector.includes(`[`)) return
-
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 
 			let fix: FixCallback | undefined
 			let hasFixed
@@ -118,13 +111,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (hasFixed) {
 				let fixedSelector = String(selectorTree)
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 
 			/**
@@ -133,7 +120,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			 * @param index - The index of the violation.
 			 */
 			function complain (message: string, index: number): void {
-				let sourceIndex = toSelectorSourceIndex(index, inlineComments)
+				let sourceIndex = copies.toSourceIndex(index)
 
 				report({
 					message,

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.ts
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.ts
@@ -5,13 +5,10 @@ import { LEADING_WHITESPACE_AND_REST, WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findSelectorBlockComments } from "../../utils/findSelectorBlockComments/index.ts"
-import { findSelectorInlineComments, type InlineComment } from "../../utils/findSelectorInlineComments/index.ts"
+import type { InlineComment } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -48,24 +45,9 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			let hasFixed = false
 
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
+			let copies = syntax.selectorCopies(ruleNode)
 
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
-
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
-
-			/**
-			 * Gives back the way the file spells a stretch of the parsed selector.
-			 * @param text - The text as the parsed selector spells it.
-			 * @param rawIndex - The index that text stands at in the parsed selector.
-			 * @returns The same stretch, spelled as the file spells it.
-			 */
-			function sourceSpelling (text: string, rawIndex: number): string {
-				if (!selectorRaws || !selectorRaws.scss) return text
-
-				return selectorRaws.scss.slice(toSelectorSourceIndex(rawIndex, inlineComments), toSelectorSourceIndex(rawIndex + text.length, inlineComments))
-			}
+			let { selector } = copies
 
 			let fullSelector = parseSelector(selector, result, ruleNode)
 
@@ -89,10 +71,10 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						result,
 						ruleName,
 						message: messages.rejected,
-						messageArgs: [sourceSpelling(text, combinatorNode.sourceIndex)],
+						messageArgs: [copies.sourceSpelling(text, combinatorNode.sourceIndex)],
 						node: ruleNode,
-						index: toSelectorSourceIndex(combinatorNode.sourceIndex, inlineComments),
-						endIndex: toSelectorSourceIndex(combinatorNode.sourceIndex, inlineComments),
+						index: copies.toSourceIndex(combinatorNode.sourceIndex),
+						endIndex: copies.toSourceIndex(combinatorNode.sourceIndex),
 					})
 
 					return
@@ -102,7 +84,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				if (isLeftOverOfCombinator(combinatorNode)) return
 
 				// A descendant combinator, on the other hand, keeps whatever comments stand inside it, and they are what the whitespace has to be measured between: each stretch of it is a run of its own, reported at its own position and collapsed on its own, so that every comment stays where the author put it.
-				let segments = splitAtComments(text, combinatorNode.sourceIndex, inlineComments)
+				let segments = splitAtComments(text, combinatorNode.sourceIndex, copies.comments)
 
 				// The combinator prints its raw value where it has one, so writing the whole run there — and emptying the spaces the parser had split it across — is what makes a collapsed run reach the output. It is the shape the parser itself gives a combinator whose text does not come apart into whitespace and a single space.
 				function write (): void {
@@ -127,7 +109,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					// An inline comment ends with the line break standing behind it, and that break is in this run. A single space would close no comment, so there is nothing this rule could ask for here and nothing it could write: the run is passed over, as the whitespace behind a combinator of another kind is.
 					if (segment.closesInlineComment) return
 
-					let index = toSelectorSourceIndex(segment.index, inlineComments)
+					let index = copies.toSourceIndex(segment.index)
 
 					report({
 						result,
@@ -151,13 +133,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (hasFixed) {
 				let fixedSelector = String(fullSelector)
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 		})
 	}

--- a/lib/rules/selector-list-comma-newline-after/index.ts
+++ b/lib/rules/selector-list-comma-newline-after/index.ts
@@ -4,13 +4,9 @@ import stylelint from "stylelint"
 import { LEADING_WHITESPACE, WHITESPACE_THEN_BLOCK_COMMENT, WHITESPACE_THEN_INLINE_COMMENT } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -55,11 +51,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			// The raw selector is what is read, so that an end-of-line comment is allowed, e.g.
 			//   a, /* comment */
 			//   b {}
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
-
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+			let copies = syntax.selectorCopies(ruleNode)
+			let { selector } = copies
 
 			let fixIndices: number[] = []
 
@@ -85,8 +78,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 							// Under the `never` options the whitespace behind the comma — or behind the comment standing after it — is taken away, and it may hold the line break that closes an inline comment: without that break everything behind it would land in the comment's text. The problem is reported and the code left as it was. The `always` options only add a break in front of that whitespace, and take nothing.
 							let fixIndex = indextoCheckAfter + 1
 							let runEnd = fixIndex + (selector.slice(fixIndex).length - selector.slice(fixIndex).trimStart().length)
-							let closesInlineComment = primary.startsWith(`never`) && inlineComments.some((inlineComment) => fixIndex <= inlineComment.endIndex && inlineComment.endIndex < runEnd)
-							let sourceIndex = toSelectorSourceIndex(match.startIndex, inlineComments)
+							let closesInlineComment = primary.startsWith(`never`) && copies.comments.some((inlineComment) => fixIndex <= inlineComment.endIndex && inlineComment.endIndex < runEnd)
+							let sourceIndex = copies.toSourceIndex(match.startIndex)
 
 							report({
 								message: m,
@@ -119,13 +112,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					fixedSelector = beforeSelector + afterSelector
 				}
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 		})
 	}

--- a/lib/rules/selector-list-comma-newline-before/index.ts
+++ b/lib/rules/selector-list-comma-newline-before/index.ts
@@ -4,13 +4,10 @@ import stylelint from "stylelint"
 import { TRAILING_SPACES_AND_TABS, TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -79,11 +76,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
-
-				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.
-				let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+				let copies = syntax.selectorCopies(ruleNode)
+				let { selector } = copies
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeSelector = selector.slice(0, index)
@@ -99,13 +93,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					selector = beforeSelector + afterSelector
 				}
 
-				if (selectorRaws) {
-					selectorRaws.raw = selector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(selector, inlineComments)
-				}
-				else ruleNode.selector = selector
+				copies.write(selector)
 			}
 		}
 	}

--- a/lib/rules/selector-list-comma-space-after/index.ts
+++ b/lib/rules/selector-list-comma-space-after/index.ts
@@ -4,12 +4,9 @@ import stylelint from "stylelint"
 import { LEADING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -70,11 +67,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
-
-				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.
-				let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+				let copies = syntax.selectorCopies(ruleNode)
+				let { selector } = copies
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeSelector = selector.slice(0, index + 1)
@@ -86,13 +80,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					selector = beforeSelector + afterSelector
 				}
 
-				if (selectorRaws) {
-					selectorRaws.raw = selector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(selector, inlineComments)
-				}
-				else ruleNode.selector = selector
+				copies.write(selector)
 			}
 		}
 	}

--- a/lib/rules/selector-list-comma-space-before/index.ts
+++ b/lib/rules/selector-list-comma-space-before/index.ts
@@ -4,12 +4,9 @@ import stylelint from "stylelint"
 import { TRAILING_WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { selectorListCommaWhitespaceChecker } from "../../utils/selectorListCommaWhitespaceChecker/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
 let { utils: { validateOptions } } = stylelint
@@ -76,11 +73,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		if (fixData) {
 			for (let [ruleNode, commaIndices] of fixData.entries()) {
-				let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-				let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
-
-				// The comments are read off the two spellings before anything is written, since the alignment the pair is read by holds only while the copies tell one story.
-				let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+				let copies = syntax.selectorCopies(ruleNode)
+				let { selector } = copies
 
 				for (let index of commaIndices.toSorted((a, b) => b - a)) {
 					let beforeSelector = selector.slice(0, index)
@@ -92,13 +86,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					selector = beforeSelector + afterSelector
 				}
 
-				if (selectorRaws) {
-					selectorRaws.raw = selector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(selector, inlineComments)
-				}
-				else ruleNode.selector = selector
+				copies.write(selector)
 			}
 		}
 	}

--- a/lib/rules/selector-max-empty-lines/index.ts
+++ b/lib/rules/selector-max-empty-lines/index.ts
@@ -2,12 +2,8 @@ import stylelint from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { isNumber } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -28,10 +24,11 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, a number.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: number): RuleCheck {
 	let maxAdjacentNewlines = primary + 1
 
 	return (root, result) => {
@@ -48,11 +45,10 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 		let allowedCRLFNewLinesString = `\r\n`.repeat(maxAdjacentNewlines)
 
 		root.walkRules((ruleNode) => {
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
+			let copies = syntax.selectorCopies(ruleNode)
+			let { selector } = copies
 
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. The positions are reported in the file's own coordinates, and a fix is written to both copies. The line break that closes each comment stands outside it and survives the fix, since collapsing the empty lines always leaves the first break standing.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+			// The line break that closes each comment stands outside it and survives the fix, since collapsing the empty lines always leaves the first break standing.
 
 			if (violatedLFNewLinesRegex.test(selector) || violatedCRLFNewLinesRegex.test(selector)) {
 				report({
@@ -60,7 +56,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 					messageArgs: [primary],
 					node: ruleNode,
 					index: 0,
-					endIndex: toSelectorSourceIndex(selector.length, inlineComments),
+					endIndex: copies.toSourceIndex(selector.length),
 					result,
 					ruleName,
 					fix () {
@@ -68,13 +64,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: numb
 							.replaceAll(new RegExp(violatedLFNewLinesRegex, `gmu`), allowedLFNewLinesString)
 							.replaceAll(new RegExp(violatedCRLFNewLinesRegex, `gmu`), allowedCRLFNewLinesString)
 
-						if (selectorRaws) {
-							selectorRaws.raw = newSelectorString
-
-							// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-							if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(newSelectorString, inlineComments)
-						}
-						else ruleNode.selector = newSelectorString
+						copies.write(newSelectorString)
 					},
 				})
 			}

--- a/lib/rules/selector-pseudo-class-case/index.ts
+++ b/lib/rules/selector-pseudo-class-case/index.ts
@@ -3,13 +3,9 @@ import stylelint from "stylelint"
 import { LEVEL_ONE_AND_TWO_PSEUDO_ELEMENTS } from "../../reference/selectors.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -45,13 +41,11 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		root.walkRules((ruleNode) => {
 			if (!syntax.isStandardRule(ruleNode)) return
 
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
+			let copies = syntax.selectorCopies(ruleNode)
+			let { selector } = copies
 
 			if (!selector.includes(`:`)) return
 
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 			let hasFixed = false
 
 			let selectorTree = parseSelector(selector, result, ruleNode)
@@ -69,7 +63,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 				if (pseudo === expectedPseudo) return
 
-				let sourceIndex = toSelectorSourceIndex(pseudoNode.sourceIndex, inlineComments)
+				let sourceIndex = copies.toSourceIndex(pseudoNode.sourceIndex)
 
 				report({
 					message: messages.expected,
@@ -89,13 +83,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (hasFixed) {
 				let fixedSelector = String(selectorTree)
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 		})
 	}

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.ts
@@ -4,13 +4,9 @@ import stylelint, { type FixCallback } from "stylelint"
 import { LEADING_WHITESPACE_OR_BLOCK_COMMENT, LEADING_WHITESPACE_RUN, LINE_BREAK, TRAILING_WHITESPACE_RUN, WHITESPACE } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../../utils/typeGuards/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -62,12 +58,10 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let fix: FixCallback | undefined
 			let hasFixed = false
 
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
+			let copies = syntax.selectorCopies(ruleNode)
 
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
+			let { selector } = copies
 
-			// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 			let selectorTree = parseSelector(selector, result, ruleNode)
 
 			if (!selectorTree) return
@@ -108,7 +102,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				}
 
 				// An inline comment ends with the line break standing behind it, and where that break is the whitespace this end is about, it is what an option would write over. A space there would put the closing parenthesis inside the comment, and taking the break away would do the same, so the end is passed over: neither option can be satisfied, and neither can be asked for.
-				if (inlineComments.some((inlineComment) => inlineComment.startIndex < openIndex + paramString.trimEnd().length && openIndex + paramString.trimEnd().length <= inlineComment.endIndex)) lastNode = undefined
+				if (copies.comments.some((inlineComment) => inlineComment.startIndex < openIndex + paramString.trimEnd().length && openIndex + paramString.trimEnd().length <= inlineComment.endIndex)) lastNode = undefined
 
 				if (lastNode) {
 					let prevCharIsSpace = paramString.endsWith(` `)
@@ -135,13 +129,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (hasFixed) {
 				let fixedSelector = String(selectorTree)
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 
 			/**
@@ -150,7 +138,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			 * @param rawIndex - The index of the violation in the selector as it is parsed.
 			 */
 			function complain (message: string, rawIndex: number): void {
-				let index = toSelectorSourceIndex(rawIndex, inlineComments)
+				let index = copies.toSourceIndex(rawIndex)
 
 				report({
 					message,

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -8,13 +8,10 @@ import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
-import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
 import { isAtRule, type SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean } from "../../utils/validateTypes/index.ts"
 
@@ -92,14 +89,13 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		function checkRule (ruleNode: Rule): void {
 			if (!syntax.isStandardRule(ruleNode)) return
 
-			let selectorRaws: SyntaxRaw | undefined = ruleNode.raws.selector
+			let copies = syntax.selectorCopies(ruleNode)
 
 			// `ruleNode.selector` is a copy with every comment taken out, so a position counted in it stands short of the file wherever a comment goes before, and a fix written to it prints without the comments. The raw is the text the file holds — except under `postcss-scss`, which spells every inline comment of the raw as a block one and keeps the file's spelling beside it, two characters shorter per comment. The raw is what is parsed here, every position is translated back into the file's coordinates, and a fix is written to both copies.
-			let selector = selectorRaws ? selectorRaws.raw : ruleNode.selector
+			let { selector } = copies
 
 			if (!selector.includes(`[`) || !selector.includes(`=`)) return
 
-			let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 			let selectorFixed = false
 
 			let selectorTree = parseSelector(selector, result, ruleNode)
@@ -109,7 +105,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			selectorTree.walkAttributes((attributeNode) => {
 				if (!attributeNode.quoted) return
 
-				let maybeProblemIndex = toSelectorSourceIndex(attributeNode.sourceIndex + attributeNode.offsetOf(`value`), inlineComments)
+				let maybeProblemIndex = copies.toSourceIndex(attributeNode.sourceIndex + attributeNode.offsetOf(`value`))
 
 				if (attributeNode.quoteMark === correctQuote && avoidEscape) {
 					assertString(attributeNode.value)
@@ -183,13 +179,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (selectorFixed) {
 				let fixedSelector = String(selectorTree)
 
-				if (selectorRaws) {
-					selectorRaws.raw = fixedSelector
-
-					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-				}
-				else ruleNode.selector = fixedSelector
+				copies.write(fixedSelector)
 			}
 		}
 

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -3,6 +3,7 @@ import type { AtRule, Declaration, Root, Rule as PostcssRule } from "postcss"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
 import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
 import { getRuleSelector } from "../../utils/getRuleSelector/index.ts"
@@ -18,13 +19,15 @@ import { isStandardSyntaxValue } from "../../utils/isStandardSyntaxValue/index.t
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { inlineCommentReading, readsInlineComments, syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index.ts"
+import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import { searchCopy } from "../../utils/searchCopy/index.ts"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
 import { setDeclarationValue } from "../../utils/setDeclarationValue/index.ts"
 import { setRuleSelector } from "../../utils/setRuleSelector/index.ts"
-import { isDeclaration, isRule } from "../../utils/typeGuards/index.ts"
+import { toSelectorSourceIndex } from "../../utils/toSelectorSourceIndex/index.ts"
+import { isDeclaration, isRule, type SyntaxRaw } from "../../utils/typeGuards/index.ts"
 import { writesIntoInlineComment } from "../../utils/writesIntoInlineComment/index.ts"
-import type { Syntax } from "../index.ts"
+import type { SelectorCopies, Syntax } from "../index.ts"
 
 /** The syntax of the core: plain CSS, which every rule of the plugin is written for. A styled template is the `styled` namespace's to read, so a root carrying that parser's mark is refused; every other root is still accepted, custom syntaxes without a namespace of their own included. */
 export let css: Syntax = {
@@ -59,4 +62,29 @@ export let css: Syntax = {
 	movesEndIntoInlineComment,
 	writesIntoInlineComment,
 	searchCopy,
+	selectorCopies (rule: PostcssRule): SelectorCopies {
+		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
+		let selector = selectorRaws ? selectorRaws.raw : rule.selector
+		let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+
+		return {
+			selector,
+			comments: inlineComments,
+			toSourceIndex: (index: number) => toSelectorSourceIndex(index, inlineComments),
+			sourceSpelling (text: string, rawIndex: number): string {
+				if (!selectorRaws || !selectorRaws.scss) return text
+
+				return selectorRaws.scss.slice(toSelectorSourceIndex(rawIndex, inlineComments), toSelectorSourceIndex(rawIndex + text.length, inlineComments))
+			},
+			write (fixedSelector: string): void {
+				if (selectorRaws) {
+					selectorRaws.raw = fixedSelector
+
+					// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it
+					if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
+				}
+				else rule.selector = fixedSelector
+			},
+		}
+	},
 }

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -5,6 +5,7 @@ import type { PostcssResult } from "stylelint"
 
 import type { CommentSpan } from "../utils/findCommentSpans/index.ts"
 import type { InlineCommentSpan } from "../utils/findInlineCommentSpans/index.ts"
+import type { InlineComment } from "../utils/findSelectorInlineComments/index.ts"
 import type { InlineCommentReading } from "../utils/readsInlineComments/index.ts"
 
 import { styled } from "./styled/index.ts"
@@ -194,6 +195,46 @@ export type Syntax = {
 	 * @returns The copy, with the spans of the comments the syntax reads.
 	 */
 	searchCopy (text: string, node: Node, result: PostcssResult): { searchString: string, commentSpans: CommentSpan[] },
+
+	/**
+	 * Opens a rule's selector for a rule that parses it.
+	 *
+	 * `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw copy a parser can read, keeps the source spelling beside it and prints that one, so the two copies drift apart by two characters per comment. What comes back holds the parsed copy, the map from its positions into the file's own coordinates, the file's own spelling of a stretch of it, and the writer that lands a fixed selector in every copy the syntax keeps.
+	 * @param rule - The rule whose selector is opened.
+	 * @returns The copies.
+	 */
+	selectorCopies (rule: PostcssRule): SelectorCopies,
+}
+
+/** A rule's selector, opened for parsing and writing: see {@link Syntax#selectorCopies}. */
+export type SelectorCopies = {
+
+	/** The copy a parser can read, every inline comment rewritten into a block one. */
+	selector: string,
+
+	/** The inline comments the pair of copies holds, each with its span in both. */
+	comments: InlineComment[],
+
+	/**
+	 * Maps a position of the parsed copy into the file's own coordinates.
+	 * @param index - The index in the parsed copy.
+	 * @returns The index in the file's spelling.
+	 */
+	toSourceIndex (index: number): number,
+
+	/**
+	 * Gives back the way the file spells a stretch of the parsed copy.
+	 * @param text - The text as the parsed copy spells it.
+	 * @param rawIndex - The index that text stands at in the parsed copy.
+	 * @returns The same stretch, spelled as the file spells it.
+	 */
+	sourceSpelling (text: string, rawIndex: number): string,
+
+	/**
+	 * Writes a fixed selector into every copy the syntax keeps, the inline comments of the printed one spelled the way the file spells them.
+	 * @param fixedSelector - The selector, as the fix leaves the parsed copy.
+	 */
+	write (fixedSelector: string): void,
 }
 
 /** The syntaxes registered beside the core, each under a namespace of its own. A syntax is not registered until it is listed here. */

--- a/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
+++ b/lib/utils/selectorAttributeOperatorSpaceChecker/index.ts
@@ -4,11 +4,7 @@ import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
 import type { Syntax } from "../../syntaxes/index.ts"
-import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
-import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -34,13 +30,10 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 	options.root.walkRules((rule) => {
 		if (!options.syntax.isStandardRule(rule)) return
 
-		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
-		let selector = selectorRaws ? selectorRaws.raw : rule.selector
+		let copies = options.syntax.selectorCopies(rule)
+		let { selector } = copies
 
 		if (!selector.includes(`[`) || !selector.includes(`=`)) return
-
-		// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw parsed here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw and reported in the file's own coordinates, and a fix is written to both copies.
-		let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
 
 		let hasFixed = false
 
@@ -65,13 +58,7 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 		if (hasFixed) {
 			let fixedSelector = String(selectorTree)
 
-			if (selectorRaws) {
-				selectorRaws.raw = fixedSelector
-
-				// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-				if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-			}
-			else rule.selector = fixedSelector
+			copies.write(fixedSelector)
 		}
 
 		/**
@@ -87,7 +74,7 @@ export function selectorAttributeOperatorSpaceChecker (options: {
 				source,
 				index,
 				err: (msg) => {
-					let problemIndex = toSelectorSourceIndex(attributeNode.sourceIndex + index, inlineComments)
+					let problemIndex = copies.toSourceIndex(attributeNode.sourceIndex + index)
 
 					report({
 						message: msg.replace(

--- a/lib/utils/selectorCombinatorSpaceChecker/index.ts
+++ b/lib/utils/selectorCombinatorSpaceChecker/index.ts
@@ -4,11 +4,7 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { WHITESPACE } from "../../regexps.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
-import { findSelectorInlineComments } from "../findSelectorInlineComments/index.ts"
 import { parseSelector } from "../parseSelector/index.ts"
-import { restoreSelectorInlineComments } from "../restoreSelectorInlineComments/index.ts"
-import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../typeGuards/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -54,9 +50,8 @@ export function selectorCombinatorSpaceChecker (opts: {
 
 		hasFixed = false
 
-		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
-		let selector = selectorRaws ? selectorRaws.raw : rule.selector
-		let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+		let copies = opts.syntax.selectorCopies(rule)
+		let { selector } = copies
 
 		let selectorTree = parseSelector(selector, opts.result, rule)
 
@@ -80,19 +75,13 @@ export function selectorCombinatorSpaceChecker (opts: {
 			let sourceIndex = node.sourceIndex
 			let index = node.value.length > 1 && opts.locationType === `before` ? sourceIndex : sourceIndex + node.value.length - 1
 
-			check(selector, node, index, rule, toSelectorSourceIndex(sourceIndex, inlineComments))
+			check(selector, node, index, rule, copies.toSourceIndex(sourceIndex))
 		})
 
 		if (hasFixed) {
 			let fixedSelector = String(selectorTree)
 
-			if (selectorRaws) {
-				selectorRaws.raw = fixedSelector
-
-				// The stringifier reads the copy the source spelled, so the fix has to reach that one as well, with every inline comment spelled the way the file spells it.
-				if (selectorRaws.scss) selectorRaws.scss = restoreSelectorInlineComments(fixedSelector, inlineComments)
-			}
-			else rule.selector = fixedSelector
+			copies.write(fixedSelector)
 		}
 	})
 

--- a/lib/utils/selectorListCommaWhitespaceChecker/index.ts
+++ b/lib/utils/selectorListCommaWhitespaceChecker/index.ts
@@ -2,10 +2,8 @@ import type { Root, Rule } from "postcss"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
-import type { Syntax } from "../../syntaxes/index.ts"
-import { findSelectorInlineComments, type InlineComment } from "../findSelectorInlineComments/index.ts"
-import { toSelectorSourceIndex } from "../toSelectorSourceIndex/index.ts"
-import type { SyntaxRaw } from "../typeGuards/index.ts"
+import type { SelectorCopies, Syntax } from "../../syntaxes/index.ts"
+import type { InlineComment } from "../findSelectorInlineComments/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -47,11 +45,8 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 	opts.root.walkRules((rule) => {
 		if (!opts.syntax.isStandardRule(rule)) return
 
-		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
-		let selector = selectorRaws ? selectorRaws.raw : rule.selector
-
-		// `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw read here, keeps the source spelling beside it and prints that one, so the two strings drift apart by two characters per comment. Every position is counted in the raw, reported in the file's own coordinates, and handed to the rule's fixer as the raw spells it, since the raw is the copy the rule slices.
-		let inlineComments = findSelectorInlineComments(selector, selectorRaws && selectorRaws.scss)
+		let copies = opts.syntax.selectorCopies(rule)
+		let { selector } = copies
 
 		styleSearch(
 			{
@@ -60,7 +55,7 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 				functionArguments: `skip`,
 			},
 			(match) => {
-				checkDelimiter(selector, match.startIndex, rule, inlineComments)
+				checkDelimiter(selector, match.startIndex, rule, copies)
 			},
 		)
 	})
@@ -70,16 +65,16 @@ export function selectorListCommaWhitespaceChecker (opts: SelectorListCommaWhite
 	 * @param source - The source string being checked.
 	 * @param index - The index of the delimiter.
 	 * @param node - The rule node.
-	 * @param inlineComments - The inline comments of the selector.
+	 * @param copies - The selector, opened by the syntax.
 	 */
-	function checkDelimiter (source: string, index: number, node: Rule, inlineComments: InlineComment[]): void {
+	function checkDelimiter (source: string, index: number, node: Rule, copies: SelectorCopies): void {
 		opts.locationChecker({
 			source,
 			index,
 			err: (message) => {
 				// A rule may know that this particular problem cannot be fixed without breaking the code. The decision has to be made before the report, since Stylelint counts a fixer as applied whatever it does.
-				let isFixable = fix && (!opts.isFixable || opts.isFixable(source, index, inlineComments))
-				let sourceIndex = toSelectorSourceIndex(index, inlineComments)
+				let isFixable = fix && (!opts.isFixable || opts.isFixable(source, index, copies.comments))
+				let sourceIndex = copies.toSourceIndex(index)
 
 				report({
 					message,


### PR DESCRIPTION
The fourth layer of the seam: the three-copy machinery of a selector folds into `syntax.selectorCopies(rule)` — the parsed copy, the inline comments the pair holds, the map into the file's own coordinates, the file's spelling of a stretch, and the writer that lands a fixed selector in every copy the syntax keeps. Ten selector rules and three checkers ask it in place of the `findSelectorInlineComments` / `toSelectorSourceIndex` / `restoreSelectorInlineComments` triad each spelled out, and the per-site prose about the two drifting spellings goes with it — the story lives once, on the contract.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
