### PR TITLE
Ask the syntax the three questions with one asker each

### DIFF
--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -13,7 +13,6 @@ import { lastNonCommentNode } from "../../utils/lastNonCommentNode/index.ts"
 import { nextNonCommentNode } from "../../utils/nextNonCommentNode/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
-import { requiresTrailingSemicolon } from "../../utils/requiresTrailingSemicolon/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isAtRule, isDeclaration, isRoot } from "../../utils/typeGuards/index.ts"
 
@@ -194,7 +193,7 @@ function takeTheTrailingSemicolonsAway (node: ChildNode): void {
  * @returns True where the fix may be written.
  */
 function isFixable (syntax: Syntax, node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult): boolean {
-	if (primary === `never`) return !semicolonOutlivesTheFlag(node) && !requiresTrailingSemicolon(node, result)
+	if (primary === `never`) return !semicolonOutlivesTheFlag(node) && !syntax.requiresTrailingSemicolon(node, result)
 
 	return !hasBlock(node) && !syntax.writesIntoInlineComment(node, result, spelledBetween)
 }

--- a/lib/rules/function-whitespace-after/index.ts
+++ b/lib/rules/function-whitespace-after/index.ts
@@ -46,21 +46,6 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		if (!validOptions) return
 
 		/**
-		 * Asks whether the syntax that spelled a node reads arithmetic of its own, in which the whitespace in front of every sign is what makes the sign an operator.
-		 *
-		 * Nothing in the tree can answer this: `foo($a) -2px`, which Sass reads as a list of two values, and `foo($a)-2px`, which it reads as a subtraction, are one declaration node either way, and the difference lives in the compiler of the language rather than in what PostCSS hands over. What can be asked is whether a double slash opens a comment in that syntax — the very question {@link searchCopy} puts for itself in each of the walks below — and the two answers coincide: Sass and Less spell arithmetic of their own and comments of their own both, and plain CSS spells neither. A syntax the probe learns nothing about is answered yes here as it is there, which leaves the whitespace standing and costs a warning rather than a file.
-		 *
-		 * What this question cannot do is tell Sass from Less, and one place where those two differ is the plus: Less reads the whitespace in front of it as it reads the whitespace in front of a minus, and Sass reads a plus as an operator whatever whitespace stands beside it. So one reading answers for both syntaxes, and a plus behind a call is left alone under Sass as well, where closing it up would have been safe. That is a warning left unsaid, which is the side of the answer this whole question is decided on. A probe telling those two apart is there to be written — `postcss-less` reads `@a: 1;` as an at-rule it marks a variable and `postcss-scss` reads a plain one — so this is one reading chosen for two languages rather than a wall, and what it buys is a second question the plugin does not have to keep answering.
-		 *
-		 * The question is put to the node rather than to the file, since a page may hold a plain `<style>` beside a `<style lang="scss">` and each block carries the syntax that spelled it.
-		 * @param node - The node whose text is being read.
-		 * @returns True where the syntax that spelled that node spells arithmetic of its own.
-		 */
-		function readsOwnArithmetic (node: Node): boolean {
-			return syntax.readsInlineComments(node, result)
-		}
-
-		/**
 		 * Checks a node for function whitespace after violations.
 		 * @param node - The node to check.
 		 * @param value - The value to check.
@@ -117,7 +102,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			}
 			else if (primary === `never` && isWhitespace(nextChar)) {
 				// The whitespace in front of a `+` or a `-` that stands as an operator belongs to the sum rather than to the call: it is what makes the sign one, so `a { b: calc(var(--x) + 1px); }` closed up is a calculation no browser reads and a declaration it drops. Which signs stand as operators is what the syntax says: CSS reads `-1px` as a single number token, so a sign opening a number is part of that number and the whitespace in front of it is the call's, while a syntax spelling arithmetic of its own reads that whitespace as the whole of what tells a list of two values from a subtraction
-				if ((readsOwnArithmetic(node) ? LEADING_SPACED_SIGN : LEADING_SPACED_SUM_OPERATOR).test(searchString.slice(index))) return
+				if ((syntax.spellsOwnArithmetic(node, result) ? LEADING_SPACED_SIGN : LEADING_SPACED_SUM_OPERATOR).test(searchString.slice(index))) return
 
 				report({
 					message: messages.rejected,

--- a/lib/rules/unit-case/index.ts
+++ b/lib/rules/unit-case/index.ts
@@ -10,7 +10,7 @@ import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { findInlineCommentSpanHolding } from "../../utils/findInlineCommentSpans/index.ts"
-import { findInterpolationSpans, findInterpolationSpanTouching } from "../../utils/findInterpolationSpans/index.ts"
+import { findInterpolationSpanTouching } from "../../utils/findInterpolationSpans/index.ts"
 import { getDimension } from "../../utils/getDimension/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { opensAnAddress } from "../../utils/opensAnAddress/index.ts"
@@ -74,7 +74,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			// A double slash opens a comment that runs to the end of its line, and the value parser knows nothing of the kind: what such a comment holds comes back as ordinary words and calls
 			let inlineComments = comments.filter(({ isInline }) => isInline)
 			// An interpolation is written in a language of its own, and the compiler expanding it settles what the text beside it means, so nothing a value spells next to one is a dimension this rule can read. The interpolations are found in the value once, and every node of the walk is measured against them. They are sought in a copy with every comment blanked out, since a brace written in a comment closes no interpolation and the code standing behind such a brace is code the file spells
-			let interpolations = findInterpolationSpans(blankComments(checkedValue, comments))
+			let interpolations = syntax.interpolationSpans(blankComments(checkedValue, comments))
 
 			/**
 			 * Reads the dimension a value node holds and says where its unit is written in the case the option does not ask for.

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -3,6 +3,7 @@ import type { AtRule, Declaration, Root, Rule as PostcssRule } from "postcss"
 import { endsWithInlineComment } from "../../utils/endsWithInlineComment/index.ts"
 import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
 import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInterpolationSpans } from "../../utils/findInterpolationSpans/index.ts"
 import { findSelectorInlineComments } from "../../utils/findSelectorInlineComments/index.ts"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
@@ -19,6 +20,7 @@ import { isStandardSyntaxValue } from "../../utils/isStandardSyntaxValue/index.t
 import { movesEndIntoInlineComment } from "../../utils/movesEndIntoInlineComment/index.ts"
 import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { inlineCommentReading, readsInlineComments, syntaxKeepsInlineComments } from "../../utils/readsInlineComments/index.ts"
+import { requiresTrailingSemicolon } from "../../utils/requiresTrailingSemicolon/index.ts"
 import { restoreSelectorInlineComments } from "../../utils/restoreSelectorInlineComments/index.ts"
 import { searchCopy } from "../../utils/searchCopy/index.ts"
 import { setAtRuleParams } from "../../utils/setAtRuleParams/index.ts"
@@ -62,6 +64,9 @@ export let css: Syntax = {
 	movesEndIntoInlineComment,
 	writesIntoInlineComment,
 	searchCopy,
+	requiresTrailingSemicolon,
+	spellsOwnArithmetic: readsInlineComments,
+	interpolationSpans: findInterpolationSpans,
 	selectorCopies (rule: PostcssRule): SelectorCopies {
 		let selectorRaws: SyntaxRaw | undefined = rule.raws.selector
 		let selector = selectorRaws ? selectorRaws.raw : rule.selector

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -5,6 +5,7 @@ import type { PostcssResult } from "stylelint"
 
 import type { CommentSpan } from "../utils/findCommentSpans/index.ts"
 import type { InlineCommentSpan } from "../utils/findInlineCommentSpans/index.ts"
+import type { InterpolationSpan } from "../utils/findInterpolationSpans/index.ts"
 import type { InlineComment } from "../utils/findSelectorInlineComments/index.ts"
 import type { InlineCommentReading } from "../utils/readsInlineComments/index.ts"
 
@@ -204,6 +205,35 @@ export type Syntax = {
 	 * @returns The copies.
 	 */
 	selectorCopies (rule: PostcssRule): SelectorCopies,
+
+	/**
+	 * Asks whether the node must keep its trailing semicolon whatever an option says, because the language will not part with it.
+	 * @param node - The node the semicolon stands behind.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns True where the semicolon has to stay.
+	 */
+	requiresTrailingSemicolon (node: Node, result: PostcssResult): boolean,
+
+	/**
+	 * Asks whether the syntax that spelled a node reads arithmetic of its own, in which the whitespace in front of every sign is what makes the sign an operator.
+	 *
+	 * Nothing in the tree can answer this: `foo($a) -2px`, which Sass reads as a list of two values, and `foo($a)-2px`, which it reads as a subtraction, are one declaration node either way, and the difference lives in the compiler of the language rather than in what PostCSS hands over. What can be asked is whether a double slash opens a comment in that syntax, and the two answers coincide: Sass and Less spell arithmetic of their own and comments of their own both, and plain CSS spells neither. A syntax the probe learns nothing about is answered yes, which leaves the whitespace standing and costs a warning rather than a file.
+	 *
+	 * What this question cannot do is tell Sass from Less, and one place where those two differ is the plus: Less reads the whitespace in front of it as it reads the whitespace in front of a minus, and Sass reads a plus as an operator whatever whitespace stands beside it. So one reading answers for both syntaxes, and a plus behind a call is left alone under Sass as well, where closing it up would have been safe. That is a warning left unsaid, which is the side of the answer this whole question is decided on. A probe telling those two apart is there to be written — `postcss-less` reads `@a: 1;` as an at-rule it marks a variable and `postcss-scss` reads a plain one — so this is one reading chosen for two languages rather than a wall.
+	 *
+	 * The question is put to the node rather than to the file, since a page may hold a plain `<style>` beside a `<style lang="scss">` and each block carries the syntax that spelled it.
+	 * @param node - The node whose text is being read.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns True where the syntax that spelled that node spells arithmetic of its own.
+	 */
+	spellsOwnArithmetic (node: Node, result: PostcssResult): boolean,
+
+	/**
+	 * Finds the spans the interpolations of a preprocessor occupy in a text — a stretch written in a language of its own, which no rule reads code beside.
+	 * @param text - The text, with its comments blanked where a brace inside one must not close an interpolation.
+	 * @returns The spans, in the text's own coordinates.
+	 */
+	interpolationSpans (text: string): InterpolationSpan[],
 }
 
 /** A rule's selector, opened for parsing and writing: see {@link Syntax#selectorCopies}. */


### PR DESCRIPTION
The last layer of the seam takes the point questions onto the contract: `requiresTrailingSemicolon` moves whole with its one asker; `function-whitespace-after` loses its private `readsOwnArithmetic` to `spellsOwnArithmetic`, whose reasoning — one reading chosen for Sass and Less both — moves onto the contract where every adapter to come has to face it; and `unit-case` takes a value's interpolation spans from `interpolationSpans`, still handing it the comment-blanked copy, since a brace inside a comment closes no interpolation and that reasoning is the rule's own.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed.
