### PR TITLE
Ask the syntax where the printed text's inline comments stand

### DIFF
--- a/lib/preprocessor/findRewrittenCommentSpans/index.ts
+++ b/lib/preprocessor/findRewrittenCommentSpans/index.ts
@@ -1,0 +1,46 @@
+import type { InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
+import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.ts"
+
+/**
+ * Finds the spans the inline comments of a value occupy in it, out of the two copies `postcss-scss` keeps of that value: one with every inline comment rewritten into a block comment, and one spelled as the file spells it. Only the comments set the two apart, so the first character they disagree on is the second character of one — the asterisk of a block comment against the second slash of an inline one. A comment ends with its line in both copies, and none of them holds a line break, so the next line break puts the two back in step whatever the rewriting did to the text in between, and the distance between them there is what a position behind the comment has to be moved by to be read in the rewritten copy.
+ *
+ * Everything here rests on the two copies being the two copies of one text, which holds only until a rule writes to one of them and leaves the other where it was — a line break of the raw taken away, a colour spelled differently in it, a space put in front of it. The reading is therefore checked against the raw before it is handed out, by rewriting the comments it found the way the syntax rewrote them, and nothing is returned unless the raw comes back character for character.
+ * @param rewritten - The copy the comments were rewritten in.
+ * @param spelled - The copy spelled as the file spells it.
+ * @returns The spans, in the coordinates of the spelled copy, or `null` if the two copies have gone out of step.
+ */
+export function findRewrittenCommentSpans (rewritten: string, spelled: string): InlineCommentSpan[] | null {
+	let spans: InlineCommentSpan[] = []
+	let rewrittenIndex = 0
+	let spelledIndex = 0
+
+	while (rewrittenIndex < rewritten.length && spelledIndex < spelled.length) {
+		if (rewritten[rewrittenIndex] === spelled[spelledIndex]) {
+			rewrittenIndex += 1
+			spelledIndex += 1
+
+			continue
+		}
+
+		// The asterisk of a block comment against the second slash of an inline one, and the first slash of both already behind. Anything else is two texts that have parted ways.
+		if (spelledIndex === 0 || rewritten[rewrittenIndex] !== `*` || spelled[spelledIndex] !== `/` || spelled[spelledIndex - 1] !== `/`) return null
+
+		let lineBreakIndex = spelled.indexOf(`\n`, spelledIndex)
+		let rewrittenLineBreakIndex = rewritten.indexOf(`\n`, rewrittenIndex)
+		let runsToTheEnd = lineBreakIndex === -1 || rewrittenLineBreakIndex === -1
+
+		spans.push({
+			start: spelledIndex - 1,
+			end: runsToTheEnd ? spelled.length : lineBreakIndex,
+			delta: runsToTheEnd ? rewritten.length - spelled.length : rewrittenLineBreakIndex - lineBreakIndex,
+		})
+
+		if (runsToTheEnd) break
+
+		spelledIndex = lineBreakIndex
+		rewrittenIndex = rewrittenLineBreakIndex
+	}
+
+	// A reading of one copy against the other proves nothing by itself: the walk above sees where the two part company, not whether they ever meant the same text. Rewriting the comments it found the way the syntax rewrites them does prove it — the raw comes back or it does not.
+	return rewriteInlineComments(spelled, spans) === rewritten ? spans : null
+}

--- a/lib/rules/string-quotes/index.ts
+++ b/lib/rules/string-quotes/index.ts
@@ -7,12 +7,10 @@ import { atRuleParamIndex } from "../../utils/atRuleParamIndex/index.ts"
 import { blankComments } from "../../utils/blankComments/index.ts"
 import { declarationValueIndex } from "../../utils/declarationValueIndex/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
-import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { parseSelector } from "../../utils/parseSelector/index.ts"
-import { rewriteInlineComments } from "../../utils/rewriteInlineComments/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
-import { isAtRule, type SyntaxRaw } from "../../utils/typeGuards/index.ts"
+import { isAtRule } from "../../utils/typeGuards/index.ts"
 import { assertString, isBoolean } from "../../utils/validateTypes/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
@@ -191,18 +189,13 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 		 */
 		function checkDeclOrAtRule<T extends AtRule | Declaration> (node: T, rawValue: string, getIndex: (node: T) => number): void {
 			let fixPositions: number[] = []
-
-			let raws: SyntaxRaw | undefined = isAtRule(node) ? node.raws.params : node.raws.value
-
-			// `postcss-scss` rewrites every `//` comment inside the raw into a block comment, keeps the spelling of the file in a copy of its own and prints that copy. The rule works in that copy, since it is the file it reports positions in and the text a fix has to reach.
-			let value = (raws && raws.scss) || rawValue
+			let value = rawValue
 
 			// Get out quickly if there are no erroneous quotes
 			if (!value.includes(erroneousQuote)) return
 
-			// The comments the syntax rewrote in the raw are the comments it found, and the two copies say between them where each of them runs. They say it only while both still measure the same text: a rule that has written to one of them and left the other behind takes that away, and the text is then scanned as one carrying no such pair at all.
-			let rewrittenSpans = raws && raws.scss ? findRewrittenCommentSpans(raws.raw, raws.scss) : null
-			let inlineCommentSpans = rewrittenSpans || scanCommentSpans(raws, value)
+			// Where the comments of the text stand is the syntax's to say: off the pair of copies it keeps while the pair is in step, off a scan of the text otherwise
+			let inlineCommentSpans = syntax.printedInlineComments(node, value, result)
 
 			if (isAtRule(node) && node.name === `charset`) {
 				let hasValidQuotes = node.params.startsWith(`"`) && node.params.endsWith(`"`)
@@ -245,33 +238,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			if (fixPositions.length === 0) return
 
-			// The copy spelled as the file spells it is the one that is printed, so the fix goes there; the raw beside it is kept in step with it, for the rules that come after — as far as the two still measure the same text and a position can be carried between them.
-			if (raws && raws.scss) {
-				raws.scss = replaceQuotes(value, fixPositions)
-
-				if (rewrittenSpans) raws.raw = replaceQuotes(raws.raw, fixPositions.map((fixIndex) => toRewrittenIndex(fixIndex, rewrittenSpans)))
-
-				return
-			}
-
-			let fixed = replaceQuotes(value, fixPositions)
-
-			syntax.write(node, fixed)
-		}
-
-		/**
-		 * Scans a value for the inline comments it carries, where nothing else says where they are. `postcss-less` leaves the `//` comment of a variable spanning more than one line inside the params, where the value tokenizer takes the quotes in its text for a string of code.
-		 * @param raws - The raws of the value, if it has any.
-		 * @param value - The value, as the file spells it.
-		 * @returns The spans, in the coordinates of the value.
-		 */
-		function scanCommentSpans (raws: SyntaxRaw | undefined, value: string): InlineCommentSpan[] {
-			if (!value.includes(`//`)) return []
-
-			// A double slash of a syntax that marks its comments in a copy of its own is code — part of an address, most often. Unless that copy has gone out of step with the value and left the scan to answer after all, and then the comments are the ones the text spells.
-			if (!(raws && raws.scss) && !syntax.keepsInlineComments(root, result)) return []
-
-			return findInlineCommentSpans(value)
+			// The write lands in every copy the syntax keeps, the raw regenerated from the fixed text the way the syntax itself fills it — which is byte for byte the old raw with the quotes replaced, since a quote the rule fixes never stands inside a comment
+			syntax.write(node, replaceQuotes(value, fixPositions))
 		}
 
 		/**
@@ -288,69 +256,6 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			return fixed
 		}
 	}
-}
-
-/**
- * Finds the spans the inline comments of a value occupy in it, out of the two copies `postcss-scss` keeps of that value: one with every inline comment rewritten into a block comment, and one spelled as the file spells it. Only the comments set the two apart, so the first character they disagree on is the second character of one — the asterisk of a block comment against the second slash of an inline one. A comment ends with its line in both copies, and none of them holds a line break, so the next line break puts the two back in step whatever the rewriting did to the text in between, and the distance between them there is what a position behind the comment has to be moved by to be read in the rewritten copy.
- *
- * Everything here rests on the two copies being the two copies of one text, which holds only until a rule writes to one of them and leaves the other where it was — a line break of the raw taken away, a colour spelled differently in it, a space put in front of it. The reading is therefore checked against the raw before it is handed out, by rewriting the comments it found the way the syntax rewrote them, and nothing is returned unless the raw comes back character for character.
- * @param rewritten - The copy the comments were rewritten in.
- * @param spelled - The copy spelled as the file spells it.
- * @returns The spans, in the coordinates of the spelled copy, or `null` if the two copies have gone out of step.
- */
-function findRewrittenCommentSpans (rewritten: string, spelled: string): InlineCommentSpan[] | null {
-	let spans: InlineCommentSpan[] = []
-	let rewrittenIndex = 0
-	let spelledIndex = 0
-
-	while (rewrittenIndex < rewritten.length && spelledIndex < spelled.length) {
-		if (rewritten[rewrittenIndex] === spelled[spelledIndex]) {
-			rewrittenIndex += 1
-			spelledIndex += 1
-
-			continue
-		}
-
-		// The asterisk of a block comment against the second slash of an inline one, and the first slash of both already behind. Anything else is two texts that have parted ways.
-		if (spelledIndex === 0 || rewritten[rewrittenIndex] !== `*` || spelled[spelledIndex] !== `/` || spelled[spelledIndex - 1] !== `/`) return null
-
-		let lineBreakIndex = spelled.indexOf(`\n`, spelledIndex)
-		let rewrittenLineBreakIndex = rewritten.indexOf(`\n`, rewrittenIndex)
-		let runsToTheEnd = lineBreakIndex === -1 || rewrittenLineBreakIndex === -1
-
-		spans.push({
-			start: spelledIndex - 1,
-			end: runsToTheEnd ? spelled.length : lineBreakIndex,
-			delta: runsToTheEnd ? rewritten.length - spelled.length : rewrittenLineBreakIndex - lineBreakIndex,
-		})
-
-		if (runsToTheEnd) break
-
-		spelledIndex = lineBreakIndex
-		rewrittenIndex = rewrittenLineBreakIndex
-	}
-
-	// A reading of one copy against the other proves nothing by itself: the walk above sees where the two part company, not whether they ever meant the same text. Rewriting the comments it found the way the syntax rewrites them does prove it — the raw comes back or it does not.
-	return rewriteInlineComments(spelled, spans) === rewritten ? spans : null
-}
-
-/**
- * Moves a position of the value into the copy of it a syntax rewrote the comments in.
- * @param index - The position, in the coordinates of the value.
- * @param spans - The spans of the inline comments the value carries.
- * @returns The position, in the coordinates of the rewritten copy.
- */
-function toRewrittenIndex (index: number, spans: InlineCommentSpan[]): number {
-	let delta = 0
-
-	// A position inside a comment is not one the rule ever fixes, so every span the position does not stand behind is passed over.
-	for (let span of spans) {
-		if (index < span.end) break
-
-		delta = span.delta || 0
-	}
-
-	return index + delta
 }
 
 /**

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -2,6 +2,7 @@ import type { AtRule, Declaration, Root, Rule as PostcssRule } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 import { endsWithInlineComment } from "../../preprocessor/endsWithInlineComment/index.ts"
+import { findRewrittenCommentSpans } from "../../preprocessor/findRewrittenCommentSpans/index.ts"
 import { findSelectorInlineComments, type InlineComment } from "../../preprocessor/findSelectorInlineComments/index.ts"
 import { movesEndIntoInlineComment } from "../../preprocessor/movesEndIntoInlineComment/index.ts"
 import { inlineCommentReading, readsInlineComments, syntaxKeepsInlineComments } from "../../preprocessor/readsInlineComments/index.ts"
@@ -10,7 +11,7 @@ import { searchCopy } from "../../preprocessor/searchCopy/index.ts"
 import { toSelectorSourceIndex } from "../../preprocessor/toSelectorSourceIndex/index.ts"
 import { writesIntoInlineComment } from "../../preprocessor/writesIntoInlineComment/index.ts"
 import { findCommentSpans } from "../../utils/findCommentSpans/index.ts"
-import { findInlineCommentSpans } from "../../utils/findInlineCommentSpans/index.ts"
+import { findInlineCommentSpans, type InlineCommentSpan } from "../../utils/findInlineCommentSpans/index.ts"
 import { findInterpolationSpans } from "../../utils/findInterpolationSpans/index.ts"
 import { getAtRuleParams } from "../../utils/getAtRuleParams/index.ts"
 import { getDeclarationValue } from "../../utils/getDeclarationValue/index.ts"
@@ -73,6 +74,17 @@ export let css: Syntax = {
 	writesIntoInlineComment,
 	searchCopy,
 	// The one semicolon a language will not part with is a preprocessor's; no construct of plain CSS or of `postcss-scss` holds one
+	printedInlineComments (node: AtRule | Declaration, text: string, result: PostcssResult): InlineCommentSpan[] {
+		let raws: SyntaxRaw | undefined = isDeclaration(node) ? node.raws.value : node.raws.params
+
+		// The comments the syntax rewrote in the raw are the comments it found, and the two copies say between them where each of them runs — while both still measure the same text; a pair out of step leaves the text to be scanned as one carrying no pair at all
+		if (raws && typeof raws.scss === `string`) return findRewrittenCommentSpans(raws.raw, raws.scss) ?? (text.includes(`//`) ? findInlineCommentSpans(text) : [])
+
+		if (!text.includes(`//`)) return []
+
+		// A double slash of a syntax that marks its comments in a copy of its own is code — part of an address, most often
+		return syntaxKeepsInlineComments(nodeSyntax(node, result)) ? findInlineCommentSpans(text) : []
+	},
 	requiresTrailingSemicolon: () => false,
 	// No rule of plain CSS carries a parameter list, and no at-rule of it is a variable: both marks are `postcss-less`'s, and the less namespace reads them
 	readsRuleParams: () => false,

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -192,6 +192,17 @@ export type Syntax = {
 	searchCopy (text: string, node: Node, result: PostcssResult): { searchString: string, commentSpans: CommentSpan[] },
 
 	/**
+	 * Finds the spans the inline comments occupy in the text a node prints — a declaration's value or an at-rule's params, as `read` hands it over.
+	 *
+	 * Where the syntax keeps a pair of copies and the pair is still in step, the spans are read off the pair, exactly as the parser saw them; where the pair has gone out of step, the text is scanned as one carrying no pair at all; and where the syntax spells no inline comment in that text, there are none.
+	 * @param node - The declaration or at-rule.
+	 * @param text - The text the node prints, as `read` hands it over.
+	 * @param result - The Stylelint result, which holds the syntax the file was opened with.
+	 * @returns The spans, in the text's own coordinates.
+	 */
+	printedInlineComments (node: AtRule | Declaration, text: string, result: PostcssResult): InlineCommentSpan[],
+
+	/**
 	 * Opens a rule's selector for a rule that parses it.
 	 *
 	 * `postcss-scss` rewrites every inline comment of a selector into a block comment in the raw copy a parser can read, keeps the source spelling beside it and prints that one, so the two copies drift apart by two characters per comment. What comes back holds the parsed copy, the map from its positions into the file's own coordinates, the file's own spelling of a stretch of it, and the writer that lands a fixed selector in every copy the syntax keeps.

--- a/scripts/check-break-readings.ts
+++ b/scripts/check-break-readings.ts
@@ -77,6 +77,10 @@ const DEBT: Record<string, string[]> = {
 	],
 	"lib/rules/indentation/index.ts": [`target: \`\\n\`,`],
 	"lib/rules/max-empty-lines/index.ts": [`target: CRLF.test(rootString) ? \`\\r\\n\` : \`\\n\`,`],
+	"lib/preprocessor/findRewrittenCommentSpans/index.ts": [
+		`let lineBreakIndex = spelled.indexOf(\`\\n\`, spelledIndex)`,
+		`let rewrittenLineBreakIndex = rewritten.indexOf(\`\\n\`, rewrittenIndex)`,
+	],
 	"lib/rules/max-line-length/index.ts": [
 		`styleSearch({ source: rootString, target: [\`\\n\`], comments: \`check\` }, (match) => checkNewline(match))`,
 		`let nextNewlineIndex = rootString.indexOf(\`\\n\`, match.endIndex)`,
@@ -92,10 +96,6 @@ const DEBT: Record<string, string[]> = {
 	"lib/rules/selector-max-empty-lines/index.ts": [
 		`let violatedCRLFNewLinesRegex = new RegExp(\`(?:\\r\\n){\${maxAdjacentNewlines + 1},}\`, \`u\`)`,
 		`let violatedLFNewLinesRegex = new RegExp(\`\\n{\${maxAdjacentNewlines + 1},}\`, \`u\`)`,
-	],
-	"lib/rules/string-quotes/index.ts": [
-		`let lineBreakIndex = spelled.indexOf(\`\\n\`, spelledIndex)`,
-		`let rewrittenLineBreakIndex = rewritten.indexOf(\`\\n\`, rewrittenIndex)`,
 	],
 	"lib/rules/value-list-max-empty-lines/index.ts": [
 		`let violatedCRLFNewLinesRegex = new RegExp(\`(?:\\r\\n){\${maxAdjacentNewlines + 1},}\`, \`u\`)`,


### PR DESCRIPTION
`string-quotes` was the last rule of the core holding SCSS machinery of its own — a diff of the two copies `postcss-scss` keeps of a value, proving the pair in step by rewriting the comments it found and asking whether the raw comes back character for character, and a position map for writing the fix into both. It is syntax-blind now: the diff moves to `lib/preprocessor/findRewrittenCommentSpans/`, and the contract gains `printedInlineComments(node, text, result)`, which answers off the pair while it is in step, off a scan of the text where the pair has drifted or the syntax keeps its comments in the text, and with nothing where the syntax spells none.

Two simplifications ride on what the seam already guarantees: the scss-first read of the value was spelled twice, once at the call site through `syntax.read` and once inside the check, so the inner one goes; and the fix is written through `syntax.write` unconditionally, since the position-mapped write into the raw was byte for byte what `write` regenerates for a pair in step — the diff itself proves `rewriteInlineComments(spelled) === raw`, and a quote the rule fixes never stands inside a comment. For a pair out of step the write now repairs the raw from the fixed text rather than leaving it behind, the reading every other write of the plugin has had since the seam.

Runs: `make verify`; `make oracles` against `origin/main` — all six oracles, no row added, removed or changed; the inline corpus of the `control` and `twins` oracles is largely a `string-quotes` corpus, which is why it is the run that matters here.
