### PR TITLE
Read the `linebreaks` setting under the asking rule's namespace

### DIFF
--- a/lib/rules/at-rule-semicolon-newline-after/index.ts
+++ b/lib/rules/at-rule-semicolon-newline-after/index.ts
@@ -73,7 +73,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						result,
 						ruleName,
 						fix () {
-							nodeToCheck.raws.before = getLineBreak(root, result) + nodeToCheck.raws.before
+							nodeToCheck.raws.before = getLineBreak(syntax, root, result) + nodeToCheck.raws.before
 						},
 					})
 				},

--- a/lib/rules/block-closing-brace-empty-line-before/index.ts
+++ b/lib/rules/block-closing-brace-empty-line-before/index.ts
@@ -36,11 +36,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always-multi-line` and `never`.
  * @param secondaryOptions - The secondary options: `except`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always-multi-line` | `never`, secondaryOptions: { except?: `after-closing-brace` | `after-closing-brace`[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always-multi-line` | `never`, secondaryOptions: { except?: `after-closing-brace` | `after-closing-brace`[] }): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -113,7 +114,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 						return
 					}
 
-					addEmptyLineAfter(statement, result)
+					addEmptyLineAfter(syntax, statement, result)
 				},
 			})
 		}

--- a/lib/rules/block-closing-brace-newline-after/index.ts
+++ b/lib/rules/block-closing-brace-newline-after/index.ts
@@ -37,11 +37,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, one of `always`, `always-single-line`, `never-single-line`, `always-multi-line` and `never-multi-line`.
  * @param secondaryOptions - The secondary options: `ignoreAtRules`.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreAtRules?: string | string[] }): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: `always` | `always-single-line` | `never-single-line` | `always-multi-line` | `never-multi-line`, secondaryOptions: { ignoreAtRules?: string | string[] }): RuleCheck {
 	let checker = whitespaceChecker(`newline`, primary, messages)
 
 	return (root, result) => {
@@ -125,7 +126,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: `alw
 								// Trim up to the break that already stands there, whichever character it is, and add one only where none does
 								let index = nodeToCheckRaws.before.search(LINE_BREAK)
 
-								nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(root, result) + nodeToCheckRaws.before
+								nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheckRaws.before
 							}
 							else if (primary.startsWith(`never`)) nodeToCheckRaws.before = ``
 						},

--- a/lib/rules/block-closing-brace-newline-before/index.ts
+++ b/lib/rules/block-closing-brace-newline-before/index.ts
@@ -115,7 +115,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								let newlineAfter = firstWhitespaceIndex >= 0 ? raw.slice(firstWhitespaceIndex) : ``
 								let newlineIndex = newlineAfter.search(LINE_BREAK)
 
-								setBlockAfter(statement, newlineIndex >= 0 ? newlineBefore + newlineAfter.slice(newlineIndex) : newlineBefore + getLineBreak(root, result) + newlineAfter)
+								setBlockAfter(statement, newlineIndex >= 0 ? newlineBefore + newlineAfter.slice(newlineIndex) : newlineBefore + getLineBreak(syntax, root, result) + newlineAfter)
 							}
 							else if (primary === `never-multi-line`) setBlockAfter(statement, raw.replaceAll(EVERY_WHITESPACE, ``))
 						},

--- a/lib/rules/block-opening-brace-newline-after/index.ts
+++ b/lib/rules/block-opening-brace-newline-after/index.ts
@@ -149,7 +149,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 									// Trim up to the break that already stands there, whichever character it is, and add one only where none does
 									let index = nodeToCheckRaws.before.search(LINE_BREAK)
 
-									nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(root, result) + nodeToCheckRaws.before
+									nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheckRaws.before
 
 									backupCommentNextBefores.delete(nodeToCheck)
 

--- a/lib/rules/block-opening-brace-newline-before/index.ts
+++ b/lib/rules/block-opening-brace-newline-before/index.ts
@@ -101,8 +101,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								if (primary.startsWith(`always`)) {
 									let spaceIndex = statement.raws.between.search(TRAILING_SPACES_AND_TABS)
 
-									if (spaceIndex >= 0) statement.raws.between = statement.raws.between.slice(0, spaceIndex) + getLineBreak(root, result) + statement.raws.between.slice(spaceIndex)
-									else statement.raws.between += getLineBreak(root, result)
+									if (spaceIndex >= 0) statement.raws.between = statement.raws.between.slice(0, spaceIndex) + getLineBreak(syntax, root, result) + statement.raws.between.slice(spaceIndex)
+									else statement.raws.between += getLineBreak(syntax, root, result)
 								}
 								else if (primary.startsWith(`never`)) statement.raws.between = statement.raws.between.replace(TRAILING_WHITESPACE, ``)
 							},

--- a/lib/rules/declaration-block-semicolon-newline-after/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.ts
@@ -95,7 +95,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 									// Trim up to the break that already stands there, whichever character it is, and add one only where none does
 									let index = nodeToCheck.raws.before.search(LINE_BREAK)
 
-									nodeToCheck.raws.before = index >= 0 ? nodeToCheck.raws.before.slice(index) : getLineBreak(root, result) + nodeToCheck.raws.before
+									nodeToCheck.raws.before = index >= 0 ? nodeToCheck.raws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheck.raws.before
 
 									return
 								}

--- a/lib/rules/declaration-block-semicolon-newline-before/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.ts
@@ -86,7 +86,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						...(isFixable && {
 							fix: (): void => {
 								if (primary.startsWith(`always`)) {
-									writeWhitespaceBeforeSemicolon(syntax, decl, getLineBreak(root, result))
+									writeWhitespaceBeforeSemicolon(syntax, decl, getLineBreak(syntax, root, result))
 
 									return
 								}

--- a/lib/rules/declaration-colon-newline-after/index.ts
+++ b/lib/rules/declaration-colon-newline-after/index.ts
@@ -99,7 +99,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 									let betweenAfter = between.slice(sliceIndex)
 
 									// Trim up to the break that already stands there, whichever character it is, and add one only where none does
-									decl.raws.between = OPENS_WITH_LINE_BREAK.test(betweenAfter) ? betweenBefore + betweenAfter.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``) : betweenBefore + getLineBreak(root, result) + betweenAfter
+									decl.raws.between = OPENS_WITH_LINE_BREAK.test(betweenAfter) ? betweenBefore + betweenAfter.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``) : betweenBefore + getLineBreak(syntax, root, result) + betweenAfter
 
 									return
 								}
@@ -110,7 +110,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								let valueAfter = syntax.read(decl)
 
 								if (OPENS_WITH_LINE_BREAK.test(valueAfter)) syntax.write(decl, valueAfter.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``))
-								else decl.raws.between += getLineBreak(root, result)
+								else decl.raws.between += getLineBreak(syntax, root, result)
 							},
 						})
 					},

--- a/lib/rules/function-comma-newline-after/index.ts
+++ b/lib/rules/function-comma-newline-after/index.ts
@@ -71,7 +71,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				functionNode,
 				expectation: primary,
 				position: `after`,
-				symb: getLineBreak(root, result),
+				symb: getLineBreak(syntax, root, result),
 			}),
 		})
 	}

--- a/lib/rules/function-comma-newline-before/index.ts
+++ b/lib/rules/function-comma-newline-before/index.ts
@@ -71,7 +71,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				functionNode,
 				expectation: primary,
 				position: `before`,
-				symb: getLineBreak(root, result),
+				symb: getLineBreak(syntax, root, result),
 			}),
 		})
 	}

--- a/lib/rules/function-parentheses-newline-inside/index.ts
+++ b/lib/rules/function-parentheses-newline-inside/index.ts
@@ -314,12 +314,12 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 				// Check opening ...
 				if (primary === `always` && !LINE_BREAK.test(checkBefore)) {
-					fix = fixWith(() => fixBeforeForAlways(valueNode, openingIndex, getLineBreak(root, result)))
+					fix = fixWith(() => fixBeforeForAlways(valueNode, openingIndex, getLineBreak(syntax, root, result)))
 					complain(messages.expectedOpening, openingIndex)
 				}
 
 				if (isMultiLine && primary === `always-multi-line` && !LINE_BREAK.test(checkBefore)) {
-					fix = fixWith(() => fixBeforeForAlways(valueNode, openingIndex, getLineBreak(root, result)))
+					fix = fixWith(() => fixBeforeForAlways(valueNode, openingIndex, getLineBreak(syntax, root, result)))
 					complain(messages.expectedOpeningMultiLine, openingIndex)
 				}
 
@@ -330,12 +330,12 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 				// Check closing ...
 				if (primary === `always` && !LINE_BREAK.test(checkAfter)) {
-					fix = fixWith(() => fixAfterForAlways(valueNode, getLineBreak(root, result)))
+					fix = fixWith(() => fixAfterForAlways(valueNode, getLineBreak(syntax, root, result)))
 					complain(messages.expectedClosing, closingIndex)
 				}
 
 				if (isMultiLine && primary === `always-multi-line` && !LINE_BREAK.test(checkAfter)) {
-					fix = fixWith(() => fixAfterForAlways(valueNode, getLineBreak(root, result)))
+					fix = fixWith(() => fixAfterForAlways(valueNode, getLineBreak(syntax, root, result)))
 					complain(messages.expectedClosingMultiLine, closingIndex)
 				}
 

--- a/lib/rules/media-query-list-comma-newline-after/index.ts
+++ b/lib/rules/media-query-list-comma-newline-after/index.ts
@@ -80,7 +80,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					let afterComma = params.slice(index + 1)
 
 					// Trim up to the break that already stands there, whichever character it is, and add one only where none does
-					if (primary.startsWith(`always`)) params = OPENS_WITH_LINE_BREAK.test(afterComma) ? beforeComma + afterComma.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``) : beforeComma + getLineBreak(root, result) + afterComma
+					if (primary.startsWith(`always`)) params = OPENS_WITH_LINE_BREAK.test(afterComma) ? beforeComma + afterComma.replace(LEADING_WHITESPACE_WITHOUT_BREAK, ``) : beforeComma + getLineBreak(syntax, root, result) + afterComma
 					else if (primary.startsWith(`never`)) params = beforeComma + afterComma.replace(LEADING_WHITESPACE, ``)
 				}
 

--- a/lib/rules/no-missing-end-of-source-newline/index.ts
+++ b/lib/rules/no-missing-end-of-source-newline/index.ts
@@ -26,11 +26,12 @@ export let meta = {
  * @param scope - What the namespace the rule is registered under hands it.
  * @param scope.ruleName - The name a configuration refers to the rule by.
  * @param scope.messages - The messages, each closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option, which is `true`.
  * @param _secondaryOptions - The secondary options, of which this rule takes none.
  * @returns The check, run over every stylesheet the rule is configured for.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true, _secondaryOptions: unknown): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: true, _secondaryOptions: unknown): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(result, ruleName, { actual: primary })
 
@@ -67,7 +68,7 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: true
 				let endsTheLine = TRAILING_LINE_BREAK.test(ended) && TRAILING_LINE_BREAK.test(endedInFile)
 
 				// The file is closed with the break a written one is spelled with: as `linebreaks` asks, or as the file spells its lines
-				root.raws.after = endsTheLine ? ended : after + getLineBreak(root, result)
+				root.raws.after = endsTheLine ? ended : after + getLineBreak(syntax, root, result)
 			},
 		})
 	}

--- a/lib/rules/selector-list-comma-newline-after/index.ts
+++ b/lib/rules/selector-list-comma-newline-after/index.ts
@@ -106,7 +106,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					let beforeSelector = fixedSelector.slice(0, index)
 					let afterSelector = fixedSelector.slice(index)
 
-					if (primary.startsWith(`always`)) afterSelector = getLineBreak(root, result) + afterSelector
+					if (primary.startsWith(`always`)) afterSelector = getLineBreak(syntax, root, result) + afterSelector
 					else if (primary.startsWith(`never-multi-line`)) afterSelector = afterSelector.replace(LEADING_WHITESPACE, ``)
 
 					fixedSelector = beforeSelector + afterSelector

--- a/lib/rules/selector-list-comma-newline-before/index.ts
+++ b/lib/rules/selector-list-comma-newline-before/index.ts
@@ -86,7 +86,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					if (primary.startsWith(`always`)) {
 						let spaceIndex = beforeSelector.search(TRAILING_SPACES_AND_TABS)
 
-						beforeSelector = spaceIndex >= 0 ? beforeSelector.slice(0, spaceIndex) + getLineBreak(root, result) + beforeSelector.slice(spaceIndex) : beforeSelector + getLineBreak(root, result)
+						beforeSelector = spaceIndex >= 0 ? beforeSelector.slice(0, spaceIndex) + getLineBreak(syntax, root, result) + beforeSelector.slice(spaceIndex) : beforeSelector + getLineBreak(syntax, root, result)
 					}
 					else if (primary === `never-multi-line`) beforeSelector = beforeSelector.replace(TRAILING_WHITESPACE, ``)
 

--- a/lib/rules/value-list-comma-newline-after/index.ts
+++ b/lib/rules/value-list-comma-newline-after/index.ts
@@ -85,7 +85,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					let beforeValue = value.slice(0, valueIndex + 1)
 					let afterValue = value.slice(valueIndex + 1)
 
-					if (primary.startsWith(`always`)) afterValue = getLineBreak(root, result) + afterValue
+					if (primary.startsWith(`always`)) afterValue = getLineBreak(syntax, root, result) + afterValue
 					else if (primary.startsWith(`never-multi-line`)) afterValue = afterValue.replace(LEADING_WHITESPACE, ``)
 
 					syntax.write(decl, beforeValue + afterValue)

--- a/lib/syntaxes/less/rules/linebreaks/integration.test.ts
+++ b/lib/syntaxes/less/rules/linebreaks/integration.test.ts
@@ -1,0 +1,46 @@
+import { createRule as createWriter } from "../../../../rules/declaration-block-semicolon-newline-before/index.ts"
+import { createRule } from "../../../../rules/linebreaks/index.ts"
+import { less } from "../../index.ts"
+
+let { ruleName, messages } = createRule(less)
+let { ruleName: writerRuleName, messages: writerMessages } = createWriter(less)
+
+// A break another rule writes is the one `linebreaks` asks for, and that setting is read under the namespace's own name: listed ahead of the writer, as the library lists the rule a block names ahead of its extra rules, `linebreaks` used to be looked up under the core's name alone, never found, and the writer fell back on the break the file spells (#478).
+let testRule = createTestRule({ ruleName, autoStripIndent: false, customSyntax: `postcss-less`, extraRules: { [writerRuleName]: `always` } })
+
+testRule({
+	ruleName,
+	config: [`windows`],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/478
+			description: `a file of line feeds asked for Windows pairs, whose written break in front of the semicolon is a pair like the respelled ones`,
+			code: `a {\n\tb: c;\n}`,
+			fixed: `a {\r\n\tb: c\r\n;\r\n}`,
+			warnings: [
+				{
+					line: 1,
+					column: 4,
+					endLine: 1,
+					endColumn: 5,
+					message: messages.expected(`windows`),
+				},
+				{
+					line: 2,
+					column: 7,
+					endLine: 2,
+					endColumn: 8,
+					message: messages.expected(`windows`),
+				},
+				{
+					line: 2,
+					column: 5,
+					endLine: 2,
+					endColumn: 6,
+					message: writerMessages.expectedBefore(),
+				},
+			],
+		},
+	],
+})

--- a/lib/syntaxes/scss/rules/linebreaks/integration.test.ts
+++ b/lib/syntaxes/scss/rules/linebreaks/integration.test.ts
@@ -1,0 +1,46 @@
+import { createRule as createWriter } from "../../../../rules/declaration-block-semicolon-newline-before/index.ts"
+import { createRule } from "../../../../rules/linebreaks/index.ts"
+import { scss } from "../../index.ts"
+
+let { ruleName, messages } = createRule(scss)
+let { ruleName: writerRuleName, messages: writerMessages } = createWriter(scss)
+
+// A break another rule writes is the one `linebreaks` asks for, and that setting is read under the namespace's own name: listed ahead of the writer, as the library lists the rule a block names ahead of its extra rules, `linebreaks` used to be looked up under the core's name alone, never found, and the writer fell back on the break the file spells (#478).
+let testRule = createTestRule({ ruleName, autoStripIndent: false, customSyntax: `postcss-scss`, extraRules: { [writerRuleName]: `always` } })
+
+testRule({
+	ruleName,
+	config: [`windows`],
+
+	reject: [
+		{
+			// https://github.com/stylelint-stylistic/stylelint-stylistic/issues/478
+			description: `a file of line feeds asked for Windows pairs, whose written break in front of the semicolon is a pair like the respelled ones`,
+			code: `a {\n\tb: c;\n}`,
+			fixed: `a {\r\n\tb: c\r\n;\r\n}`,
+			warnings: [
+				{
+					line: 1,
+					column: 4,
+					endLine: 1,
+					endColumn: 5,
+					message: messages.expected(`windows`),
+				},
+				{
+					line: 2,
+					column: 7,
+					endLine: 2,
+					endColumn: 8,
+					message: messages.expected(`windows`),
+				},
+				{
+					line: 2,
+					column: 5,
+					endLine: 2,
+					endColumn: 6,
+					message: writerMessages.expectedBefore(),
+				},
+			],
+		},
+	],
+})

--- a/lib/utils/addEmptyLineAfter/index.test.ts
+++ b/lib/utils/addEmptyLineAfter/index.test.ts
@@ -2,6 +2,8 @@ import { parse, type Rule } from "postcss"
 import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { css as syntax } from "../../syntaxes/css/index.ts"
+
 import { addEmptyLineAfter } from "./index.ts"
 
 describe(`addEmptyLineAfter`, () => {
@@ -97,7 +99,7 @@ describe(`addEmptyLineAfter`, () => {
 function run (css: string, index: number = 0, rules: Record<string, unknown> = {}): string {
 	let root = parse(css)
 
-	addEmptyLineAfter(root.nodes[index] as Rule, { stylelint: { config: { rules } } } as unknown as PostcssResult)
+	addEmptyLineAfter(syntax, root.nodes[index] as Rule, { stylelint: { config: { rules } } } as unknown as PostcssResult)
 
 	return root.toString()
 }

--- a/lib/utils/addEmptyLineAfter/index.ts
+++ b/lib/utils/addEmptyLineAfter/index.ts
@@ -2,6 +2,7 @@ import type { AtRule, Rule } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 import { CAPTURED_LINE_BREAK, LINE_BREAK } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
 import { getBlockAfter } from "../getBlockAfter/index.ts"
 import { getLineBreak } from "../getLineBreak/index.ts"
 import { setBlockAfter } from "../setBlockAfter/index.ts"
@@ -10,11 +11,12 @@ import { setBlockAfter } from "../setBlockAfter/index.ts"
  * Adds an empty line after a node. Mutates the node.
  *
  * The line is written into the block's final raw, which {@link getBlockAfter} and `setBlockAfter` find wherever the parser filed it — inside the node closing the block, where that node has swallowed it.
+ * @param syntax - The syntax the rule is built over, whose namespace names the `linebreaks` rule the break is read from.
  * @param node - The PostCSS node to modify.
  * @param result - The Stylelint result, which holds the configuration the break to write is read from.
  * @returns The modified node.
  */
-export function addEmptyLineAfter<T extends Rule | AtRule> (node: T, result: PostcssResult): T {
+export function addEmptyLineAfter<T extends Rule | AtRule> (syntax: Syntax, node: T, result: PostcssResult): T {
 	let blockAfter = getBlockAfter(node)
 
 	if (typeof blockAfter !== `string`) return node
@@ -31,7 +33,7 @@ export function addEmptyLineAfter<T extends Rule | AtRule> (node: T, result: Pos
 	}
 
 	// Nothing stands there to write twice, so the empty line is spelled the way a written break is: as `linebreaks` asks, or as the file spells its lines
-	setBlockAfter(node, blockAfter + getLineBreak(node, result).repeat(2))
+	setBlockAfter(node, blockAfter + getLineBreak(syntax, node, result).repeat(2))
 
 	return node
 }

--- a/lib/utils/getLineBreak/index.test.ts
+++ b/lib/utils/getLineBreak/index.test.ts
@@ -2,7 +2,13 @@ import { parse, type Rule, rule } from "postcss"
 import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
+import { css } from "../../syntaxes/css/index.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
+
 import { getLineBreak } from "./index.ts"
+
+/** The core's syntax with a namespace of its own, which is all a reading of the configuration can tell a namespace's syntax apart by. */
+const SCSS: Syntax = { ...css, namespace: `scss` }
 
 describe(`getLineBreak`, () => {
 	it(`the linebreaks rule, whose setting wins over whatever the file spells its lines with`, () => {
@@ -13,6 +19,13 @@ describe(`getLineBreak`, () => {
 	it(`the same setting given with the array a configuration lists a rule's options in`, () => {
 		expect(ask(`a {}\nb {}`, { "@stylistic/linebreaks": [`windows`] })).toBe(`\r\n`)
 		expect(ask(`a {}\r\nb {}`, { "@stylistic/linebreaks": [`unix`, {}] })).toBe(`\n`)
+	})
+
+	it(`the rule under the asking rule's own namespace, and not under the core's name, which refuses the file the namespace reads`, () => {
+		expect(ask(`a {}\nb {}`, { "@stylistic/scss/linebreaks": `windows` }, SCSS)).toBe(`\r\n`)
+		expect(ask(`a {}\r\nb {}`, { "@stylistic/scss/linebreaks": [`unix`] }, SCSS)).toBe(`\n`)
+		expect(ask(`a {}\nb {}`, { "@stylistic/linebreaks": `windows` }, SCSS)).toBe(`\n`)
+		expect(ask(`a {}\nb {}`, { "@stylistic/scss/linebreaks": `windows` })).toBe(`\n`)
 	})
 
 	it(`the break the file ends its lines with, where the configuration lists no such rule`, () => {
@@ -30,7 +43,7 @@ describe(`getLineBreak`, () => {
 	})
 
 	it(`a line feed for a node standing in no file at all`, () => {
-		expect(getLineBreak(rule({ selector: `a` }), result())).toBe(`\n`)
+		expect(getLineBreak(css, rule({ selector: `a` }), result())).toBe(`\n`)
 	})
 
 	it(`a bare carriage return or a form feed, which is whitespace and no break, so that the file ends no line on it`, () => {
@@ -42,14 +55,15 @@ describe(`getLineBreak`, () => {
 
 /**
  * Reads the break a fix would write into a stylesheet.
- * @param css - The stylesheet.
+ * @param code - The stylesheet.
  * @param rules - The rules the configuration lists.
+ * @param syntax - The syntax the asking rule is built over.
  * @returns The break.
  */
-function ask (css: string, rules: Record<string, unknown> = {}): string {
-	let root = parse(css)
+function ask (code: string, rules: Record<string, unknown> = {}, syntax: Syntax = css): string {
+	let root = parse(code)
 
-	return getLineBreak(root.first as Rule, result(rules))
+	return getLineBreak(syntax, root.first as Rule, result(rules))
 }
 
 /**

--- a/lib/utils/getLineBreak/index.ts
+++ b/lib/utils/getLineBreak/index.ts
@@ -2,9 +2,11 @@ import type { Input, Node } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 import { CAPTURED_LINE_BREAK } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
+import { addNamespace } from "../addNamespace/index.ts"
 
-/** The setting of the one rule about the spelling of a break, under the name a configuration lists it by. */
-const LINEBREAKS_RULE = `@stylistic/linebreaks`
+/** The one rule about the spelling of a break, under the name its directory spells; a configuration lists it under the namespace of the family that reads the file. */
+const LINEBREAKS_RULE = `linebreaks`
 
 /** The break each of that rule's options asks for. */
 const BREAK_OF_OPTION = { unix: `\n`, windows: `\r\n` }
@@ -39,13 +41,14 @@ function lineBreakOfFile (node: Node): string | undefined {
  *
  * Three answers, in order: the one `linebreaks` asks for, where the configuration lists that rule, since a break another rule writes is a break `linebreaks` would otherwise have to respell — and Stylelint runs each rule once and in the order the configuration spells them, so written the other way it never would (#352); the one the file spells its lines with, where it spells any; and a line feed. Never the line ending of the machine, which `context.newline` falls back on: a stylesheet is written for the file it stands in and not for the machine it happens to be linted on.
  *
- * The setting is read out of `result.stylelint.config`, which holds every rule's normalised settings and is assigned before any rule runs, so the answer is the same wherever a break is written.
+ * The setting is read out of `result.stylelint.config`, which holds every rule's normalised settings and is assigned before any rule runs, so the answer is the same wherever a break is written. It is read under the name of the namespace the asking rule is registered under — `@stylistic/scss/linebreaks` for a rule of the scss family — since the configuration of a file lists the core's names and a namespace's alike, and the family that reads the file is the one the rule belongs to; read under the core's name alone, the setting was never found under a namespace, and the break fell back on the file's (#478).
+ * @param syntax - The syntax the asking rule is built over, whose namespace names the `linebreaks` rule.
  * @param node - A node of the file the break is written into.
  * @param result - The Stylelint result, which holds the configuration.
  * @returns The break to write.
  */
-export function getLineBreak (node: Node, result: PostcssResult): string {
-	let setting = result.stylelint?.config?.rules?.[LINEBREAKS_RULE]
+export function getLineBreak (syntax: Syntax, node: Node, result: PostcssResult): string {
+	let setting = result.stylelint?.config?.rules?.[addNamespace(LINEBREAKS_RULE, syntax.namespace)]
 	let option = Array.isArray(setting) ? setting[0] : setting
 
 	if (typeof option === `string` && option in BREAK_OF_OPTION) return BREAK_OF_OPTION[(option as keyof typeof BREAK_OF_OPTION)]

--- a/lib/utils/whitespaceBeforeSemicolon/index.ts
+++ b/lib/utils/whitespaceBeforeSemicolon/index.ts
@@ -88,7 +88,7 @@ export function whitespaceBeforeSemicolon (syntax: Syntax, decl: Declaration, re
 		asked = option.startsWith(`always`) ? kind : undefined
 	}
 
-	if (asked === `newline`) return getLineBreak(decl, result)
+	if (asked === `newline`) return getLineBreak(syntax, decl, result)
 
 	return asked === `space` ? ` ` : ``
 }


### PR DESCRIPTION
`getLineBreak` read the `linebreaks` setting under the core's name alone, `@stylistic/linebreaks`. A file linted under a namespace lists that rule as `@stylistic/scss/linebreaks`, `@stylistic/less/linebreaks` or `@stylistic/styled/linebreaks`, so under a namespace the setting was never found, the writer fell back on the break the file spells, and the shape of #352 was back under the names the split brought — #352 itself stays closed. Fixture `a {\n  b: c;\n}\n` under `postcss-scss` on `fcee8b1`:

```
@stylistic/scss/linebreaks: windows first -> "a {\r\n  b: c\n;\r\n}\r\n"    a line feed among the pairs, respelled on the next run
the writer first                          -> "a {\r\n  b: c\r\n;\r\n}\r\n"  nothing left
```

The same under `postcss-less` with the `@stylistic/less/` names, and under `postcss-styled-syntax` over four writers of a break.

`getLineBreak` takes the syntax the asking rule is built over and reads the setting under `addNamespace("linebreaks", syntax.namespace)`, as `whitespaceBeforeSemicolon` reads its two rules (#354). Every caller hands the syntax over — the eighteen rules that write a break, `addEmptyLineAfter` with its one caller, `whitespaceBeforeSemicolon` — and three rules that had not taken `syntax` out of their scope take it now. The break of the file and the line feed behind it are read as before, and under the core's names nothing changes. No changelog entry: the split is unreleased, and the entry of #352 already says what ships.

## What the review turned up

- **Two counts in the prose were off**, neither in the code: the spec and the commit message counted eighteen rules calling `getLineBreak` where sixteen do and `block-closing-brace-empty-line-before` reaches it through `addEmptyLineAfter`, and the styled probe was said to come back as a file of Windows pairs while the host's line feed behind the closing backtick rightly stays. Both corrected.
- **Nothing found in the code**: 17 writers × three families and 6 under styled, `linebreaks` ahead and behind, one output either way and nothing on a second run; the core rows byte-identical to the base; the realistic `overrides` shape — core names in the main block, namespace names beside `customSyntax` — one file of pairs in either order.

- **Nothing else moved.** `make verify`; `make oracles` against `origin/main` — all six with no row added, removed or changed, `pairs` reading its corpus as CSS and the other five running one rule per configuration. The two integration tests — the namespace's `linebreaks` listed ahead of its `declaration-block-semicolon-newline-before` — fail over a checkout of the base and pass here. No test under the styled namespace, which holds `indentation` alone and is slated to go; the shape was measured there by probe and is covered by the same change.
- **Two rounds in all**; the second came back clean, with one wording nit taken.
- **One neighbour filed, not fixed here.** [#481](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/481) — the `max-empty-lines` fix takes no empty line off in front of a closing brace and the warnings go with it; the review met it while probing the namespaces, and it stands on the base the same.

Closes #478.
