### PR TITLE
Check the commit in a copy of it, and leave the working tree alone

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,9 +2,12 @@
 
 set -e
 
-export PATH="./node_modules/.bin:$PATH"
+root=$(git rev-parse --show-toplevel)
 
-# A rebase, a merge, a cherry-pick or a revert owns the working tree while it runs, and a stash taken under one of them can leave the operation with no way to finish. What such a commit carries has been checked once already, on its way in, and the branch is checked again when the work lands.
+# The checks run from a copy of the commit parked elsewhere on disk, so the path has to be absolute. What it points at is this worktree's own packages: the shims pnpm writes into `.bin` carry absolute paths of their own, the pinned Node among them.
+export PATH="$root/node_modules/.bin:$PATH"
+
+# A rebase, a merge, a cherry-pick or a revert owns the index while it runs, and an unmerged entry is nothing to write out. What such a commit carries has been checked once already, on its way in, and the branch is checked again when the work lands.
 for marker in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
 	if [ -e "$(git rev-parse --git-dir)/$marker" ]
 	then exit 0
@@ -18,27 +21,37 @@ fi
 
 git diff-index --check --cached "$against" --
 
-# With an empty index there is nothing to check, and `git stash -ku` would take the whole working tree away instead of the part being committed — the very thing the stash is here to keep out of the way. A `git commit --amend` that only rewords a message arrives exactly like this.
+# With an empty index there is nothing to check. A `git commit --amend` that only rewords a message arrives exactly like this.
 if git diff-index --cached --quiet "$against" --
 then exit 0
 fi
 
-stash_before=$(git rev-parse -q --verify refs/stash || true)
+# Git looks for renames of its own accord, so a renamed file arrives under `R` and would otherwise be neither linted nor tested. `core.quotePath` would spell a name outside ASCII escaped and in quotes, which is no path any more.
+changed_files=$(git -c core.quotePath=false diff --cached --name-only --diff-filter=ACMR | grep -E '\.ts$') || true
 
-git stash -ku --quiet
-
-stash_after=$(git rev-parse -q --verify refs/stash || true)
-
-# There is nothing to stash when the commit takes the whole working tree, and popping all the same would take an unrelated entry off the stash.
-if [ "$stash_before" != "$stash_after" ]
-then trap "git stash pop --quiet" EXIT
-fi
-
-changed_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.ts$') || true
-
+# Nothing to check, and no copy to pay for.
 if [ -z "$changed_files" ]
 then exit 0
 fi
+
+# The checks read the commit rather than the working tree, and they read it from a copy of their own. So the working tree is never moved: whatever becomes of this hook, a session's uncommitted work is out of its reach, and nothing at all is shared with the commit running in the next worktree. `git stash` used to do that job, and its stack is one per repository — two commits at once took each other's entries, which is [#518](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/518).
+work=$(mktemp -d)
+
+trap 'rm -rf "$work"' EXIT
+
+# Git hands a hook the very index the commit is being made from — `GIT_INDEX_FILE` names a temporary one where `git commit -a` or a commit over paths builds it — so what is written out is exactly what is about to be committed, and `-u`, which would write that index back, must never be passed. Tracked files alone: no untracked file, no `dist/`, nothing the commit does not carry. A test reading a document off disk therefore reads the committed edition of it.
+git checkout-index -a -f --ignore-skip-worktree-bits --prefix="$work/"
+
+# `.oxlintrc.json` extends its shared configuration by a path relative to itself, so the packages have to stand beside the copy. And the copy stands outside the repository because oxlint reads `.gitignore` and passes over every path under an ignored directory, `tmp/` among them, however explicitly the path is named.
+ln -s "$root/node_modules" "$work/node_modules"
+
+# The `overrides` of `.oxlintrc.json` name their files from the root of the repository, and the copy is that root.
+cd "$work"
+
+# What git prints is a path and never a pattern, and a path holding a space is one path all the same. Split it into pieces and neither check says a word: oxlint passes over a path that does not exist as long as one of the paths it was given does, and `vitest related` answers a list it cannot match with a run of no files, which is a pass. So a file would be committed unchecked while the hook reported success.
+set -f
+IFS='
+'
 
 oxlint $changed_files
 vitest related $changed_files


### PR DESCRIPTION
The `pre-commit` hook took the unstaged part of the working tree out of its own way with `git stash -ku` and put it back with a bare `git stash pop` from a trap. The stash stack is one per repository and shared by every worktree, so what a `pop` takes is whichever entry happens to stand on top of it; and because `-k` keeps the index, an entry is made even where the commit takes the whole working tree, so the window stands open on every commit for as long as the lint and the tests run:

```console
$ git status --short
M  a.txt                          # everything staged, the working tree holds nothing besides
$ git stash -ku --quiet
$ git stash list
stash@{0}: WIP on main: fcdb795 init
```

On 2026-09-02 two lanes met inside that window: the hook of one worktree popped the entry of another, whose files unpacked over the wrong branch — four in conflict, three of them as “deleted by us” — and the commit was aborted. Nothing was lost that time only because the other lane's commit had already landed; the other outcome loses a session's work.

The hook stashes nothing now and never moves the working tree. `git checkout-index` writes the index out into a directory `mktemp` makes, the packages are symlinked beside it, and `oxlint` and `vitest related` run from there — so an interrupt, a kill or a crash leaves a session's uncommitted work exactly where the session left it, and two worktrees committing at once share not so much as a file. What is written out is the index git hands the hook in `GIT_INDEX_FILE`, which is the lock of the real index under `git commit -a` and a `next-index-<pid>` under a commit naming paths, so those two shapes of commit are checked for what they carry rather than for what the disk holds. The copy stands outside the repository because oxlint reads `.gitignore` and lints nothing under an ignored directory, `tmp/` included, however explicitly a path is named. Three readings of the staged list move with it: a rename (`ACMR`), a name outside ASCII (`core.quotePath=false`), and a name holding a space (`set -f` with an `IFS` of one newline).

## What the review turned up

- **One defect, fixed in the branch.** `set -f` closed only the globbing half of the odd-path hazard: a staged path holding a space was still split on `IFS` into pieces naming nothing, and neither check says a word about that — oxlint passes over a path that does not exist as long as one of the paths it was given does, and `vitest related` answers a list it cannot match with a run of no files, which is a pass. Reproduced against the first commit of this branch: `lib/my file.ts` carrying a lint error, staged beside a clean path, was committed unchecked while the hook reported success. With the `IFS` of the fix the same file is reported and the commit refused.
- **Nothing else moved.** `make verify` is green (287 files, 9712 tests, 1 skipped). The copy answers what the worktree answers: `vitest related lib/utils/whitespaceChecker/index.ts` gives the same 118 files and 4820 tests from either root, and a seeded violation in the copy is reported through the shared configuration, so `extends`, `overrides` and the symlinked packages all resolve from there. Over a tree holding a staged change, an unstaged one and an untracked file, `git status`, `git stash list` and the mtime and size of every tracked file come out byte-identical across a run; two hooks run at once take two directories; an interrupt mid-run leaves no directory behind; a commit staging nothing written in TypeScript exits in 23 ms without making one.
- **The first remedy the issue names was weighed and not taken.** A `git stash push -m <tag>` with an `apply` by hash fixes the wrong-entry half, but `drop` addresses an entry by its position in the stack, which has to be found by the tag again — the window narrows and does not close, since the stack has no “drop this hash” at all. And an `EXIT` trap does not fire on a `SIGKILL`, so a killed hook still leaves the working tree without the session's changes while they live only in a stash entry.
- **lefthook was weighed as a replacement and rejected.** It hides only *partially* staged files (`PartiallyStagedFiles()` reads the `MM` rows of `git status --short`), so the checks would still read the working tree; it hides them with `git stash create` plus `git stash store --message "lefthook auto backup"` on the same shared stack, and with a patch at `<git rev-parse --git-path info>/lefthook-unstaged.patch`, which is the **common** `.git/info` for every worktree here — two concurrent commits over partially staged files overwrite each other's patch. Its cleanup drops every entry whose message matches, a neighbour's included, and a failed restore reverts the whole tree with `git checkout .` ([evilmartians/lefthook#1480](https://github.com/evilmartians/lefthook/issues/1480)). Their worktree bugs [#1398](https://github.com/evilmartians/lefthook/issues/1398), [#1077](https://github.com/evilmartians/lefthook/issues/1077) and [#1265](https://github.com/evilmartians/lefthook/issues/1265) are open.
- **A spin-off is filed.** [#528](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/528) asks for a `pre-push` hook running `make verify`, which the same rule about the working tree applies to.

Closes #518.
