### PR TITLE
Run `make verify` at the push, and remember the tree it answered for

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e
+
+root=$(git rev-parse --show-toplevel)
+
+cd "$root"
+
+export PATH="$root/node_modules/.bin:$PATH"
+
+# Git names every ref of the push on standard input, as `<local ref> <local sha> <remote ref> <remote sha>`, and calls the hook even where it has nothing to send at all — a push that answers `Everything up-to-date` arrives here with no line whatsoever, and a minute of checks for it would be a minute for nothing. A deletion arrives as `(delete)` and a local sha of zeros, and carries no state of the tree with it either.
+#
+# A tag is passed over only where every commit it reaches is on a remote already, which is what the release flow does and what makes the tag nothing new to check. A tag cut over commits no branch of the push carries is not: it sends those commits, and nothing would have checked them. The remote-tracking refs may be behind what the remote really holds, and that errs towards running the checks.
+refs_to_check=0
+
+while read -r local_ref local_sha remote_ref remote_sha
+do
+	case "$local_sha" in
+		*[!0]*) ;;
+		*) continue ;;
+	esac
+
+	case "$local_ref" in
+		refs/tags/*)
+			if [ -z "$(git rev-list -1 "$local_sha" --not --remotes)" ]
+			then continue
+			fi
+			;;
+	esac
+
+	refs_to_check=1
+done
+
+if [ "$refs_to_check" = 0 ]
+then exit 0
+fi
+
+# What answers for the push is the working tree, which is what `make verify` is about and where it is meant to run: the commits being pushed are on disk already, and there is nothing here to keep out of the way. Where the tree carries anything those commits do not, that is worth a word whichever way the hook goes — what came back green is then the tree rather than the branch CI will be asked about.
+if [ -n "$(git status --porcelain)" ]
+then printf '\n\t⚠️  The working tree carries what the commits being pushed do not, so what is answered for below is the tree rather than the branch.\n\n'
+fi
+
+# `make verify` answers about the tree and about nothing else, so a state of the tree it has already come back green over is not asked about twice: a run made by hand a moment before the push is the run this finds.
+if ./scripts/verified.ts check
+then exit 0
+fi
+
+if make verify
+then exit 0
+fi
+
+printf '\n\t❌ `make verify` did not pass, so the push is refused. Push all the same with `git push --no-verify` — spelled in full, since `-n` at a push is `--dry-run`.\n\n'
+
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ make lint FILE=lib/rules/color-hex-case
 
 Two targets collect results rather than check them: `make oracles` and `make sweep FILE=…`. Both keep every result by what it depends on, under `~/.cache/stylelint-stylistic/`, and measure only the side no entry answers for, so a run is seconds and a rerun over an unchanged tree is nothing; run them freely, before a branch and after it, and read the diff they write.
 
-CI (`.github/workflows/test.yaml`) runs `pnpm ci` and then `make verify` — run `make verify` locally before pushing. The release workflow (`.github/workflows/release.yaml`) runs `pnpm ci` and then `make release` on pushes to `release` and `release-*`. The `pre-commit` hook lints the staged `.ts` files and runs, in one pass of `vitest related`, whatever test imports one of them — so a util is answered for by the rules that use it rather than by the directory it sits in.
+CI (`.github/workflows/test.yaml`) runs `pnpm ci` and then `make verify`, which the `pre-push` hook runs too, refusing a push that does not pass it and skipping the run where a green one over this very state of the tree is remembered, so proving the branch by hand a moment earlier costs nothing at the push. The release workflow (`.github/workflows/release.yaml`) runs `pnpm ci` and then `make release` on pushes to `release` and `release-*`. The `pre-commit` hook lints the staged `.ts` files and runs, in one pass of `vitest related`, whatever test imports one of them — so a util is answered for by the rules that use it rather than by the directory it sits in.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,11 @@ packages-check: build ## 📦 Check that the built plugin needs none of the synt
 	./scripts/check-optional-packages.ts
 .PHONY: packages-check
 
-verify: check lint test prose-check breaks-check build packages-check ## ✅ Run every check the CI runs
+verify: ## ✅ Run every check the CI runs
+	@test -z "$(FILE)$(LINT_FLAGS)$(TEST_FLAGS)" || { printf "\t❌ $(ANSI_BOLD)verify runs every check over the whole tree, and takes no FILE, LINT_FLAGS or TEST_FLAGS$(ANSI_RESET)\n\n"; exit 2; }
+	tree=$$(./scripts/verified.ts tree)
+	$(MAKE) --no-print-directory check lint test prose-check breaks-check build packages-check
+	./scripts/verified.ts record $$tree
 .PHONY: verify
 
 release: verify build ## 🚀 Release a new version

--- a/scripts/harness/cache.ts
+++ b/scripts/harness/cache.ts
@@ -11,7 +11,7 @@ import { createHash } from "node:crypto"
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
-import { env } from "node:process"
+import { env, pid } from "node:process"
 
 import { ROOT } from "./checkout.ts"
 
@@ -21,8 +21,8 @@ const CACHE_DIR = env.STYLISTIC_CACHE ?? path.join(homedir(), `.cache`, `styleli
 /** The mode a written result is left in: readable by everyone, writable by no one. */
 const READ_ONLY = 0o444
 
-/** The index the working tree is hashed through, so that the real one is never touched. */
-const SCRATCH_INDEX = path.join(ROOT, `tmp`, `harness-index`)
+/** The index the working tree is hashed through, so that the real one is never touched; it is named by the process, since two runs asking for the hash at once would otherwise write over each other's. */
+const SCRATCH_INDEX = path.join(ROOT, `tmp`, `harness-index-${pid}`)
 
 /**
  * Runs Git in the repository and hands back what it printed.
@@ -51,10 +51,15 @@ function treeOf (revision: string): string {
 
 		let indexEnv = { GIT_INDEX_FILE: SCRATCH_INDEX }
 
-		git([`read-tree`, `HEAD`], indexEnv)
-		git([`add`, `-A`, `--`, `.`], indexEnv)
-		worktreeTree = git([`write-tree`], indexEnv)
-		rmSync(SCRATCH_INDEX, { force: true })
+		try {
+			git([`read-tree`, `HEAD`], indexEnv)
+			git([`add`, `-A`, `--`, `.`], indexEnv)
+			worktreeTree = git([`write-tree`], indexEnv)
+		}
+		finally {
+			// A name of its own is a file of its own, and a throw between the three calls would leave it standing where the one name every run shared was written over by the next
+			rmSync(SCRATCH_INDEX, { force: true })
+		}
 	}
 
 	return worktreeTree

--- a/scripts/verified.ts
+++ b/scripts/verified.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * Remembers the state of the tree `make verify` came back green over, and answers whether it has come back green over this one.
+ *
+ * A run is a minute, and it answers about the tree and about nothing else, so a state already answered for is not asked about twice: `make verify` records here on its way out and the `pre-push` hook asks here first, so a run made by hand a moment before the push is the run the hook finds. A record is a file named by the hash of the tree, under the store the oracles keep their results in — outside every working tree, so a rebase that lands the same tree in another worktree finds it too.
+ *
+ * The hash is taken twice, which is what `tree` is for: once before the checks start and once as they finish. A session goes on editing while a run of a minute goes by, and a record written from the tree as it stands at the end would name a state no check ever read. Where the two hashes differ nothing is recorded at all, since the checks then read neither state whole.
+ *
+ * `tree` prints the hash, `record <hash>` writes a record where the tree still stands at that hash, and `check` exits 0 where a record stands and 1 where none does.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { argv, exit, stderr, stdout } from "node:process"
+
+import { CACHE_DIR, treeOf } from "./harness/cache.ts"
+
+let mode = argv[2]
+
+if (mode !== `tree` && mode !== `record` && mode !== `check`) {
+	stderr.write(`\t❌ ${argv[1]} takes one of \`tree\`, \`record <hash>\` and \`check\`\n`)
+	exit(2)
+}
+
+let tree = treeOf(`worktree`)
+let file = path.join(CACHE_DIR, `verified`, `trees`, `${tree}.json`)
+
+if (mode === `tree`) {
+	stdout.write(`${tree}\n`)
+}
+else if (mode === `record`) {
+	let opened = argv[3]
+
+	if (!opened) {
+		stderr.write(`\t❌ ${argv[1]} record takes the hash the run opened on\n`)
+		exit(2)
+	}
+
+	if (opened === tree) {
+		mkdirSync(path.dirname(file), { recursive: true })
+		writeFileSync(file, `${JSON.stringify({ tree, verifiedAt: new Date().toISOString() }, null, `\t`)}\n`)
+		stdout.write(`\t🔖 the tree ${tree.slice(0, 8)} is answered for\n`)
+	}
+	else {
+		stdout.write(`\t🔖 the tree moved while the checks ran, from ${opened.slice(0, 8)} to ${tree.slice(0, 8)}, and neither state is recorded\n`)
+	}
+}
+else if (existsSync(file)) {
+	stdout.write(`\t🔖 \`make verify\` came back green over the tree ${tree.slice(0, 8)} already\n`)
+}
+else {
+	exit(1)
+}


### PR DESCRIPTION
`make verify` is what CI runs and what [AGENTS.md](https://github.com/stylelint-stylistic/stylelint-stylistic/blob/main/AGENTS.md) asked for before a push, and nothing but the author's memory stood between a branch and a red CI run: a commit green on its own still leaves `tsc`, the whole suite, the prose check, the break check, the build or the package check red, and that was found minutes later, in CI, by whoever opened the pull request. A `pre-push` hook runs it now and refuses a push that does not pass it. What answers for the push is the working tree, which is what `make verify` is about and where it is meant to run — the commits being pushed are on disk already, so nothing has to be kept out of the way and the rule [#518](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/518) settled holds of its own accord.

The pushes that have nothing for it to say were read off git rather than guessed at — a scratch repository whose hook prints what it is given:

```console
$ git push origin main               # something to send
[refs/heads/main] [94ad1fe…] [refs/heads/main] [000…0]
$ git push origin main               # Everything up-to-date: called all the same, with no line at all
$ git push origin v1                 # a tag
[refs/tags/v1] [7680060…] [refs/tags/v1] [000…0]
$ git push origin :refs/heads/main   # a deletion
[(delete)] [000…0] [refs/heads/main] [94ad1fe…]
```

A run is a minute and it answers about the tree and about nothing else, so a state of the tree already answered for is not asked about twice: `make verify` records the hash of the tree and the hook asks for it first, so a run made by hand a moment before the push is the run it finds. That is what makes it a hook to keep rather than one to bypass. The hash is taken twice — before the checks and as they finish — and a record is written only where the two agree, since a session goes on editing while a minute goes by and a record taken at the end would name a state no check ever read. The record stands in the store the oracles already keep results in, outside every working tree, so the same tree landing in another worktree by a rebase finds it too, and an amend that touches no file keeps the answer.

## What the review turned up

- **Five findings, every one fixed in the branch.**
	- **The record could name a tree nothing had checked.** `record` hashed the tree as the last check finished, so an edit made while the run went by was stamped as verified and the next push was let through over content no check had read — the very failure the feature exists to prevent. The hash is taken before the run too, and where the two differ neither state is recorded.
	- **The warning about a dirty tree stood below the question about the record**, so on the commonest path — the record hits, the hook exits — it never fired at all. It now stands above it, and the wording answers for both paths.
	- **`make verify FILE=…` stamped the whole tree.** `lint` and `test` take `FILE`, `LINT_FLAGS` and `TEST_FLAGS`, and AGENTS.md advertises them, so a narrowed run recorded a tree whose suite was never run. `verify` refuses to start under any of the three now — which, with the pair of hashes above, is what turned it from a list of prerequisites into a recipe that takes the hash, runs the checks through `$(MAKE)` and records.
	- **The pid-named scratch index leaked on a throw.** The old shared name was written over by the next run; a name of its own is a file of its own, so the three git calls are wrapped and the file goes with the throw.
	- **The tag skip rested on an assumption git does not make.** A tag cut over commits no branch of the push carries sends those commits, and nothing would have checked them. A tag is passed over only where `git rev-list -1 <sha> --not --remotes` is empty; the remote-tracking refs may be behind what the remote really holds, and that errs towards running the checks.
- **Nothing else moved.** `make verify` is green, and its own shape is unchanged for every caller: CI runs it as it did, `release` still has it as a prerequisite. The runs: a push with no ref lines, one deleting a ref and one carrying a tag whose commit is on a remote each exit without starting `make`; a tag over a commit no remote holds does not, nor does a tag beside a branch; a real ref with the record standing prints one line and exits, and the same under a `GIT_DIR` set as a push sets it; a real ref with no record runs every check and leaves a record behind; a lint error in the tree refuses the push with the bypass spelled out, exit 1; `record` over a hash the tree has moved away from writes nothing and says so; `make verify FILE=…` and `make verify TEST_FLAGS=…` refuse to start; `make cache-gc` walks the store with those records in it and comes back as it did. This very pull request was pushed through the hook.
- **Two things are known and left as they are.** A record is a hundred bytes named by a tree hash and nothing collects it: `make cache-gc` prunes by the `lib/` trees a ref reaches, which is a different key space, and it neither trips over the new directory nor empties it. And the tag rule reads the remote-tracking refs as they last stood, which is the conservative side of stale.

Closes #528.
