### PR TITLE
Let a rule refuse an option under the runner

### DIFF
--- a/lib/utils/defersToRunEnd/index.test.ts
+++ b/lib/utils/defersToRunEnd/index.test.ts
@@ -186,7 +186,7 @@ describe(`linenessRank`, () => {
 })
 
 describe(`LINENESS_RULES`, () => {
-	// The plugin itself is asked which rules take a primary conditioned on lineness, so that a rule gaining or losing one is caught here rather than left to fall to the table's default. The question is put to the linter rather than to the runner of the oracles — a file name is what asks for it — since `validateOptions` hands back `true` wherever `result.stylelint.config.validate` is unset, which the runner's configuration leaves out, so no rule refuses an option there
+	// The plugin itself is asked which rules take a primary conditioned on lineness, so that a rule gaining or losing one is caught here rather than left to fall to the table's default. A rule refusing its option is what the answer is read off, and the runner of the oracles answers that as the linter does, since its configuration carries the `validate` flag `validateOptions` opens by reading
 	let plugin = new URL(`../../index.ts`, import.meta.url).pathname
 	let linenessPrimaries = [`always-single-line`, `never-single-line`, `always-multi-line`, `never-multi-line`]
 
@@ -196,7 +196,7 @@ describe(`LINENESS_RULES`, () => {
 		for (let shortName of Object.keys(registry)) {
 			for (let primary of linenessPrimaries) {
 				// eslint-disable-next-line no-await-in-loop
-				let { results } = await stylelint.lint({ code: `a { color: pink; }\n`, codeFilename: `probe.css`, config: { plugins: [plugin], rules: { [`@stylistic/${shortName}`]: primary } } })
+				let { results } = await stylelint.lint({ code: `a { color: pink; }\n`, config: { plugins: [plugin], rules: { [`@stylistic/${shortName}`]: primary } } })
 
 				if (results[0]?.invalidOptionWarnings.length === 0) {
 					taking.push(shortName)

--- a/scripts/harness/lint.test.ts
+++ b/scripts/harness/lint.test.ts
@@ -1,0 +1,88 @@
+import stylelint from "stylelint"
+import { assert, describe, expect, it } from "vitest"
+
+import rules from "../../lib/rules/index.ts"
+import { css } from "../../lib/syntaxes/css/index.ts"
+import { namespaces } from "../../lib/syntaxes/index.ts"
+import { RULE_OPTIONS } from "../oracles/options.ts"
+
+import { buildRegistry, lint, lintDirect } from "./lint.ts"
+
+/** The rules under the names a configuration spells them with, built the way `vitest.setup.ts` builds the registry the suite is linted through. */
+const REGISTRY = buildRegistry(rules, [css, ...namespaces])
+
+/** The plugin as a configuration names it, which is the path `vitest.setup.ts` hands the testing library. */
+const PLUGIN = new URL(`../../lib/index.ts`, import.meta.url).pathname
+
+/** A stylesheet the three rules of the cases below have nothing to say about, so that a warning could only be one the option should have stopped. The case putting the whole option list over it reads the objections alone, and seventeen of those rules do warn about it. */
+const CODE = `a {\n\tcolor: pink;\n}\n`
+
+/** The same stylesheet with a space at the end of its second line, which `no-eol-whitespace` takes away wherever it runs at all — so that a rewrite is what shows the fix pass ran. The space is written inside a one-line literal, where no editor trims it. */
+const CODE_WITH_TRAILING_SPACE = `a {\n\tcolor: pink; \n}\n`
+
+// #540: the configuration the runner assembled carried no `validate` flag, and `stylelint.utils.validateOptions` opens by reading one — so it handed back `true` for every option of every rule, and every `if (!validOptions) return` of `lib/rules/` was dead
+describe(`a primary option the rule does not take`, () => {
+	it(`is refused in the words the linter refuses it with`, async () => {
+		let answer = await lintDirect({ code: CODE, rules: [[`max-empty-lines`, `abc`]], registry: REGISTRY })
+
+		assert(!answer.unparsable)
+		expect(answer.invalidOptions).toStrictEqual([`Invalid option "abc" for rule "@stylistic/max-empty-lines"`])
+		expect(answer.warnings).toHaveLength(0)
+	})
+
+	it(`is refused on the fix pass as much as on the check, so that the rule writes nothing`, async () => {
+		let answer = await lintDirect({ code: CODE_WITH_TRAILING_SPACE, rules: [[`no-eol-whitespace`, `abc`]], registry: REGISTRY, fix: true })
+		// The same text under the option the rule does take, so that the case cannot pass by standing over a fixture there was nothing to write into
+		let taken = await lintDirect({ code: CODE_WITH_TRAILING_SPACE, rules: [[`no-eol-whitespace`, true]], registry: REGISTRY, fix: true })
+
+		assert(!answer.unparsable)
+		assert(!taken.unparsable)
+		expect(answer.invalidOptions).toHaveLength(1)
+		expect(answer.code).toBe(CODE_WITH_TRAILING_SPACE)
+		expect(taken.code).not.toBe(CODE_WITH_TRAILING_SPACE)
+	})
+
+	it(`stops a rule whose primary is a number before it builds a regular expression out of the keyword`, async () => {
+		let answer = await lintDirect({ code: CODE, rules: [[`function-max-empty-lines`, `abc`]], registry: REGISTRY })
+
+		assert(!answer.unparsable)
+		expect(answer.invalidOptions).toHaveLength(1)
+	})
+
+	it(`reaches the oracles as an option warning naming the rule under its own namespace`, async () => {
+		let { results } = await lint({ code: CODE, config: { plugins: [PLUGIN], customSyntax: `postcss-less`, rules: { "@stylistic/less/max-empty-lines": `abc` } } })
+
+		expect(results[0].invalidOptionWarnings).toStrictEqual([{ text: `Invalid option "abc" for rule "@stylistic/less/max-empty-lines"` }])
+		expect(results[0].warnings).toHaveLength(0)
+	})
+
+	it(`reaches a test case as the option warning the testing library reads`, async () => {
+		let { results } = await stylelint.lint({ code: CODE, config: { plugins: [PLUGIN], rules: { "@stylistic/max-empty-lines": `abc` } } })
+
+		expect(results[0]?.invalidOptionWarnings).toStrictEqual([{ text: `Invalid option "abc" for rule "@stylistic/max-empty-lines"` }])
+	})
+})
+
+/** The syntaxes the oracles read the corpus under, each with the package a configuration names it by, so that the option list is put to the instance of a rule under each of them rather than to the core's alone. Those three are the list's own reach: it is what the oracles run, and they read no other. */
+const SYNTAXES: [string, string | undefined][] = [[`css`, undefined], [`scss`, `postcss-scss`], [`less`, `postcss-less`]]
+
+// The list is written out by hand so that a run of an oracle over an older commit stays comparable, and an option a rule does not take is the list having fallen behind the plugin. Nothing else fails on such a row: every oracle answers a refused run with no row at all, so the corpus quietly shrinks and the diff of a branch says nothing
+describe(`the option list the oracles read`, () => {
+	it(`holds no option a rule of the plugin refuses, under any of the three syntaxes the oracles read`, async () => {
+		let refused: string[] = []
+
+		for (let [syntaxName, syntax] of SYNTAXES) {
+			for (let [rule, primaries] of Object.entries(RULE_OPTIONS)) {
+				for (let primary of primaries) {
+					let name = syntaxName === `css` ? rule : `${syntaxName}/${rule}`
+					// eslint-disable-next-line no-await-in-loop
+					let answer = await lintDirect({ code: CODE, rules: [[name, primary]], registry: REGISTRY, syntax })
+
+					if (!answer.unparsable && answer.invalidOptions.length > 0) refused.push(`${name}: ${JSON.stringify(primary)}`)
+				}
+			}
+		}
+
+		expect(refused).toStrictEqual([])
+	})
+})

--- a/scripts/harness/lint.ts
+++ b/scripts/harness/lint.ts
@@ -1,7 +1,7 @@
 /**
  * Lints one text under one or more rules of this plugin the way Stylelint would, without Stylelint.
  *
- * A call of `stylelint.lint` over a snippet costs about 0.8 ms on this machine, and 0.7 of them are the linter around the rule — a linter created for the call, a configuration searched for and augmented, an ignore file looked up, reference roots loaded, disable comments walked. The parse and the rule cost 0.05 ms together. An oracle or a sweep makes hundreds of thousands of such calls over snippets that carry no configuration comment and no ignore file, so the runner here does what `lintPostcssResult.mjs` does for one rule and nothing of the rest: it parses, hangs the `stylelint` object `report()` reads on the result, calls the rule, and hands back what the rule said and what it wrote. `verify-lint.ts` is the proof that the two agree, run over every run the oracles make.
+ * A call of `stylelint.lint` over a snippet costs about 0.8 ms on this machine, and 0.7 of them are the linter around the rule — a linter created for the call, a configuration searched for and augmented, an ignore file looked up, reference roots loaded, disable comments walked. The parse and the rule cost 0.05 ms together. An oracle or a sweep makes hundreds of thousands of such calls over snippets that carry no configuration comment and no ignore file, so the runner here does what `lintPostcssResult.mjs` does for one rule and nothing of the rest: it parses, hangs the `stylelint` object `report()` and `validateOptions` read on the result, calls the rule, and hands back what the rule said and what it wrote. `verify-lint.ts` is the proof that the two agree, run over every run the oracles make.
  *
  * What is not reproduced, since no corpus of this repository carries it: disable comments and their ranges, `ignoreDisables`, `quiet`, `computeEditInfo`, the lexer and the reference roots. A rule reaching for one of them would show up in the verification as a disagreement rather than as a wrong answer.
  */
@@ -49,13 +49,13 @@ export type Registry = Record<string, Rule>
 /** What `lib/rules/index.ts` exports: a factory per rule, or — in a checkout from before the factories — the rule itself. */
 type Exported = Rule | ((syntax: RuleSyntax) => Rule)
 
-/** What the rules said and wrote, or why the text could not be read. */
+/** What the rules said and wrote, or why the text could not be read. `invalidOptions` holds what the rules objected to about their options, in the words `validateOptions` wrote them in, so that a run standing on an option no rule takes is told apart from one over which the rules had nothing to say — and told which option of which rule was refused. */
 export type Answer = {
 	unparsable: true,
 	detail: string,
 } | {
 	unparsable: false,
-	usable: boolean,
+	invalidOptions: string[],
 	warnings: Warning[],
 	code: string,
 }
@@ -150,8 +150,8 @@ function settingsOf (rules: Record<string, unknown>): RuleSetting[] {
  * @param options.registry - The rule registry to take the rules from, as `loadRules` returns it.
  * @param [options.syntax] - The syntax to read the text with; plain CSS where none is given.
  * @param [options.fix] - Whether the rules are let write.
- * @param [options.stripNamespaces] - Whether the namespace segment is read out of every warning's name and text, which is how the oracles compare a row measured under `@stylistic/less/<rule>` with one measured under `@stylistic/<rule>`; the tests compare texts as they stand, and leave this off.
- * @returns What the rules said and wrote, or why the text could not be read at all. A run is `usable` where no rule objected to its options, as `isUsable` of the oracles has it.
+ * @param [options.stripNamespaces] - Whether the namespace segment is read out of every warning's name and text, which is how the oracles compare a row measured under `@stylistic/less/<rule>` with one measured under `@stylistic/<rule>`; the tests compare texts as they stand, and leave this off. An objection to an option keeps its full name whatever this says, since Stylelint keeps it there. `verify-lint.ts` compares such a text with the flag off; the case beside this module is what pins the name under the flag.
+ * @returns What the rules said and wrote, or why the text could not be read at all. A run whose `invalidOptions` stand empty is one no rule objected to, which is what `isUsable` of the oracles asks.
  */
 async function lintDirect ({ code, rules, registry, syntax, fix = false, stripNamespaces = false }: {
 	code: string,
@@ -177,11 +177,13 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false, stripNa
 		return { unparsable: true, detail: reason ?? message }
 	}
 
+	// `validate` is what `stylelint.utils.validateOptions` opens by reading, and a configuration without it makes that util hand back `true` for every option of every rule: no rule would refuse an option it does not take, and every `if (!validOptions) return` would be dead. The linter's own default is `true`, so the runner carries it too
 	let config: {
 		fix: boolean,
 		rules: Record<string, [unknown, object | undefined]>,
+		validate: boolean,
 		customSyntax?: string,
-	} = { fix, rules: {}, ...(typeof syntax === `string` && { customSyntax: syntax }) }
+	} = { fix, rules: {}, validate: true, ...(typeof syntax === `string` && { customSyntax: syntax }) }
 
 	let ruleSeverities: Record<string, RuleSeverity> = {}
 
@@ -225,7 +227,7 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false, stripNa
 	}
 
 	let warnings: Warning[] = []
-	let usable = true
+	let invalidOptions: string[] = []
 
 	// What `report` hangs on a warning beyond what PostCSS declares: the kind of warning where it is not a rule's, and the rule where it is
 	for (let warning of (result.warnings() as (PostcssWarning & {
@@ -233,7 +235,7 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false, stripNa
 		rule?: string,
 	})[])) {
 		if (warning.stylelintType === `invalidOption`) {
-			usable = false
+			invalidOptions.push(warning.text)
 			continue
 		}
 
@@ -244,7 +246,7 @@ async function lintDirect ({ code, rules, registry, syntax, fix = false, stripNa
 			: { rule: warning.rule, text: warning.text, line: warning.line, column: warning.column, endLine: warning.endLine, endColumn: warning.endColumn })
 	}
 
-	return { unparsable: false, usable, warnings, code: result.root.toString(parser.stringify) }
+	return { unparsable: false, invalidOptions, warnings, code: result.root.toString(parser.stringify) }
 }
 
 /** The registries already loaded, by the plugin path a configuration names. */
@@ -284,7 +286,7 @@ async function lint ({ code, config, fix = false }: {
 	if (answer.unparsable) return { results: [{ warnings: [{ rule: `CssSyntaxError`, text: `${answer.detail} (CssSyntaxError)`, severity: SEVERITY }], invalidOptionWarnings: [] }], code: undefined }
 
 	return {
-		results: [{ warnings: answer.warnings, invalidOptionWarnings: answer.usable ? [] : [{ text: `invalid option` }] }],
+		results: [{ warnings: answer.warnings, invalidOptionWarnings: answer.invalidOptions.map((text) => ({ text })) }],
 		code: fix ? answer.code : undefined,
 	}
 }

--- a/scripts/harness/verify-lint.ts
+++ b/scripts/harness/verify-lint.ts
@@ -3,7 +3,7 @@
 /**
  * Proves that `lintDirect` says and writes what `stylelint.lint` says and writes, over every run the oracles make.
  *
- * Every rule under every primary option over every fixture of the shared corpus, under each syntax, is linted twice by each of the two — once for its warnings and once for its fix — and the four answers are compared field by field: whether the syntax read the text at all, whether the rule accepted its options, every warning's rule, text and four positions, and the text the fix left. Then every fixture is linted under pairs of rules in both orders, since a run of several rules is where the runner has to reproduce the order Stylelint gives a plugin's rules. A disagreement is printed and fails the script; the count of runs compared is printed either way, so that a pull request can quote it.
+ * Every rule under every primary option over every fixture of the shared corpus, under each syntax, is linted twice by each of the two — once for its warnings and once for its fix — and the four answers are compared field by field: whether the syntax read the text at all, in what words the rules refused their options, every warning's rule, text and four positions, and the text the fix left. Then every fixture is linted under pairs of rules in both orders, since a run of several rules is where the runner has to reproduce the order Stylelint gives a plugin's rules. Then every rule is handed, under every syntax, two settings no rule takes, since no option of `options.ts` is refused and a refusal compared nowhere is a field the two are free to part on. A disagreement is printed and fails the script; the counts of runs compared and of refusals among them are printed either way, so that a pull request can quote them.
  */
 
 import { exit, stdout } from "node:process"
@@ -11,7 +11,7 @@ import { exit, stdout } from "node:process"
 import stylelint from "stylelint"
 
 import { RULE_OPTIONS } from "../oracles/options.ts"
-import { buildRuns, isUsable } from "../oracles/runs.ts"
+import { buildRuns, type Run } from "../oracles/runs.ts"
 
 import { type Answer, type Config, lintDirect, loadRules, settingsOf } from "./lint.ts"
 
@@ -20,6 +20,18 @@ const REGISTRY = await loadRules(new URL(`../../lib`, import.meta.url).pathname)
 
 /** How many neighbouring rules of the option list are paired for the two-rule runs. */
 const PAIRS_PER_FIXTURE = 24
+
+/** The settings put to every rule so that a refusal is compared: a keyword no option list holds, and the `false` Stylelint answers with a message of its own. Shortening the list narrows what is compared and no count can say so, since every count here is derived from the list itself. */
+const SETTINGS_NO_RULE_TAKES = [`there-is-no-such-option`, false]
+
+/** Every run the oracles make, which is what this script stands over. */
+let runs = buildRuns()
+
+/** How many rule-and-syntax pairs a refusal has to have been compared over: every rule of the option list, under every syntax the corpus is read under. */
+const REFUSALS_EXPECTED = new Set(runs.map((run) => run.syntaxName)).size * Object.keys(RULE_OPTIONS).length
+
+/** How many runs stand on a setting no rule takes: each of those pairs, under every such setting, checked and fixed. */
+const REFUSALS_PUT = REFUSALS_EXPECTED * SETTINGS_NO_RULE_TAKES.length * 2
 
 /**
  * Asks Stylelint, and shapes its answer like the runner's.
@@ -48,7 +60,7 @@ async function askStylelint (code: string, config: Config, fix: boolean): Promis
 
 	return {
 		unparsable: false,
-		usable: isUsable(first),
+		invalidOptions: first.invalidOptionWarnings.map(({ text }) => text),
 		warnings: first.warnings.map(({ rule, text, line, column, endLine, endColumn }) => ({ rule, text, line, column, endLine, endColumn })),
 		code: result.code ?? code,
 	}
@@ -74,8 +86,7 @@ function askRunner (code: string, config: Config, fix: boolean): Promise<Answer>
 function disagreement (expected: Answer, actual: Answer): string | null {
 	if (expected.unparsable !== actual.unparsable) return `unparsable`
 	if (expected.unparsable || actual.unparsable) return null
-	if (expected.usable !== actual.usable) return `usable`
-	if (!expected.usable) return null
+	if (JSON.stringify(expected.invalidOptions) !== JSON.stringify(actual.invalidOptions)) return `invalidOptions`
 	if (expected.code !== actual.code) return `code`
 	if (JSON.stringify(expected.warnings) !== JSON.stringify(actual.warnings)) return `warnings`
 
@@ -83,6 +94,7 @@ function disagreement (expected: Answer, actual: Answer): string | null {
 }
 
 let compared = 0
+let refused = 0
 
 let failures: {
 	label: string,
@@ -97,9 +109,11 @@ let failures: {
  * @param label - What to print where the two disagree.
  * @param code - The text.
  * @param config - The configuration.
- * @returns Nothing; a disagreement is recorded.
+ * @returns Whether either pass was refused its options; a disagreement is recorded rather than returned.
  */
-async function compare (label: string, code: string, config: Config): Promise<void> {
+async function compare (label: string, code: string, config: Config): Promise<boolean> {
+	let refusedHere = false
+
 	for (let fix of [false, true]) {
 		// The two are asked in turn so that a run of this script stays as light on the machine as the oracle it stands in for
 		// eslint-disable-next-line no-await-in-loop
@@ -108,11 +122,16 @@ async function compare (label: string, code: string, config: Config): Promise<vo
 
 		compared += 1
 
+		if (!expected.unparsable && expected.invalidOptions.length > 0) {
+			refused += 1
+			refusedHere = true
+		}
+
 		if (field) failures.push({ label, fix, field, expected, actual })
 	}
-}
 
-let runs = buildRuns()
+	return refusedHere
+}
 
 for (let run of runs) {
 	// eslint-disable-next-line no-await-in-loop
@@ -136,8 +155,29 @@ for (let [name, run] of fixtures) {
 	}
 }
 
-stdout.write(`${compared} runs compared, ${failures.length} disagreements\n`)
+// A refusal is put under every syntax, since an objection names the rule the way the rule reports — with the namespace segment a syntax registers it under — and that is a text the runner has to spell as Stylelint spells it. What varies between the three is the name the configuration spells, not the parse: a rule refuses its options before it has read anything, so the fixture each refusal stands over is only whatever the corpus offers first, and the text the fix leaves is compared beside the objection all the same
+let refusalFixtures: Map<string, Run> = new Map()
+let refusalsCompared: Set<string> = new Set()
+
+for (let run of runs) if (!refusalFixtures.has(run.syntaxName)) refusalFixtures.set(run.syntaxName, run)
+
+for (let [syntaxName, run] of refusalFixtures) {
+	for (let rule of Object.keys(RULE_OPTIONS)) {
+		for (let setting of SETTINGS_NO_RULE_TAKES) {
+			let name = syntaxName === `css` ? `@stylistic/${rule}` : `@stylistic/${syntaxName}/${rule}`
+
+			// eslint-disable-next-line no-await-in-loop
+			if (await compare(`${name} ${JSON.stringify(setting)} ${syntaxName} ${run.name}`, run.code, { ...run.config, rules: { [name]: setting } })) refusalsCompared.add(`${syntaxName}|${rule}`)
+		}
+	}
+}
+
+stdout.write(`${compared} runs compared, ${refused} of them refusing an option, ${failures.length} disagreements\n`)
+
+// What the two counts hold the script to is that a refusal was compared over every rule of the option list and every syntax of the corpus. The pairs are counted against the corpus rather than against the loop, so a loop narrowed to one syntax ends the run and an emptied list of settings ends it too; a shortened one does not, since every count here is derived from that list. A setting some rule turns out to take, and a row of `options.ts` the plugin refuses, each move the count of refusals without showing up as a disagreement
+if (refused !== REFUSALS_PUT) stdout.write(`${refused} refusals where ${REFUSALS_PUT} were put: a setting handed to every rule is one some rule takes, or a row of options.ts is one no rule takes\n`)
+if (refusalsCompared.size !== REFUSALS_EXPECTED) stdout.write(`a refusal was compared over ${refusalsCompared.size} rule-and-syntax pairs of ${REFUSALS_EXPECTED}\n`)
 
 for (let failure of failures.slice(0, 20)) stdout.write(`${JSON.stringify(failure, null, `\t`)}\n`)
 
-exit(failures.length === 0 ? 0 : 1)
+exit(failures.length === 0 && refused === REFUSALS_PUT && refusalsCompared.size === REFUSALS_EXPECTED ? 0 : 1)

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -40,7 +40,7 @@ async function measureOne (options: Omit<Parameters<typeof lintDirect>[0], `fix`
 	let checked = await lintDirect({ ...options, stripNamespaces: true })
 
 	if (checked.unparsable) return { unparsable: true }
-	if (!checked.usable) return { usable: false }
+	if (checked.invalidOptions.length > 0) return { usable: false }
 
 	let fixed = await lintDirect({ ...options, fix: true, stripNamespaces: true })
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -53,7 +53,7 @@ async function lint (options: LinterOptions): Promise<LinterResult> {
 		: answer.warnings.map((warning: object) => ({ ...warning, severity: `error` }))
 	let code = answer.unparsable ? options.code : answer.code
 
-	return { results: [{ warnings, parseErrors: [], invalidOptionWarnings: answer.unparsable || answer.usable ? [] : [{ text: `invalid option` }], _postcssResult: { root: { toString: () => code }, opts: {} } }] } as unknown as LinterResult
+	return { results: [{ warnings, parseErrors: [], invalidOptionWarnings: answer.unparsable ? [] : answer.invalidOptions.map((text) => ({ text })), _postcssResult: { root: { toString: () => code }, opts: {} } }] } as unknown as LinterResult
 }
 
 // The library and this file import one and the same `stylelint`, loaded by Node rather than by Vitest, and its default export is an object whose `lint` can be replaced in place


### PR DESCRIPTION
`stylelint.utils.validateOptions` opens by reading `result.stylelint.config?.validate` and hands back `true` where the flag is missing. The configuration the runner of the oracles assembled carried `fix`, `rules` and sometimes `customSyntax` and nothing else, so no rule ever refused an option under it — `make oracles`, `make sweep` and every test case the suite answers without the linter all run through that runner.

```shell
$ node -e "… lint({ code: 'a { color: pink; }\n', config: { plugins: [plugin], rules: { '@stylistic/max-empty-lines': 'abc' } } })"
before   invalidOptionWarnings: 0, warnings: 0   # the rule ran with an option it would have refused
after    invalidOptionWarnings: 1, warnings: 0   # what the linter itself answers

$ node -e "… the same for the three rules that build a regular expression out of a numeric primary"
before   SyntaxError: Invalid regular expression: /(?:\r\n){abc11,}/u: Incomplete quantifier
after    invalidOptionWarnings: 1
```

The configuration carries `validate: true` now, the linter's own default. An `Answer` carries the objections in the words `validateOptions` wrote them in rather than the one `invalid option` the runner stood in with, and the derived `usable` is gone. `verify-lint.ts` compares those words, over two settings no rule takes handed to every rule under each of the three syntaxes, and compares a refused run whole rather than in its objection alone — the early return it had inherited left what a refusal is for, a rule running over nothing and writing nothing, the one thing the two sides were free to part on. A refusal on its own only drops a run and no oracle reports it, so `scripts/harness/lint.test.ts` — the first test the runner has ever had — puts every row of `scripts/oracles/options.ts` to it and reddens the suite on a row a rule refuses.

## What the review turned up

- **Nothing in `lib/` moved.** Over one `lib` tree, with `scripts/oracles` and the lockfile alike on both sides, all six oracles answer byte-identically under the runner of `main` and under this one: converge 0 rows, control 2, comments 0, twins 25, nodes 0, pairs 3, and `make oracles` prints them at `+0 −0 ~0`. `make harness-check` compares 57 972 runs, 948 of them refusing an option, with 0 disagreements. The suite passes at 9 853 cases and the one skip it already carried, six of them new; the base stands at 9 847.
- **The guard is pinned by thirteen mutations.** Eight of the change — the flag removed, carried only where nothing is written, carried only under a custom syntax; the objection collapsed into a word of the runner's own, dropped on its way out of the loop, or read off the wrong kind of warning; and either of the two places that hand an objection on put back as it was. Three of the cases — the option list drifted from the plugin under all three syntaxes and under one alone, and the space taken off the end of the fixture the fix pass stands over. Two more end `make harness-check`: the refusal loop narrowed to one syntax, and a refused run let to write. A list of settings merely shortened is not caught, and that is stated as a limit rather than a guarantee.
- **One workaround goes with the defect.** `lib/utils/defersToRunEnd/index.test.ts` asks the plugin which rules take a primary conditioned on lineness by reading which of them refuse one, and named a file so that the linter rather than the runner would answer. It goes through the runner now, and is red without the flag too.
- **The guard found something on its first firing**, and it is not in `lib/`: `scripts/sweeps/colon-in-comment.ts` lists `never-single-line` among the primaries of `declaration-colon-space-after`, which takes three options and not that one. 3 960 of that sweep's 59 400 rows stand under it, 1 628 of them holding a warning in the result the merged run left in the store. Filed as #543 rather than fixed here, since dropping the option changes what the sweep measures and the counts a merged commit quotes are what it has to be measured against. A probe putting all 431 configurations of the eighteen sweeps to the runner reports that one and no other.
- **The branch leaves a cost of its own**, filed as #544: the result store keys an entry on the tree hash of the whole `scripts/harness` directory, which from now on holds a test, so rewording a case there will make every oracle and every sweep measure both sides afresh for nothing.
- **No changelog entry.** The runner ships in neither `lib/` nor `dist/`.

Closes #540.
