### PR TITLE
Let the pnpm action install the pnpm this repository asks for

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v6
-        with:
-          version: latest
       - run: pnpm ci
       - run: make release
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,5 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
-          version: latest
       - run: pnpm ci
       - run: make verify


### PR DESCRIPTION
Both workflows told `pnpm/action-setup` `version: latest`, and pnpm's `latest` dist-tag is the v11 line:

```console
$ pnpm view pnpm dist-tags
latest: 11.25.0
latest-11: 11.25.0
latest-12: 12.3.4
```

`devEngines.packageManager` has asked for `>=12.3` since `079e976`, so CI started a pnpm that does not satisfy the repository's own requirement. pnpm's answer to that is `onFail: download`: it fetched pnpm 12.3.1 into its store and tried to re-execute as it. A v11 launcher starts the fetched version by importing its entry as an ES module, and a v12 entry is a native executable. Reproduced away from CI, over a copy of the tree, through pnpm 11.25.0:

```console
$ …/pnpm11/node_modules/.bin/pnpm install --frozen-lockfile
file:///…/store/v11/links/@/pnpm/12.3.1/…/node_modules/pnpm/pnpm:1
ELF          >    0A%     @       ??        @ 8

SyntaxError: Invalid or unexpected token
    at compileSourceTextModule (node:internal/modules/esm/utils:355:16)
    …
Node.js v26.8.1
```

The input is dropped rather than given a number. `pnpm/action-setup` reads `devEngines.packageManager` out of `package.json` when it is handed no `version`, so the requirement stays written in one place and CI installs whatever satisfies it.

## What the review turned up

- **Nothing needs the exact version in the workflow.** pnpm re-executes as the version the lockfile resolved, whichever member of the v12 line starts it: the same frozen install through pnpm 12.3.4 came back `Done in 156ms using pnpm v12.3.1` and left `pnpm-lock.yaml` byte for byte as it was.
- **The runtime is not what broke.** The reproduction above ran under Node 26.8.1 — the version `devEngines.runtime` asks for, and one the runner does not have — and died exactly as CI does. #572 named the missing `actions/setup-node` step as one of two things standing beside the failure; it is not the cause. CI gets its Node from `devEngines.runtime` in any case: `+ node 26.7.0` in the last green run's install.
- **`release.yaml` carried the same input** and would have died the same way on the first release after the bump. It has not run since, so nothing there is proved by a green mark on this pull request.
- **The proof of this one is the run on it.** `make verify` says nothing about a workflow, and the previous pull request was pushed green and still came back red.

Closes #572.
