### PR TITLE
Measure a sweep under no configuration the plugin refuses

### DIFF
--- a/scripts/sweeps/colon-in-comment.ts
+++ b/scripts/sweeps/colon-in-comment.ts
@@ -68,7 +68,7 @@ const corpus: Sweep[`corpus`] = multiply({
 /** Every reader of `raws.between`, under every primary option `scripts/oracles/options.ts` lists for it. */
 const configs: Sweep[`configs`] = ([
 	[`declaration-colon-newline-after`, [`always`, `always-multi-line`]],
-	[`declaration-colon-space-after`, [`always`, `never`, `always-single-line`, `never-single-line`]],
+	[`declaration-colon-space-after`, [`always`, `never`, `always-single-line`]],
 	[`declaration-colon-space-before`, [`always`, `never`]],
 	[`declaration-block-semicolon-newline-before`, [`always`, `always-multi-line`, `never-multi-line`]],
 	[`declaration-block-semicolon-space-before`, [`always`, `never`]],

--- a/scripts/sweeps/configs.test.ts
+++ b/scripts/sweeps/configs.test.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import rules from "../../lib/rules/index.ts"
+import { css } from "../../lib/syntaxes/css/index.ts"
+import { namespaces } from "../../lib/syntaxes/index.ts"
+import { buildRegistry, lintDirect } from "../harness/lint.ts"
+
+import type { Sweep } from "./run.ts"
+
+/** The rules under the names a configuration spells them with, built the way `vitest.setup.ts` builds the registry the suite is linted through. */
+const REGISTRY = buildRegistry(rules, [css, ...namespaces])
+
+/** Where the sweep modules stand, which is where this file stands: the case is about the sweeps beside it and not about a path the repository is asked for. */
+const DIRECTORY = import.meta.dirname
+
+/** What stands in that directory besides a sweep module and a test of one: the runner, which cannot be imported by a case, and the module naming what a result of a sweep depends on. */
+const NOT_A_SWEEP = new Set([`run.ts`, `key.ts`])
+
+/** The syntaxes a sweep is read under where it names none, as `DEFAULT_SYNTAXES` of the runner spells them; the last case holds the two lists to each other. */
+const DEFAULT_SYNTAXES = [`css`, `scss`, `less`]
+
+/** The stylesheet the configurations are put over. Only what the rules objected to about their options is read off the run, so what they have to say about the text itself does not matter. */
+const CODE = `a {\n\tcolor: pink;\n}\n`
+
+/** A primary no rule of the plugin takes, so that a name whose rule is reached at all can be told from one whose is not. */
+const REFUSED_PRIMARY = `abc`
+
+/**
+ * Spells a rule the way the runner spells it, the core's carrying no segment of its own.
+ * @param syntaxName - The syntax the sweep is read under.
+ * @param rule - The rule's short name.
+ * @returns The name a configuration refers to that rule by, behind `@stylistic/`.
+ */
+function nameOf (syntaxName: string, rule: string): string {
+	return `${syntaxName === `css` ? `` : `${syntaxName}/`}${rule}`
+}
+
+/** The names of the files a sweep module could stand in. */
+let files = readdirSync(DIRECTORY).filter((file) => file.endsWith(`.ts`) && !file.endsWith(`.test.ts`) && !NOT_A_SWEEP.has(file)).toSorted()
+
+/** Every module of that directory, each with the name of the file it stands in. */
+let modules: [string, Partial<Sweep>][] = await Promise.all(files.map(async (file): Promise<[string, Partial<Sweep>]> => [file, await import(path.join(DIRECTORY, file))]))
+
+/** The ones of them that export what a sweep exports; a module that does not is named by a case of its own rather than left to throw inside a loop that would not say which file it was. */
+let sweeps = modules.filter(([, module]) => Array.isArray(module.corpus) && Array.isArray(module.configs)) as [string, Sweep][]
+
+/** Every name the sweeps spell a rule with, once each. */
+let names = [...new Set(sweeps.flatMap(([, sweep]) => (sweep.syntaxes ?? DEFAULT_SYNTAXES).flatMap((syntaxName) => sweep.configs.map((config) => nameOf(syntaxName, config.rule)))))].toSorted()
+
+// #543: `scripts/sweeps/colon-in-comment.ts` listed `never-single-line` among the primaries of `declaration-colon-space-after`, which takes three options and not that one, so 3 960 of that sweep's 59 400 rows stood under a configuration no run of Stylelint reaches. Nothing said so: the runner wrote a row of `{ usable: false }` for each of them and went on, and the counts a merged commit quoted held them all
+describe(`the configurations the sweeps measure under`, () => {
+	it(`hold no option a rule of the plugin refuses, under any namespace a sweep is read under`, async () => {
+		let refused: string[] = []
+
+		for (let [file, sweep] of sweeps) {
+			for (let syntaxName of sweep.syntaxes ?? DEFAULT_SYNTAXES) {
+				for (let config of sweep.configs) {
+					let name = nameOf(syntaxName, config.rule)
+					// The text is read as plain CSS whichever namespace is asked: a rule refuses an option before it has read anything of the file, so which syntax parsed the text does not enter the answer, and a stylesheet opened with no custom syntax is the one every namespace of the plugin accepts — so no syntax package is loaded to put the question
+					// eslint-disable-next-line no-await-in-loop
+					let answer = await lintDirect({ code: CODE, rules: [[name, config.primary, config.secondary]], registry: REGISTRY })
+
+					if (!answer.unparsable && answer.invalidOptions.length > 0) refused.push(`${file}: ${name} ${JSON.stringify(config.primary)}`)
+				}
+			}
+		}
+
+		expect(refused).toStrictEqual([])
+	})
+
+	it(`are put to names whose rule is reached at all, a primary no rule takes being refused under each of them`, async () => {
+		// The control the case above needs, and the property both guards rest on. `defineRule` gates a check on the syntax accepting the root, and a root a namespace turns away draws a warning of its own instead — `validateOptions` never runs, no objection is drawn, and a drifted option reads exactly like a sound one. Under a custom syntax that is already so: only the namespace whose syntax parsed the text reaches its rules, which is why the question is put with none
+		let silent: string[] = []
+
+		for (let name of names) {
+			// eslint-disable-next-line no-await-in-loop
+			let answer = await lintDirect({ code: CODE, rules: [[name, REFUSED_PRIMARY]], registry: REGISTRY })
+
+			if (answer.unparsable || answer.invalidOptions.length === 0) silent.push(name)
+		}
+
+		expect(silent).toStrictEqual([])
+	})
+
+	it(`are read out of every file of the directory that is neither the runner nor the module of the key`, () => {
+		// Three ways the two cases above could measure nothing and say nothing, one assertion each. A directory the flat listing under-reports — the day a sweep moves into a directory of its own — is caught by the recursive listing beside it; a listing that came back empty, by the sweep named here, which is a canary and goes the day that sweep does; and a file that is no sweep at all, by the last, which names it rather than letting a loop throw over a module it would not name
+		expect(readdirSync(DIRECTORY, { recursive: true, encoding: `utf8` }).filter((entry) => entry.endsWith(`.ts`) && !entry.endsWith(`.test.ts`) && !NOT_A_SWEEP.has(entry)).toSorted()).toStrictEqual(files)
+		expect(files).toContain(`colon-in-comment.ts`)
+		expect(modules.filter(([file]) => !sweeps.some(([name]) => name === file)).map(([file]) => file)).toStrictEqual([])
+		expect(sweeps.filter(([, sweep]) => sweep.configs.length === 0).map(([file]) => file)).toStrictEqual([])
+	})
+
+	it(`are read under the syntaxes the runner reads them under`, () => {
+		// The runner cannot be imported by a case — it reads `argv`, imports the module it was handed and measures both sides as it loads — so its list is read as text instead, the way `key.test.ts` reads that file for what it names
+		let runner = readFileSync(path.join(DIRECTORY, `run.ts`), `utf8`)
+		let listed = runner.match(/const DEFAULT_SYNTAXES = \[(?<names>[^\]]*)\]/u)?.groups?.names ?? ``
+
+		expect([...listed.matchAll(/`(?<name>[^`]+)`/gu)].map((match) => match.groups?.name)).toStrictEqual(DEFAULT_SYNTAXES)
+	})
+})

--- a/scripts/sweeps/run.ts
+++ b/scripts/sweeps/run.ts
@@ -25,6 +25,9 @@ const SYNTAXES: Record<string, string | undefined> = { css: undefined, scss: `po
 /** The syntaxes a sweep is read under where it names none: the stylesheet syntaxes, since a styled template is a JavaScript file around a stylesheet and a corpus written for one is no corpus for the other. */
 const DEFAULT_SYNTAXES = [`css`, `scss`, `less`]
 
+/** The stylesheet every configuration is put over before a row is measured. Only what the rules objected to about their options is read off that run, so what they have to say about the text itself does not matter, and neither does the syntax: a rule refuses an option before it has read anything of the file. */
+const PROBE = `a {\n\tcolor: pink;\n}\n`
+
 /** What a sweep module exports. */
 export type Sweep = {
 	name: string,
@@ -86,6 +89,37 @@ if (!file) {
 
 let sweepFile = path.resolve(file)
 let sweep: Sweep = await import(sweepFile)
+
+/**
+ * Names every configuration of the sweep the rules given refuse, in the words `validateOptions` wrote the objections in — which name the rule under its own namespace and the value it was handed.
+ *
+ * A refusal is the configuration's own: every rule of the plugin reads its options before it reads anything of the file, so the answer cannot depend on the text. What is text-dependent is whether the question is put at all — a text no syntax reads, or a root a namespace turns away, never reaches `validateOptions` — so the list goes over `PROBE` rather than over the corpus, and a configuration whose only witness in the corpus happens not to parse is asked all the same.
+ * @param registry - The rules to put the configurations to.
+ * @returns One line per refused rule setting — a rule under one namespace with its options — holding every objection the rules made about it; empty where the rules refuse none.
+ */
+async function refusalsOf (registry: Registry): Promise<string[]> {
+	let refusals: string[] = []
+
+	for (let syntaxName of sweep.syntaxes ?? DEFAULT_SYNTAXES) {
+		for (let config of sweep.configs) {
+			let rules: RuleSetting[] = [[`${syntaxName === `css` ? `` : `${syntaxName}/`}${config.rule}`, config.primary, config.secondary]]
+			// eslint-disable-next-line no-await-in-loop
+			let answer = await lintDirect({ code: PROBE, rules, registry })
+
+			if (!answer.unparsable && answer.invalidOptions.length > 0) refusals.push(answer.invalidOptions.join(`; `))
+		}
+	}
+
+	return refusals
+}
+
+// A configuration these rules refuse is a question no run of Stylelint reaches, and the rows it would keep are rows the plugin never produces: `measureOne` files each of them as unusable and the run goes on, so such a sweep used to measure, store and count them in silence (#543). The rules asked are the working tree's whichever side is being measured, and a side whose inputs have not moved is not measured at all — a sweep over a tree that moved no rule collapses both sides into one key, measured once under the label `base` and read back from the store on every run after, so a guard hanging off the head's own measurement would never fire there
+let refusals = await refusalsOf(await loadRules(libAt(`worktree`)))
+
+if (refusals.length > 0) {
+	stderr.write(`${sweep.name} measures under ${refusals.length} rule setting${refusals.length === 1 ? `` : `s`} the rules of this checkout refuse:\n${refusals.map((refusal) => `\t${refusal}\n`).join(``)}`)
+	exit(1)
+}
 
 /** One side as its digest, and its rows behind a call, since the rows are read only for the keys the digests say have moved. */
 type Result = {


### PR DESCRIPTION
`scripts/sweeps/colon-in-comment.ts` listed four primary options for `declaration-colon-space-after`, under a JSDoc saying the list is the one `scripts/oracles/options.ts` holds. That file lists three, and so does the rule, so Stylelint answers a configuration of `never-single-line` with an `invalidOptionWarning` and the rule never runs. The option was one of the sweep's fifteen configurations over a corpus of 1 320 texts under three syntaxes, so 3 960 of its 59 400 rows per side stood under a configuration no run of Stylelint reaches — and 1 628 of them hold a warning in the head side of the merged run, which is still in the store.

Nothing said so. `measureOne` of `scripts/sweeps/run.ts` files a refused run as `{ usable: false }` and the run goes on, so those rows were measured, written to the store, and counted into what the sweep reported. On this branch the sweep is 55 440 rows, and putting the option back ends the run before a row of it is measured:

```shell
$ make sweep FILE=scripts/sweeps/colon-in-comment.ts
	🧹 colon-in-comment over base (df735ee2f28fc8bd464312d9aa766f73449c270a)
55440 rows: 55440 same, 0 changed, 0 added, 0 removed — tmp/sweeps/colon-in-comment.md

$ make sweep FILE=scripts/sweeps/colon-in-comment.ts   # with `never-single-line` put back
colon-in-comment measures under 3 configurations the rules of this checkout refuse:
	Invalid option value "never-single-line" for rule "@stylistic/declaration-colon-space-after"
	Invalid option value "never-single-line" for rule "@stylistic/scss/declaration-colon-space-after"
	Invalid option value "never-single-line" for rule "@stylistic/less/declaration-colon-space-after"
make: *** [Makefile:47: sweep] Error 1
```

The option is gone from the list, and the runner puts every configuration of the sweep to the rules of the working tree before it measures a row, ending the run on a refusal. Every rule of the plugin reads its options before it reads anything of the file, so the answer is the configuration's own; whether the question is put at all is not, since a text no syntax reads and a root a namespace turns away both stop short of `validateOptions`. So the list goes over one stylesheet of the runner's own rather than over the corpus — and 45 of them go in inside the three quarters of a second the refusing run above takes end to end, node's own start-up and the loading of the rules included.

The rules asked are the working tree's whichever side is being measured, and a side whose inputs have not moved is not measured at all: a sweep over a tree that moved no rule collapses both sides into the one key labelled `base` above, read back from the store on every run after. A guard hanging off the head's own measurement would never fire there, which is this branch's own case.

`scripts/sweeps/configs.test.ts` puts the same question to every sweep of the directory on every run of the suite, which the runner cannot: it catches the drift of a sweep nobody has run. 20 sweeps, 473 configurations, 1 415 pairs of a rule under a namespace, none refused. The two guards divide the work rather than repeat it, and nothing pins the runner's: delete its block and no case turns red, because the coverage is the suite's.

Both of them stand on one property — that every namespace of the plugin accepts a root opened with no custom syntax — and the review found nothing in the repository asserting it, which is how a namespace tightened tomorrow would put the sweeps back where #543 found them. A case of its own is the control now: a primary no rule takes goes to every name the sweeps spell, and a name drawing no objection is named. Made to refuse a plainly parsed root, the Less namespace reddens that control with every `less/` name and leaves the other three cases green.

## What the review turned up

**The finding does not move.** Measured over the two `lib` trees `5cf5edb` compared, `e9daba6:lib` to `5cf5edb:lib`, with the runner of this branch: the drifted list moves 1 622 rows of 59 400 a side, and the fixed list the same 1 622 of 55 440, with the same split by rule. Under the `validate` flag the refused configuration is unusable on both sides, so it moves nothing in either direction; dropping it stops measuring 3 960 rows a side that said nothing, and takes no row of the finding with it. The head of `worktree` will not do for that comparison — `lib` has gone thirteen commits past `5cf5edb` — so it was measured by a probe repeating the runner's `measure` over the two trees, 12,7 s for both sides.

**207 of the 1 829 moved rows the merged commit quotes stood under the refused option**, which the issue records as unmeasured because the base side of that comparison is no longer in the store. The split by rule comes back `declaration-colon-newline-after` 861, `declaration-colon-space-after` 423, `declaration-colon-space-before` 312, `declaration-block-semicolon-space-before` 23, `declaration-block-semicolon-newline-before` 3 — four of the five identical to the ones `5cf5edb` quotes, the fifth 630 there. So the whole of the difference is that one rule's, which is the only rule the refused option was ever spelled for, and the base side is reproduced by the same token: a moved row is counted off both sides, and a base parting from the merged run's anywhere would have moved the other four counts too.

**The head side is reproduced to the row.** Measured now and compared with the head of the merged run in the store — the same `lib` tree, the same corpus, `multiply` of `scripts/harness/matrix.ts` not having moved since — all 59 400 keys stand on both sides and 3 490 rows differ, every one of them under the refused option. The other 470 rows of that option are `{ unparsable: true }` on both, `measureOne` answering about a text it cannot read before it answers about options. That is the measured form of the claim the paragraph above rests on: the flag moves rows only where a rule refuses.

**A guard reading the corpus would have had a blind spot, and the review found it.** The first draft put the list over the corpus's first text and dropped the whole answer where that text would not parse, so no configuration under such a syntax was ever asked. It is live: the first entry of `scripts/sweeps/interpolation-case.ts` is `a { width: #{$a}; }`, which PostCSS and `postcss-less` both refuse with `Unknown word $a`, and eight of that sweep's twelve pairs of a syntax and a configuration went unasked while `measure` ran 8 160 texts under each. The stylesheet the runner keeps for the question has no such hole; with a drifted primary added to that sweep, the run now stops and names all three namespaces.

**`{ usable: false }` stays.** On the base a refused configuration is the finding rather than a fault — a rule that has since gained the option says so exactly that way — so only the working tree's refusal ends a run. The mirror case is a cost the branch accepts: a branch that narrows a rule's `possible` list has to edit the sweep module in the same commit, which is the rule `scripts/harness/lint.test.ts` already holds `scripts/oracles/options.ts` to.

**No entry in the changelog and no row in the oracles.** The branch touches no file of `lib/`, so nothing a user of the package can see moves, and all six oracles answer `+0 −0 ~0`: converge 0 rows, control 2, comments 0, twins 9, nodes 0, pairs 3. `make verify` is green at 297 files, 10 009 cases and the one skip the suite already carried, four of the cases new; the refusal case is red on `df735ee` with the three rows above.

Closes #543
