### PR TITLE
Build the key of an oracle result in a module a case can ask

### DIFF
--- a/scripts/harness/cache.test.ts
+++ b/scripts/harness/cache.test.ts
@@ -77,7 +77,7 @@ const FILES = { "lint.ts": `a`, "lint.test.ts": `b`, "README.md": `c`, "deep/mat
 const QUOTED_TEST = `a"b.test.ts`
 
 /**
- * Hashes the sources of a directory holding the files, as `compare.ts` and `run.ts` hash the ones on disk.
+ * Hashes the sources of a directory holding the files, as the `key.ts` of the oracles and the one of the sweeps hash the ones on disk.
  * @param files - The path of every file under it, and the text it holds.
  * @param outside - The text of the file standing outside it.
  * @returns The hash of its sources.

--- a/scripts/oracles/compare.ts
+++ b/scripts/oracles/compare.ts
@@ -11,25 +11,17 @@ import { mkdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { argv, env, stdout } from "node:process"
 
-import { hashAt, hashSourcesAt, keyOf, read, write } from "../harness/cache.ts"
+import { keyOf, read, write } from "../harness/cache.ts"
 import { defaultBase, libAt, ROOT, type Side } from "../harness/checkout.ts"
 import { diff, render } from "../harness/diff.ts"
+
+import { inputsOf } from "./key.ts"
 
 /** The oracles, in the order `make oracles` has always run them. */
 const ORACLES = [`converge`, `control`, `comments`, `twins`, `nodes`, `pairs`]
 
 /** The fields that tell one row from another; everything else a row holds is what the oracle found there. */
 const IDENTITY = [`kind`, `rule`, `primary`, `syntaxName`, `name`, `spelling`, `a`, `b`]
-
-/**
- * Names the inputs a result of one oracle over one side depends on.
- * @param oracle - The oracle.
- * @param revision - The side, as `hashAt` reads it.
- * @returns The inputs, each as a hash: the one Git keeps for `lib/` and for the lock file, and the one `hashSourcesAt` takes of a directory of scripts, which passes over the tests and the documents standing there — and of the two directories here, `scripts/oracles` holds a document and no test. The scripts and the corpus are always the working tree's.
- */
-function inputsOf (oracle: string, revision: string): Record<string, string> {
-	return { oracle, lib: hashAt(revision, `lib`), oracles: hashSourcesAt(`worktree`, `scripts/oracles`), harness: hashSourcesAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
-}
 
 /**
  * Keys the rows of one oracle by their identity.

--- a/scripts/oracles/key.test.ts
+++ b/scripts/oracles/key.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import path from "node:path"
+import { env } from "node:process"
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import { hashAt, hashSourcesAt, keyOf } from "../harness/cache.ts"
+import { ROOT } from "../harness/checkout.ts"
+
+import { inputsOf } from "./key.ts"
+
+/** Where the objects of the fabricated side go. `git mktree` writes the tree it builds and cannot be told not to, and a tree no commit points at has no place in the database the worktrees share; it is written here and read beside the real one through `GIT_ALTERNATE_OBJECT_DIRECTORIES`. What `treeOf` writes for the working tree is another matter and goes on going where it goes — a tree of the working tree wherever that differs from `HEAD`, which every run of an oracle or a sweep writes too. It stands under `tmp/`, as the scratch index of `cache.ts` does. */
+let objects: string
+
+/** What `GIT_ALTERNATE_OBJECT_DIRECTORIES` stood at before, which is nothing at all unless a caller had it pointed somewhere already. */
+let alternatesBefore: string | undefined
+
+/**
+ * Runs Git in the repository, writing what it writes into the database of the file's own, and hands back what it printed. Neither subcommand put to it reads an object, which is as well: under these variables the real database is neither the primary one nor among the alternates.
+ * @param args - The subcommand and its arguments.
+ * @param input - The text to write to its standard input.
+ * @returns Standard output, trimmed.
+ */
+function git (args: string[], input: string): string {
+	return execFileSync(`git`, args, { cwd: ROOT, encoding: `utf8`, input, env: { ...env, GIT_OBJECT_DIRECTORY: objects } }).trim()
+}
+
+/**
+ * Writes a tree of the entries.
+ * @param entries - The entries it holds, in the shape `git mktree` reads: a mode, a type, a hash and a name.
+ * @returns The hash of the tree.
+ */
+function treeOfEntries (entries: string[]): string {
+	// The blob the entries name was never written — `hash-object` was asked for its hash and not for a copy of it — and a tree naming a missing object is refused without this
+	return git([`mktree`, `--missing`], `${entries.join(`\n`)}\n`)
+}
+
+/**
+ * Fabricates a side whose every path the key hashes holds something else than the working tree does, so that a case asking where an input is taken from cannot pass by the two standing the same. A revision of this repository would not do: the newest one a shallow clone reaches is `HEAD`, whose files are the ones on disk.
+ * @returns The hash of the tree, which is what `hashAt` reads a revision down to anyway.
+ */
+function fabricatedSide (): string {
+	let blob = `100644 blob ${git([`hash-object`, `--stdin`], `nothing this repository holds`)}`
+	let harness = treeOfEntries([`${blob}\tcache.ts`])
+	let oracles = treeOfEntries([`${blob}\tcompare.ts`, `${blob}\tfixtures.ts`])
+	let scripts = treeOfEntries([`040000 tree ${harness}\tharness`, `040000 tree ${oracles}\toracles`])
+
+	return treeOfEntries([`040000 tree ${treeOfEntries([`${blob}\tindex.ts`])}\tlib`, `${blob}\tpnpm-lock.yaml`, `040000 tree ${scripts}\tscripts`])
+}
+
+beforeAll(() => {
+	mkdirSync(path.join(ROOT, `tmp`), { recursive: true })
+	objects = mkdtempSync(path.join(ROOT, `tmp`, `oracle-key-objects-`))
+	alternatesBefore = env.GIT_ALTERNATE_OBJECT_DIRECTORIES
+	// Read from there beside the real database rather than instead of it, since every other hash a case asks for is the working tree's
+	env.GIT_ALTERNATE_OBJECT_DIRECTORIES = objects
+})
+
+afterAll(() => {
+	if (alternatesBefore === undefined) delete env.GIT_ALTERNATE_OBJECT_DIRECTORIES
+	else env.GIT_ALTERNATE_OBJECT_DIRECTORIES = alternatesBefore
+
+	rmSync(objects, { recursive: true, force: true })
+})
+
+// #561: the builder of this key stood in `compare.ts`, which no case can import, so an input dropped from it turned nothing red — the inputs were whole, and stayed so by nobody's asking
+describe(`what an oracle result is kept under`, () => {
+	it(`names the oracle, so that six oracles over one side stand under six keys`, () => {
+		expect(inputsOf(`converge`, `HEAD`).oracle).toBe(`converge`)
+		expect(keyOf(inputsOf(`converge`, `HEAD`))).not.toBe(keyOf(inputsOf(`control`, `HEAD`)))
+	})
+
+	it(`names the sources of the oracles, which are the scripts that measure and the corpus they measure`, () => {
+		expect(inputsOf(`converge`, `HEAD`).oracles).toBe(hashSourcesAt(`worktree`, `scripts/oracles`))
+	})
+
+	it(`names the sources of the harness, which every oracle runs through`, () => {
+		expect(inputsOf(`converge`, `HEAD`).harness).toBe(hashSourcesAt(`worktree`, `scripts/harness`))
+	})
+
+	it(`takes every input but the rules from the working tree, so that the two sides are asked one question`, () => {
+		let side = fabricatedSide()
+		let inputs = inputsOf(`converge`, side)
+
+		expect(inputs.lib).toBe(hashAt(side, `lib`))
+		expect(inputs.lib).not.toBe(hashAt(`worktree`, `lib`))
+		expect(inputs.oracles).toBe(hashSourcesAt(`worktree`, `scripts/oracles`))
+		expect(inputs.harness).toBe(hashSourcesAt(`worktree`, `scripts/harness`))
+		expect(inputs.lock).toBe(hashAt(`worktree`, `pnpm-lock.yaml`))
+	})
+
+	it(`is all the comparison keys a result on, since that file names no hash of its own`, () => {
+		// The comparison cannot be imported by a case — it reads `argv`, runs every oracle over the side no entry answers for and writes the report as it loads — so it is read as text instead, which is how `scripts/sweeps/key.test.ts` holds the same rule about the runner of the sweeps
+		let comparison = readFileSync(path.join(ROOT, `scripts`, `oracles`, `compare.ts`), `utf8`)
+
+		expect(comparison).toMatch(/\binputsOf\(/u)
+		expect(comparison).not.toMatch(/hashAt|hashSourcesAt/u)
+	})
+})

--- a/scripts/oracles/key.ts
+++ b/scripts/oracles/key.ts
@@ -1,0 +1,19 @@
+/**
+ * Names what a side of an oracle result depends on, which is what the store keys it by.
+ *
+ * It stands apart from `compare.ts` so that it can be asked: that file runs the comparison as it is imported — it reads `argv`, runs every oracle over the side no entry answers for and writes the report — and a suite cannot put a question to it. Unlike its twin in `scripts/sweeps/`, this module is itself an input of the key it builds, since `scripts/oracles` stands in that key as the hash of its sources and this file is one of them; so an edit here moves the key of every oracle over every side, which is the right direction for a file deciding what a result is kept under.
+ */
+
+import { hashAt, hashSourcesAt } from "../harness/cache.ts"
+
+/**
+ * Names the inputs a result of one oracle over one side depends on.
+ * @param oracle - The oracle.
+ * @param revision - The side, as `hashAt` reads it.
+ * @returns The five inputs, in the order they stand in the key, which is part of it: the oracle's name, the hash Git keeps of the `lib/` tree, the hashes `hashSourcesAt` takes of the sources of `scripts/oracles` and of `scripts/harness` — which pass over the tests both directories hold and the document `scripts/oracles` holds beside its sources — and the hash of the lock file. Only `lib/` is taken at the side; the scripts and the corpus are always the working tree's, so that the two sides are asked the same question.
+ */
+function inputsOf (oracle: string, revision: string): Record<string, string> {
+	return { oracle, lib: hashAt(revision, `lib`), oracles: hashSourcesAt(`worktree`, `scripts/oracles`), harness: hashSourcesAt(`worktree`, `scripts/harness`), lock: hashAt(`worktree`, `pnpm-lock.yaml`) }
+}
+
+export { inputsOf }


### PR DESCRIPTION
An oracle result is kept under a key built out of what the result depends on — see [scripts/harness/cache.ts](../blob/measurements/scripts/harness/cache.ts) — and the function building it stood in [scripts/oracles/compare.ts](../blob/measurements/scripts/oracles/compare.ts), which runs the comparison as it is imported: it reads `argv`, runs every oracle over the side no entry answers for and writes the report. No case can import such a file, so nothing asked anything about the key, and an input dropped from it turned nothing red:

```
$ sed -i 's/oracles: hashSourcesAt(`worktree`, `scripts\/oracles`), //' scripts/oracles/compare.ts
$ vitest run scripts
 Test Files  4 passed (4)
      Tests  31 passed (31)
```

The inputs were whole on `main`, so the store handed out no wrong answer; the day one of them went, six oracles would read a kept result back over a question that had moved and report that nothing moved. #553 closed the same gap on the sweeps' side and left this one, since its axis was the sweeps' key.

`inputsOf` moves into the new `scripts/oracles/key.ts` as it was — the five inputs in the order they stood in, `lib/` at the side and everything else at the working tree, its JSDoc reworded since a test now stands beside it — and `compare.ts` imports it. `scripts/oracles/key.test.ts` holds five cases in the shape of the sweeps' suite: the oracle named, so that six oracles stand under six keys; `scripts/oracles` and `scripts/harness` as the hashes of their sources; every input but `lib/` taken at the working tree, asked over a side fabricated with `git mktree` so that no input passes by standing the same on both sides and a clone of depth 1 answers it; and `compare.ts` read as text, asked to name `inputsOf` and no hash of its own.

## What the review turned up

**Twelve mutants, each red.** `oracle` taken out and made a constant — the mutation with the widest reach, since the six oracles would then share one key and five would read the first one's answer; `lib/` taken at the working tree; `oracles` and `harness` each taken out, hashed as a tree and taken at the side; `lock` taken out and taken at the side; and `compare.ts` put back on a literal of its own. The fabricated side is the only case to catch `harness` taken at the side, since the sources of `scripts/harness` stand the same in `HEAD` as on disk.

**The new module is itself an input of the key it builds.** `scripts/oracles` stands in the key as the hash of its sources, and `NOT_A_DEPENDENCY` of `cache.ts` leaves out only a test and a document. The sweeps' `key.ts` stands outside its key and its comment says why that is no gap; this one says the opposite, since it is the one thing that differs between the twins.

**The helpers that fabricate a side are copied, not shared.** A helper under `scripts/harness` would be a source hashed into the key of every oracle and every sweep, and an edit to a test helper would send all of them to measure both sides afresh.

**Moving the builder moves no key; editing the directory does.** Over one working tree the literal `compare.ts` spelled and `inputsOf` of the new module hand back one object and one key, `9c48905eac324e74721d6c23` for `converge` over the `lib/` of `e8c7997`. But the hash of the sources of `scripts/oracles` moves with any edit under it, and it stands in the key of all six oracles and of every sweep — so the issue's last sentence, that no result in the store stops answering, is not so, and no place for the new file spares it, since `scripts/harness` is hashed too. The price is the one #553 and #544 paid for editing `cache.ts` and `compare.ts`.

**Nothing else moves.** `make verify` passes at 10 042 cases and the one skip it already carried, five of them the new file's. `make oracles` measures the base afresh under a new key, one run answering for both sides since no file of `lib/` is touched, and answers converge 0, control 2, comments 0, twins 9, nodes 0 and pairs 3, all at `+0 −0 ~0`. `styled-first-line` runs over the real store under a new key of its own, 200 rows and none moved. `hashOf` in `scripts/harness/cache.test.ts` named `compare.ts` and `run.ts` as the hashers of the directories on disk, which after #553 and this branch neither is; its JSDoc names the two `key.ts` instead.

Closes #561
