### PR TITLE
Keep the suite out of the directories a session works in

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
 	test: {
 		setupFiles: [`./vitest.setup.ts`],
 		reporters: env.CI ? [`github-actions`, `default`] : [`dot`],
-		// `tmp/` holds work that belongs to a session rather than to the repository, and a checkout of another revision parked there brings a whole second suite with it — one that the setup file would test against this revision's plugin. The defaults are kept so that a later version of Vitest can add to them.
-		exclude: [...configDefaults.exclude, `tmp/**`],
+		// Three directories hold work that belongs to a session rather than to the repository, and a checkout of another revision parked in one of them brings a whole second suite with it — one that the setup file would test against this revision's plugin. `tmp/` is where a session puts its own scratch work; `.claude/` is one directory reached by every worktree through a symlink, so an agent worktree under `.claude/worktrees/` stands in every checkout at once; `.agents/` holds the guidance `.claude/skills` points at. Vitest walks into all three, dot in the name or not. The defaults are kept so that a later version of Vitest can add to them.
+		exclude: [...configDefaults.exclude, `tmp/**`, `.claude/**`, `.agents/**`],
 		isolate: false,
 		watch: false,
 		coverage: {


### PR DESCRIPTION
Vitest collected every `*.test.ts` under `.claude/` and `.agents/` as the checkout's own: the config excluded `tmp/**` beside Vitest's defaults and nothing else, and a dot in a directory's name stops the walk nowhere. `.claude/` is the one directory every worktree reaches through a symlink, so an agent worktree parked under `.claude/worktrees/` — a whole checkout of another revision, carrying a suite of its own — stood in every checkout at once, and the setup file ran its cases against this revision's plugin. #589 measures it: 595 files and 24 red cases in a tree whose own suite was 297 files and green.

All three directories are excluded now.

## What was run

A probe put one `*.test.ts` under each directory and asked `vitest list --filesOnly` what it collects. Before the change both `.agents/probe.test.ts` and `.claude/worktrees/probe-tmp/probe.test.ts` were listed; after it neither is, and the suite collects its own 302 files.

The same probe closes a second door. A `FILE=` filter is a path substring, so `make test FILE=lib/rules/indentation` used to reach a sibling session's `.claude/worktrees/…/lib/rules/indentation/index.test.ts` as well; with that file in place, `vitest list --filesOnly lib/rules/indentation` now lists none of it.

`make verify` passes over the whole tree: 302 files, 10163 tests passed and 1 skipped, and `check`, `lint`, `prose-check`, `breaks-check`, `build` and `packages-check` all green.

## The other two walkers the issue asks about

Neither needs a change, and both were measured rather than reasoned about.

`oxlint` passes over a git-ignored path even when the path is named in full — `oxlint tmp/probe.test.ts` answers `No files found to lint` — and `.claude` stands in `.git/info/exclude`, so `oxlint .claude` lints nothing. `.agents/` it does walk, at every depth, because that directory is tracked; it holds nine markdown files and no source today, so there is nothing there for it to report.

The `related` run of the `pre-commit` hook reads a copy that `git checkout-index` writes out of the index, which holds tracked files only, so nothing under `.claude/` is in the tree it collects from.

`tsc` reads neither directory: `--listFilesOnly` names no path under either, since a TypeScript glob passes over a name opening with a dot.

Closes #589
