### PR TITLE
Lift the loop that reads what the neighbours ask into `whitespaceAsked`

### DIFF
--- a/lib/utils/whitespaceAsked/index.test.ts
+++ b/lib/utils/whitespaceAsked/index.test.ts
@@ -1,0 +1,74 @@
+import { type Declaration, parse, type Rule } from "postcss"
+import type { PostcssResult } from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import { css } from "../../syntaxes/css/index.ts"
+import type { NeighbourRule } from "../neighbourSettings/index.ts"
+
+import { type Whitespace, whitespaceAsked } from "./index.ts"
+
+const NEWLINE_AFTER = `@stylistic/function-comma-newline-after`
+const SPACE_AFTER = `@stylistic/function-comma-space-after`
+
+/** The two rules about the run behind a call's comma, which is the run the tests below ask about. */
+const RULES: Partial<Record<Whitespace, NeighbourRule>> = {
+	newline: {
+		name: `function-comma-newline-after`,
+		options: [`always`, `always-multi-line`, `never-multi-line`],
+	},
+	space: {
+		name: `function-comma-space-after`,
+		options: [`always`, `never`, `always-single-line`, `never-single-line`],
+	},
+}
+
+describe(`whitespaceAsked`, () => {
+	it(`nothing where no rule speaks of the run, or the fallback the caller names`, () => {
+		expect(ask({})).toBe(``)
+		expect(ask({}, ` `)).toBe(` `)
+		expect(ask({ [NEWLINE_AFTER]: `always-multi-line` }, ` `)).toBe(` `)
+		expect(ask({ [SPACE_AFTER]: `sometimes` }, ` `)).toBe(` `)
+	})
+
+	it(`nothing under a never option, whatever the fallback, since the rule speaks and asks for none`, () => {
+		expect(ask({ [SPACE_AFTER]: `never` }, ` `)).toBe(``)
+		expect(ask({ [SPACE_AFTER]: `never-single-line` }, ` `)).toBe(``)
+	})
+
+	it(`a line break under the newline rule's always, and a space under the space rule's`, () => {
+		expect(ask({ [NEWLINE_AFTER]: `always` })).toBe(`\n`)
+		expect(ask({ [SPACE_AFTER]: `always` })).toBe(` `)
+		expect(ask({ [SPACE_AFTER]: [`always-single-line`, {}] })).toBe(` `)
+	})
+
+	it(`the rule the configuration lists later, where both speak, since that is the one that runs last`, () => {
+		expect(ask({ [SPACE_AFTER]: `always`, [NEWLINE_AFTER]: `always` })).toBe(`\n`)
+		expect(ask({ [NEWLINE_AFTER]: `always`, [SPACE_AFTER]: `always` })).toBe(` `)
+		expect(ask({ [NEWLINE_AFTER]: `always`, [SPACE_AFTER]: `never` })).toBe(``)
+	})
+
+	it(`a rule whose fix is turned off only where no live rule speaks`, () => {
+		expect(ask({ [SPACE_AFTER]: [`never`, { disableFix: true }] }, ` `)).toBe(``)
+		expect(ask({ [NEWLINE_AFTER]: [`always`, { disableFix: true }] })).toBe(`\n`)
+		expect(ask({ [SPACE_AFTER]: `always`, [NEWLINE_AFTER]: [`always`, { disableFix: true }] })).toBe(` `)
+		expect(ask({ [NEWLINE_AFTER]: [`always`, { disableFix: true }], [SPACE_AFTER]: `never` })).toBe(``)
+	})
+
+	it(`the break the file spells its lines with`, () => {
+		expect(ask({ [NEWLINE_AFTER]: `always` }, ``, `a {\r\n\tb: c\r\n}`)).toBe(`\r\n`)
+	})
+})
+
+/**
+ * Reads the whitespace a fix would write behind the comma of a call in the last declaration of a stylesheet's first rule, the call standing on one line.
+ * @param rules - The rules the configuration lists, in the order it lists them.
+ * @param fallback - What to write where no rule speaks.
+ * @param code - The stylesheet.
+ * @returns The whitespace.
+ */
+function ask (rules: Record<string, unknown>, fallback: string = ``, code: string = `a { b: c }`): string {
+	let decl = (parse(code).first as Rule).last as Declaration
+	let result = { stylelint: { config: { rules } } } as unknown as PostcssResult
+
+	return whitespaceAsked(css, decl, result, RULES, () => true, fallback)
+}

--- a/lib/utils/whitespaceAsked/index.ts
+++ b/lib/utils/whitespaceAsked/index.ts
@@ -1,0 +1,50 @@
+import type { Node } from "postcss"
+import type { PostcssResult } from "stylelint"
+
+import type { Syntax } from "../../syntaxes/index.ts"
+import { getLineBreak } from "../getLineBreak/index.ts"
+import { type NeighbourRule, neighbourSettings, speaksOf } from "../neighbourSettings/index.ts"
+
+/** The whitespace a rule about a run writes: a line break, or a single space. A rule asking for neither is a `never`, and asks for nothing at all. */
+export type Whitespace = `newline` | `space`
+
+/**
+ * Reads what the rules about one run of whitespace ask a writer to put there, so that a fix writing the run spells it the way those rules would rather than bare, for one of them to respell on the run after — or, where the rule has no fixer, to report on every run after and never put right.
+ *
+ * Stylelint runs each rule once and in the order the configuration lists them, so a run written behind a rule about it is one that rule never sees until the next run of `--fix` (#354). The settings are read through `neighbourSettings`, under the names of the namespace the asking rule is registered under and in the order the run makes them.
+ *
+ * Where two rules speak of the run, the one the configuration lists later wins — an `always` with its whitespace, a `never` with none: that is the rule that runs last, and over a run the file spelled from the start it rewrites or strips what the other wrote, so the file ends up spelling such runs one way either way, a configuration contradicting itself included. The winner is the last-listed speaking rule whose fix is turned on, since that is the last write the file gets: a speaking rule whose fix the configuration turned off cannot rewrite what a live one leaves, so it wins only where no live one speaks — and there the whitespace it asks for is still written, the write being the caller's own text rather than the turned-off fix (#485).
+ * @param syntax - The syntax the asking rule is built over, whose namespace names the rules.
+ * @param node - The node the run is written into, which the line break is read for.
+ * @param result - The Stylelint result, which holds the configuration.
+ * @param rules - The rules about the run, by the whitespace each of them writes.
+ * @param isSingleLine - Whether the text those rules count the lines of stands on one line, asked only where an option turns on it.
+ * @param fallback - What to write where no rule speaks of the run at all, which is nothing unless the caller says otherwise.
+ * @returns The whitespace: the line break `getLineBreak` gives, a single space, nothing, or the fallback.
+ */
+export function whitespaceAsked (syntax: Syntax, node: Node, result: PostcssResult, rules: Partial<Record<Whitespace, NeighbourRule>>, isSingleLine: () => boolean, fallback: string = ``): string {
+	let spoke = false
+	let asked: Whitespace | undefined
+	let askedByTurnedOff: Whitespace | undefined
+	let aFixSpeaks = false
+
+	for (let [kind, option, fixTurnedOff] of neighbourSettings(syntax, result, rules)) {
+		if (!speaksOf(option, isSingleLine)) continue
+
+		spoke = true
+
+		if (fixTurnedOff) {
+			askedByTurnedOff = option.startsWith(`always`) ? kind : undefined
+			continue
+		}
+
+		aFixSpeaks = true
+		asked = option.startsWith(`always`) ? kind : undefined
+	}
+
+	if (!spoke) return fallback
+	if (!aFixSpeaks) asked = askedByTurnedOff
+	if (asked === `newline`) return getLineBreak(syntax, node, result)
+
+	return asked === `space` ? ` ` : ``
+}

--- a/lib/utils/whitespaceBeforeSemicolon/index.ts
+++ b/lib/utils/whitespaceBeforeSemicolon/index.ts
@@ -4,10 +4,10 @@ import type { PostcssResult } from "stylelint"
 import { TRAILING_CSS_WHITESPACE } from "../../regexps.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
 import { blockString } from "../blockString/index.ts"
-import { getLineBreak } from "../getLineBreak/index.ts"
 import { isSingleLineString } from "../isSingleLineString/index.ts"
-import { type NeighbourRule, neighbourSettings, speaksOf } from "../neighbourSettings/index.ts"
+import type { NeighbourRule } from "../neighbourSettings/index.ts"
 import { isAtRule } from "../typeGuards/index.ts"
+import { type Whitespace, whitespaceAsked } from "../whitespaceAsked/index.ts"
 
 /** The rules about the whitespace in front of a semicolon, by the kind of node the semicolon closes and by the whitespace each of them writes. A declaration block's semicolons have two, one for the break and one for the space; an at-rule's has the space alone. */
 const RULES_OF_WHITESPACE: Record<`decl` | `atrule`, Partial<Record<Whitespace, NeighbourRule>>> = {
@@ -29,15 +29,12 @@ const RULES_OF_WHITESPACE: Record<`decl` | `atrule`, Partial<Record<Whitespace, 
 	},
 }
 
-/** The whitespace one of those rules writes. */
-type Whitespace = `newline` | `space`
-
 /**
  * The whitespace a fix writes in front of a semicolon it puts behind a declaration or a bodiless at-rule, so that the semicolon is written the way the rules about that whitespace ask for rather than bare, for one of them to respell afterwards — or, where the rule has no fixer, to report on every run after and never to put right.
  *
  * Stylelint runs each rule once and in the order the configuration lists them, so a semicolon written behind `declaration-block-semicolon-newline-before` or `declaration-block-semicolon-space-before` is one those rules never see until the next run of `--fix` (#354), and one written behind `at-rule-semicolon-space-before` is one that rule reports on the run after and cannot fix at all (#477). Their settings are read through `neighbourSettings`, under the names of the namespace the asking rule is registered under and in the order the run makes them.
  *
- * Where two rules speak of the block, the one the configuration lists later wins — an `always` with its whitespace, a `never` with none: that is the rule that runs last, and over a semicolon the file spelled from the start it rewrites or strips what the other wrote, so the block ends up spelling its semicolons one way either way, a configuration contradicting itself included.
+ * Which of two rules speaking of the block wins is `whitespaceAsked`'s question, and it is answered there the same way for every run a fix writes: the later-listed one whose fix is turned on.
  *
  * Whether the block stands on one line is asked of it as it stands when the fix is written, which is what the rule itself would read on the run after, and a rule listed ahead may have broken the block already; a rule listed behind still may, and which of the two the `-single-line` and `-multi-line` options speak of is #355's question rather than this one's.
  * @param syntax - The syntax the asking rule is built over, whose namespace names the rules and which says whether an at-rule is one the rule about it reads.
@@ -56,9 +53,6 @@ export function whitespaceBeforeSemicolon (syntax: Syntax, node: AtRule | Declar
 	// Held under a name of its own, since the narrowing above does not reach into the function below
 	let block = parent
 	let singleLine: boolean | undefined
-	let asked: Whitespace | undefined
-	let askedByTurnedOff: Whitespace | undefined
-	let aFixSpeaks = false
 
 	/**
 	 * Asks whether the block stands on one line, printing it once however many options turn on the answer.
@@ -70,23 +64,7 @@ export function whitespaceBeforeSemicolon (syntax: Syntax, node: AtRule | Declar
 		return singleLine
 	}
 
-	// The winner is the last-listed speaking rule whose fix is turned on, since that is the last write the file gets: a speaking rule whose fix the configuration turned off cannot rewrite what a live one leaves, so it wins only where no live one speaks — and there the whitespace it asks for is still written, the write being this writer's own text rather than the turned-off fix (#485)
-	for (let [kind, option, fixTurnedOff] of neighbourSettings(syntax, result, RULES_OF_WHITESPACE[node.type])) {
-		if (!speaksOf(option, isSingleLine)) continue
-
-		if (fixTurnedOff) {
-			askedByTurnedOff = option.startsWith(`always`) ? kind : undefined
-			continue
-		}
-
-		aFixSpeaks = true
-		asked = option.startsWith(`always`) ? kind : undefined
-	}
-
-	if (!aFixSpeaks) asked = askedByTurnedOff
-	if (asked === `newline`) return getLineBreak(syntax, node, result)
-
-	return asked === `space` ? ` ` : ``
+	return whitespaceAsked(syntax, node, result, RULES_OF_WHITESPACE[node.type], isSingleLine)
 }
 
 /**


### PR DESCRIPTION
A fix that writes a delimiter has to spell the whitespace around it the way the rules about that whitespace ask, or a neighbour the configuration lists ahead of it is left with a warning that only the next run of `--fix` puts right — the `hard` class of the `pairs` oracle, and the census #356 closed. The loop that answers it is the one `whitespaceBeforeSemicolon` arrived at over #354, #477, #478, #479 and #485, and it was written out into `whitespaceAsked` on the branch of #521, whose pull request closed unmerged when the rule it was written for was judged not a stylistic plugin's business. So the utility and its unit test have been orphaned on `origin/fraction` at `10cc478` ever since, and this lifts the two of them, with the semicolon writer that reads through them, and nothing else of that branch. What the writer answers is unchanged, measured over five configurations by a probe run in a process per side, `514b248` against the branch:

```
input: a { color: red }

trailing-semicolon: always, semicolon-space-before: always                 "a { color: red ; }"
trailing-semicolon: always, semicolon-space-before: never                  "a { color: red; }"
trailing-semicolon: always, semicolon-newline-before: always               "a { color: red\n; }"
space-before: always, then trailing-semicolon, then newline-before: always "a { color: red\n; }"
trailing-semicolon: always, semicolon-space-before: always + disableFix    "a { color: red ; }"
```

`whitespaceAsked(syntax, node, result, rules, isSingleLine, fallback)` gives the whitespace a writer is to put into one run: the later-listed live rule wins, whether it asks with an `always` or takes the run away with a `never`; a neighbour whose fix the configuration turned off wins only where no live rule speaks (#485); `getLineBreak` gives the break. What the loop gained in the move out is the `fallback`, the answer for a run no rule speaks of at all, since a writer putting a run where none stood has a text of its own to write there. `whitespaceBeforeSemicolon` leaves that fallback at its default of nothing and reads through the utility, and the `Whitespace` type moves with the loop rather than being declared a second time.

## What the review turned up

- **No review round has run on this code.** The branch it was written on never had one, and what its pull request said about it is what the probes and the oracles turned up while it was written. This is where it gets read.
- **Nothing a user sees moves, so there is no changelog entry.** `make verify` is green — 303 files, 10176 tests — and the four rules that write a semicolon through the writer were run on their own besides.
- **The oracles answer row for row as over `514b248`**: all six at `+0 −0 ~0`, `pairs` still on the three rows of #536.
- **The unit test comes over whole because of the one pair no `testRule` case can hold.** Two live rules contradicting each other over one run — `function-comma-space-after: always` with `function-comma-newline-after: always` — cannot be pinned by a rule's own suite, since the relint the testing library runs after `fixed` reports whichever of the two lost.
- **The utility arrives without the rule it was written for.** `grid-flexible-track-no-content-minimum` stays on `origin/fraction`. The consumer it is lifted for is #550: `aspect-ratio-notation` writes a solidus and reads nobody about the whitespace around it, so once the four rules of #548 exist it would write, under `value-slash-space-before: never`, a run one of them has to strip on the run after.

Closes #549.
