### PR TITLE
Print a declaration down to the end of its value once, and name what stands behind it at either caller

### DIFF
--- a/lib/syntaxes/scss/index.test.ts
+++ b/lib/syntaxes/scss/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 
 import { declarationColonSource } from "../../utils/declarationColonSource/index.ts"
 import { declarationString } from "../../utils/declarationString/index.ts"
+import { declarationThroughValue } from "../../utils/declarationThroughValue/index.ts"
 import { moveDeclarationValueHeadIntoBetween } from "../../utils/moveDeclarationValueHeadIntoBetween/index.ts"
 
 import { scss } from "./index.ts"
@@ -30,6 +31,10 @@ describe(`the shared utils over the adapter's pair`, () => {
 
 	it(`declarationString prints the spelled copy with the bang behind it`, () => {
 		expect(declarationString(scss, firstDecl(`a { margin: 0 // c\n  1px !important }`))).toBe(`margin: 0 // c\n  1px !important`)
+	})
+
+	it(`declarationThroughValue prints the spelled copy and stops in front of the bang`, () => {
+		expect(declarationThroughValue(scss, firstDecl(`a { margin: 0 // c\n  1px !important }`))).toBe(`margin: 0 // c\n  1px`)
 	})
 
 	it(`moveDeclarationValueHeadIntoBetween takes the whitespace in front of an inline comment, the comment staying in the value`, () => {

--- a/lib/utils/declarationColonSource/index.ts
+++ b/lib/utils/declarationColonSource/index.ts
@@ -2,13 +2,13 @@ import type { Declaration } from "postcss"
 import type { PostcssResult } from "stylelint"
 
 import type { Syntax } from "../../syntaxes/index.ts"
-import { declarationValueIndex } from "../declarationValueIndex/index.ts"
+import { declarationThroughValue } from "../declarationThroughValue/index.ts"
 import { runPastDeclaration } from "../runPastDeclaration/index.ts"
 
 /**
  * Builds the text a rule reads to see what a declaration prints behind its colon.
  *
- * PostCSS hands the whitespace standing after the colon to `raws.between` only where the value has a word of its own to leave behind. Where it has none — where all that stands behind the colon is whitespace, comments and a flag — `raws.between` ends at the colon and the run stays at the head of the value instead: in the raw of it where PostCSS keeps one, and in `decl.value` itself where it does not. So the value is laid behind the property and that raw, in the copy of it the syntax prints, and the run is in this text wherever the declaration keeps it.
+ * PostCSS hands the whitespace standing after the colon to `raws.between` only where the value has a word of its own to leave behind. Where it has none — where all that stands behind the colon is whitespace, comments and a flag — `raws.between` ends at the colon and the run stays at the head of the value instead: in the raw of it where PostCSS keeps one, and in `decl.value` itself where it does not. So the text opens on the declaration down to the end of its value, as {@link declarationThroughValue} prints it, and the run is in this text wherever the declaration keeps it.
  *
  * Where the declaration prints nothing at all behind its colon and the file writes no semicolon behind it, the run reaches none of those three copies and stands in the raw of whatever the file wrote next, so it is laid out behind the value in its turn. `runPastDeclaration` is what says whether there is such a run and where it stands, and the text a rule reads is the whole of what the file spells behind the colon either way — save at the end of a stylesheet, where that raw is the one the stylesheet closes its last line in and `runPastDeclaration` hands it to nobody, so the text ends at the colon whatever stands behind it. The two rules that read behind the colon pass such a declaration over before they ask for this text at all; `declaration-colon-space-before` asks for it and reads in front of the colon, where the run is no part of what it counts.
  * https://github.com/stylelint-stylistic/stylelint-stylistic/issues/387
@@ -16,12 +16,12 @@ import { runPastDeclaration } from "../runPastDeclaration/index.ts"
  *
  * The characters tacked onto the end give the checker something that is not whitespace to read behind the colon. Either caller reads two at the most — one asks about a space and the other about one character only — and the third stands against the branch of the checker that reads a character further than that, which neither of them reaches. A declaration with no value at all — `a { color:; }` — ends at the colon, and both halves of the checker return without a word where the character they ask about is not there, so `always` would pass such a declaration over in silence.
  *
- * `declarationString` lays out the same property, raw and value; behind them it prints the flag — the raw of it where PostCSS kept one, and a spelling of its own where it did not — since what it is written for is to give the declaration back as the file spells it, for a position to be counted in. This text is written to be read past the colon instead, and where the file spells nothing behind the value there has to be something there to read.
+ * The flag is nowhere in this text: {@link declarationString} prints it behind the same value, and where the file spells nothing behind the value there has to be something here to read past the colon instead.
  * @param syntax - The syntax the rule is built over.
  * @param decl - The CSS declaration node.
  * @param result - The Stylelint result, which holds the syntax the file was opened with.
  * @returns The declaration as the file prints it, up to the end of the value and of whatever run ran on past it, with a sentinel behind that.
  */
 export function declarationColonSource (syntax: Syntax, decl: Declaration, result: PostcssResult): string {
-	return `${decl.toString().slice(0, declarationValueIndex(decl))}${syntax.read(decl)}${runPastDeclaration(syntax, decl, result) ?? ``}xxx`
+	return `${declarationThroughValue(syntax, decl)}${runPastDeclaration(syntax, decl, result) ?? ``}xxx`
 }

--- a/lib/utils/declarationString/index.ts
+++ b/lib/utils/declarationString/index.ts
@@ -1,12 +1,12 @@
 import type { Declaration } from "postcss"
 
 import type { Syntax } from "../../syntaxes/index.ts"
-import { declarationValueIndex } from "../declarationValueIndex/index.ts"
+import { declarationThroughValue } from "../declarationThroughValue/index.ts"
 
 /**
- * Prints a declaration as the file spells it.
+ * Prints a declaration as the file spells it, from its property to the end of its bang, if it has one.
  *
- * `decl.toString()` prints it through the stringifier of PostCSS itself, which knows nothing of the second copy `postcss-scss` keeps of a value carrying an inline comment and prints the raw one, with every `//` comment rewritten into a block comment. A position counted in that string therefore stands two characters further along per comment than the file spells it, and a fix reading the value through `syntax.read` and cutting it at that position cuts it in the wrong place.
+ * The declaration down to the end of its value is what {@link declarationThroughValue} prints, in the copy the syntax spells it in; behind that this prints the flag — the raw of it where PostCSS kept one, and a spelling of its own where it did not — since what the text is written for is to give the declaration back as the file spells it, for a position to be counted in.
  *
  * This is not {@link nodeString} on a declaration, and the two answer different questions. A Sass nested property is a declaration carrying a block, and `postcss-scss` prints that block where PostCSS prints nothing at all, so `nodeString` hands back `font: 12px { family: serif; }` where this hands back `font: 12px`. What the callers here read is the text a bang, a comma or the semicolon of **that** declaration stands in, and every position they write is counted in it: a block behind the value holds none of the three, and taking one in would put a second copy of everything the block's own declarations carry in front of the checker, and every fix at the wrong end of the text. `indentation` reads none of the three and asks only how wide the declaration is, which is the same question one line further out.
  * @param syntax - The syntax the rule is built over.
@@ -16,6 +16,5 @@ import { declarationValueIndex } from "../declarationValueIndex/index.ts"
 export function declarationString (syntax: Syntax, decl: Declaration): string {
 	let important = decl.important ? (decl.raws.important || ` !important`) : ``
 
-	// Only the value is spelled in two copies: the property and everything between it and the value are printed as they stand, so the string PostCSS prints holds them exactly as the file does
-	return decl.toString().slice(0, declarationValueIndex(decl)) + syntax.read(decl) + important
+	return declarationThroughValue(syntax, decl) + important
 }

--- a/lib/utils/declarationThroughValue/index.test.ts
+++ b/lib/utils/declarationThroughValue/index.test.ts
@@ -1,0 +1,57 @@
+import postcss, { type Declaration, type Parser, type Rule } from "postcss"
+import less from "postcss-less"
+import { describe, expect, it } from "vitest"
+
+import { css as syntax } from "../../syntaxes/css/index.ts"
+
+import { declarationThroughValue } from "./index.ts"
+
+/**
+ * Reads the first declaration of a stylesheet and prints it down to the end of its value.
+ * @param parser - The parser to read the stylesheet with.
+ * @param css - The stylesheet, whose first rule holds the declaration.
+ * @returns The text.
+ */
+function through (parser: { parse: Parser }, css: string): string {
+	let rule = parser.parse(css).first as Rule
+
+	return declarationThroughValue(syntax, rule.first as Declaration)
+}
+
+describe(`declarationThroughValue`, () => {
+	it(`a value with a word of its own, whose run behind the colon PostCSS keeps in \`raws.between\``, () => {
+		expect(through(postcss, `a { color:  pink; }`)).toBe(`color:  pink`)
+	})
+
+	it(`a comment inside the value, which the raw of the value keeps and \`decl.value\` drops`, () => {
+		expect(through(postcss, `a { margin: 0 /* c */ 1px; }`)).toBe(`margin: 0 /* c */ 1px`)
+	})
+
+	it(`a comment in front of the colon, which is printed as it stands`, () => {
+		expect(through(postcss, `a { color/*c*/ : pink; }`)).toBe(`color/*c*/ : pink`)
+	})
+
+	it(`a flag behind the value, which is no part of the text`, () => {
+		expect(through(postcss, `a { color: pink  ! important; }`)).toBe(`color: pink`)
+	})
+
+	it(`a value holding no word, whose run stays at the head of the value's raw and the flag is printed behind`, () => {
+		expect(through(postcss, `a { color:  !important; }`)).toBe(`color:  `)
+	})
+
+	it(`a declaration with no value at all, which ends at the colon`, () => {
+		expect(through(postcss, `a { color:; }`)).toBe(`color:`)
+	})
+
+	it(`a declaration printing nothing behind its colon, whose run the block's own raw holds and the text stops in front of`, () => {
+		expect(through(postcss, `a { color:  }`)).toBe(`color:`)
+	})
+
+	it(`a custom property whose whitespace PostCSS keeps in \`decl.value\` itself`, () => {
+		expect(through(postcss, `a { --b:  ; }`)).toBe(`--b:  `)
+	})
+
+	it(`a comment opened by a double slash under Less, where the parser reads it as the value's own word`, () => {
+		expect(through(less, `a { color:  //c\n!important; }`)).toBe(`color:  //c`)
+	})
+})

--- a/lib/utils/declarationThroughValue/index.ts
+++ b/lib/utils/declarationThroughValue/index.ts
@@ -1,0 +1,19 @@
+import type { Declaration } from "postcss"
+
+import type { Syntax } from "../../syntaxes/index.ts"
+import { declarationValueIndex } from "../declarationValueIndex/index.ts"
+
+/**
+ * Prints a declaration from its property to the end of its value, as the file spells it.
+ *
+ * `decl.toString()` prints the declaration through the stringifier of PostCSS itself, which knows nothing of the second copy `postcss-scss` keeps of a value carrying an inline comment and prints the raw one, with every `//` comment rewritten into a block comment. A position counted in that string therefore stands two characters further along per comment than the file spells it, and a fix reading the value through `syntax.read` and cutting it at that position cuts it in the wrong place. Only the value is spelled in two copies: the property and everything between it and the value are kept once, so the string PostCSS prints holds them as every syntax prints them, and it is cut in front of the value and the copy the syntax prints laid behind the cut.
+ *
+ * What stands behind the value is the caller's to name, and the two callers name different things: {@link declarationString} prints the flag there, so that a position can be counted in the declaration as the file spells it, while {@link declarationColonSource} prints the run that ran on past the declaration and a sentinel, so that a checker reading past the colon has a character to ask about where the file spells none. Neither text is the other with something taken off — `a { color:  !important; }` prints as `color:  !important` to the one and as `color:  xxx` to the other — so neither is built over the other.
+ * https://github.com/stylelint-stylistic/stylelint-stylistic/issues/415
+ * @param syntax - The syntax the rule is built over.
+ * @param decl - The declaration to print.
+ * @returns The declaration, from its property to the end of its value.
+ */
+export function declarationThroughValue (syntax: Syntax, decl: Declaration): string {
+	return decl.toString().slice(0, declarationValueIndex(decl)) + syntax.read(decl)
+}


### PR DESCRIPTION
`declarationString` and `declarationColonSource` laid out one text and parted only behind it. Both cut the string PostCSS prints in front of the value and lay the copy of the value the syntax spells behind the cut; the first then prints the flag, the second the run that ran on past the declaration and a sentinel. The same two imports, the same slice, the same paragraph of explanation in either JSDoc, one directory apart:

```js
// declarationString
return decl.toString().slice(0, declarationValueIndex(decl)) + syntax.read(decl) + important
// declarationColonSource
return `${decl.toString().slice(0, declarationValueIndex(decl))}${syntax.read(decl)}${runPastDeclaration(syntax, decl, result) ?? ``}xxx`
```

`declarationThroughValue` now prints the declaration from its property to the end of its value, and both are one line over it, each naming its own tail. Neither is built over the other, since neither is the other with something taken off: `a { color:  !important; }` prints as `color:  !important` to the one and as `color:  xxx` to the other. No caller changes, and no text a rule reads does. `declarationValueAsSpelled`, the third reading over the same declaration, is left alone: it shares only `syntax.read` with the two, opens on the tail of `raws.between` rather than on the property and cuts the trailing run off, since the lines a reader sees are another question than the position a fix writes at.

## What the review turned up

- **Nothing moves.** The six oracles against `81d16b8` read `+0 −0 ~0` each, and the three sweeps on the colon's axis — `run-past-declaration`, `colon-lineness`, `colon-in-comment` — read 159 552 rows with none changed. That the corpus sees the shared line rather than passing it by is shown by five mutants of the branch, each measured in a process of its own over the same three corpora: `decl.value` for the syntax's copy moves 6 168 rows, a cut behind the colon rather than in front of the value 21 654, the sentinel taken off 1 800, the run past the declaration taken off 1 404, the flag taken off 1 018.
- **No changelog entry.** Nothing a user of the package sees changes, and an entry forces a release.
- **Spin-offs.** None.

Closes #415.
