### PR TITLE
Pin the column a warning past an interpolation reports under `postcss-styled-syntax`

### DIFF
--- a/lib/syntaxes/styled/rules/declaration-block-single-line-max-declarations/index.test.ts
+++ b/lib/syntaxes/styled/rules/declaration-block-single-line-max-declarations/index.test.ts
@@ -39,7 +39,7 @@ testRule({
 			endColumn: 57,
 			message: messages.expected(1),
 		},
-		// #641; the span ends two columns short of the brace, as the base reports it (#644)
+		// #641
 		{
 			description: `a single-line block holding an interpolated declaration beside another inside a template, whose runs the fix writes as in a stylesheet`,
 			code: `const A = styled.div\`a { color: \${c}; top: 0; }\``,
@@ -48,6 +48,17 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 48,
+			message: messages.expected(1),
+		},
+		// #644; interpolations of unequal length, so the span's end moves where either is counted short
+		{
+			description: `a single-line block holding two interpolated declarations inside a template`,
+			code: `const A = styled.div\`a { color: \${c}; top: \${dd}; }\``,
+			fixed: `const A = styled.div\`a {\ncolor: \${c};\ntop: \${dd};\n}\``,
+			line: 1,
+			column: 24,
+			endLine: 1,
+			endColumn: 52,
 			message: messages.expected(1),
 		},
 	],


### PR DESCRIPTION
Issue #644 does not reproduce. Under `postcss-styled-syntax` a warning standing past a `${…}` interpolation lands exactly where the file spells it, both at the base of this branch and at `f4048da`, the commit the issue names. Neither the plugin nor the syntax counts an interpolation shorter than its text, so no rule changes here: the branch takes a false claim out of the suite and widens the case beside it to a span standing past two interpolations.

## What the issue reported

Over `const A = styled.div` carrying the template `a { color: ${c}; top: 0; }`, the rule `declaration-block-single-line-max-declarations: 1` reports `1:24-1:48`, and the issue reads that as ending in front of the block's closing brace. The brace stands in column 47. Stylelint's `endColumn` is the boundary past the last covered character, so `1:24-1:48` opens on the `{` in column 24 and closes past the `}` in column 47, which is the whole block. Over `a { color: ${c}; top: ${d}; }` the brace stands in column 50 and the span is `1:24-1:51`. Column 56, which the issue names there, is the brace of the neighbouring case in the same test file, the one carrying `@media (x)` in its head. The issue's third line, offered as the control without an interpolation, counts the brace at 48 as well; that template is the first one with `pink` in place of `${c}`, four characters for four, and its brace stands in column 47 too.

## How it was measured

Three probes, each run on this branch and on `f4048da`, answering the same on both.

Sixteen shapes were read character by character: the two forms of the issue, three interpolations in a row, a multi-line template, a multi-line block, a template below the first line, an interpolation in front of a line break, an interpolation as the first node of a block, two templates in one file, an interpolation in a selector, a multi-line interpolation, a nested template inside an interpolation, and an interpolation inside a block comment, inside a string, and holding a brace in quotes. Every warning of the four rules named by the issue opens and closes on the character it points at.

Every rule of the registry, with each of its primary options from `scripts/oracles/options.ts`, then ran over twelve bodies twice: once with `${c}` in the body and once with the four-letter word `aaaa` in its place, both sides under the `styled` namespace and inside the same `const A = styled.div` template, so that only the interpolation tells them apart. 2748 comparisons, 369 warnings, not one position apart. Eleven rule-option-body triples report nothing at all on the interpolated side: five selector rules over `a[x=${c}] > b`, which `isStandardSyntaxSelector` refuses, and six options of the four `value-slash-*` rules over `grid-template-columns: ${c} / 1fr`, whose value `isStandardValue` refuses.

The same runs with `${cccc}` in place of `${c}` put every warning on the same character of the file, save two rows of `max-line-length: 40` whose longer line crosses the limit. An index standing past an interpolation is mapped at the length the file spells for it.

## What the branch ships

The comment beside the interpolated case written for #641 said the span ends two columns short of the brace, "as the base reports it". It does not, and the sentence is gone.

That case stands past a single interpolation. A case standing past two of unequal length is added, `${c}` and `${dd}`, whose span `1:24-1:52` moves where either of them is counted at other than the length the file spells.

No case here is red on the base, the base answering right. Nothing under `lib/rules/` or in the styled adapter is touched, so no oracle and no sweep can move a row.

Closes #644
