### PR TITLE
Pass over the encoding declaration in the three rules that respell its head

### DIFF
--- a/lib/regexps.ts
+++ b/lib/regexps.ts
@@ -136,6 +136,9 @@ export const LEADING_CSS_WHITESPACE = /^[ \t\n\r\f]*/u
 /** The leading word, up to the first tokenizer whitespace, the complement of {@link LEADING_CSS_WHITESPACE}, for cutting a run `postcss-value-parser` read too wide ([#496](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/496)). */
 export const LEADING_CSS_WORD = /^[^ \t\n\r\f]*/u
 
+/** The encoding declaration as the fallback-encoding step of css-syntax-3 reads it out of the byte stream: at the very start, one space, the label in double quotes, a semicolon. Any other spelling declares no encoding ([#703](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/703)). */
+export const LEADING_ENCODING_DECLARATION = /^@charset "[^"]*";/u
+
 /** A leading hexadecimal escape with its one closing whitespace character; a Windows pair counts as one. */
 export const LEADING_HEX_ESCAPE = /^\\[\da-f]{1,6}(?:\r\n|[ \t\n\r\f])?/iu
 

--- a/lib/rules/at-rule-name-case/README.md
+++ b/lib/rules/at-rule-name-case/README.md
@@ -12,6 +12,8 @@ The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatical
 
 The [`message` secondary option](https://stylelint.io/user-guide/configure/#message) can accept the arguments of this rule.
 
+The rule passes over an encoding declaration spelled as the specification reads it — `@charset "utf-8";` at the very start of the file, with one space and double quotes — since no other spelling of it declares an encoding at all.
+
 ## Options
 
 `string`: `"lower"|"upper"`

--- a/lib/rules/at-rule-name-case/index.test.ts
+++ b/lib/rules/at-rule-name-case/index.test.ts
@@ -183,6 +183,11 @@ testRule({
 	config: [`upper`],
 
 	accept: [
+		// See #703
+		{
+			description: `an encoding declaration, whose lower-case name the specification asks for`,
+			code: `@charset "UTF-8";`,
+		},
 		{
 			description: `a name already in upper case`,
 			code: `@CHARSET 'UTF-8';`,
@@ -259,9 +264,18 @@ testRule({
 			message: messages.expected(`cHaRsEt`, `CHARSET`),
 		},
 		{
-			description: `the whole name in lower case`,
+			description: `the whole name in lower case, on a charset rule whose single quotes declare no encoding`,
 			code: `@charset 'UTF-8';`,
 			fixed: `@CHARSET 'UTF-8';`,
+			line: 1,
+			column: 1,
+			message: messages.expected(`charset`, `CHARSET`),
+		},
+		// See #703
+		{
+			description: `the same name on a charset rule spelled with two spaces, which declares none either`,
+			code: `@charset  "UTF-8";`,
+			fixed: `@CHARSET  "UTF-8";`,
 			line: 1,
 			column: 1,
 			message: messages.expected(`charset`, `CHARSET`),

--- a/lib/rules/at-rule-name-case/index.ts
+++ b/lib/rules/at-rule-name-case/index.ts
@@ -1,6 +1,7 @@
 import stylelint from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
+import { declaresTheEncoding } from "../../utils/declaresTheEncoding/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
@@ -43,6 +44,9 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		root.walkAtRules((atRule) => {
 			if (!syntax.isStandardAtRule(atRule)) return
+
+			// The lower-case name of an encoding declaration is the specification's, not a style (#703)
+			if (declaresTheEncoding(atRule)) return
 
 			let name = atRule.name
 

--- a/lib/rules/at-rule-name-newline-after/README.md
+++ b/lib/rules/at-rule-name-newline-after/README.md
@@ -9,6 +9,8 @@ Require a newline after at-rule names.
  * The newline after this at-rule name */
 ```
 
+The rule passes over an encoding declaration spelled as the specification reads it — `@charset "utf-8";` at the very start of the file, with one space and double quotes — since no other spelling of it declares an encoding at all.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"`
@@ -20,7 +22,7 @@ There _must always_ be a newline after at-rule names.
 The following patterns are considered problems:
 
 ```css
-@charset "UTF-8";
+@import "x.css";
 ```
 
 ```css
@@ -31,8 +33,8 @@ The following patterns are considered problems:
 The following patterns are _not_ considered problems:
 
 ```css
-@charset
-  "UTF-8";
+@import
+  "x.css";
 ```
 
 ```css
@@ -71,12 +73,12 @@ The following patterns are considered problems:
 The following patterns are _not_ considered problems:
 
 ```css
-@charset "UTF-8";
+@import "x.css";
 ```
 
 ```css
-@charset
-  "UTF-8";
+@import
+  "x.css";
 ```
 
 ```css

--- a/lib/rules/at-rule-name-newline-after/index.test.ts
+++ b/lib/rules/at-rule-name-newline-after/index.test.ts
@@ -7,6 +7,15 @@ testRule({
 	config: [`always`],
 
 	accept: [
+		// See #703
+		{
+			description: `an encoding declaration, whose single space the specification asks for`,
+			code: `@charset "UTF-8";`,
+		},
+		{
+			description: `an encoding declaration behind which the stylesheet goes on`,
+			code: `@charset "UTF-8";\na { color: pink; }`,
+		},
 		{
 			description: `a line feed behind the name`,
 			code: `@charset\n"UTF-8";`,
@@ -141,13 +150,6 @@ testRule({
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@layer`),
-		},
-		{
-			description: `a space where the break belongs`,
-			code: `@charset "UTF-8";`,
-			line: 1,
-			column: 8,
-			message: messages.expectedAfter(`@charset`),
 		},
 		{
 			description: `nothing at all where the break belongs`,

--- a/lib/rules/at-rule-semicolon-space-before/README.md
+++ b/lib/rules/at-rule-semicolon-space-before/README.md
@@ -10,6 +10,8 @@ Require a single space or disallow whitespace before the semicolons of at-r
 
 Nothing is asked of an at-rule the file spells no semicolon behind — one running to the brace that closes its container, or to the end of the file. There is no semicolon there for whitespace to stand in front of, and the whitespace that does stand there is the closing brace's or the file's own.
 
+The rule passes over an encoding declaration spelled as the specification reads it — `@charset "utf-8";` at the very start of the file, with one space and double quotes — since no other spelling of it declares an encoding at all.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/at-rule-semicolon-space-before/index.test.ts
+++ b/lib/rules/at-rule-semicolon-space-before/index.test.ts
@@ -7,6 +7,11 @@ testRule({
 	config: [`always`],
 
 	accept: [
+		// See #703
+		{
+			description: `an encoding declaration, whose semicolon the specification puts on the closing quotation mark`,
+			code: `@charset "UTF-8";`,
+		},
 		{
 			description: `a space in front of the semicolon`,
 			code: `@import "styles/mystyle" ;`,
@@ -80,6 +85,21 @@ testRule({
 	],
 
 	reject: [
+		// See #703
+		{
+			description: `a charset rule whose single quotes declare no encoding, so nothing holds the rule off it`,
+			code: `@charset 'UTF-8';`,
+			line: 1,
+			column: 16,
+			message: messages.expectedBefore(),
+		},
+		{
+			description: `the same rule spelled with two spaces, which declares none either`,
+			code: `@charset  "UTF-8";`,
+			line: 1,
+			column: 17,
+			message: messages.expectedBefore(),
+		},
 		{
 			// See #357
 			description: `an at-rule spelled without a space in front of its options, which the parser gives the shape of a call to a Less detached ruleset`,

--- a/lib/rules/at-rule-semicolon-space-before/index.ts
+++ b/lib/rules/at-rule-semicolon-space-before/index.ts
@@ -1,6 +1,7 @@
 import stylelint from "stylelint"
 
 import { css } from "../../syntaxes/css/index.ts"
+import { declaresTheEncoding } from "../../utils/declaresTheEncoding/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
@@ -49,6 +50,9 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (hasBlock(atRule)) return
 
 			if (!syntax.isStandardAtRule(atRule)) return
+
+			// The semicolon of an encoding declaration follows its closing quotation mark directly, as the specification reads it (#703)
+			if (declaresTheEncoding(atRule)) return
 
 			// The check asks about the position one past the at-rule, as though a semicolon stood there; where the file spells none the at-rule runs to its container's `}` or the end of the file, and the position is somebody else's (#395)
 			if (isLastNodeWithoutSemicolon(atRule)) return

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -2,6 +2,7 @@ import type { AtRule, Root } from "postcss"
 import stylelint, { type PostcssResult } from "stylelint"
 
 import type { Syntax } from "../../syntaxes/index.ts"
+import { declaresTheEncoding } from "../declaresTheEncoding/index.ts"
 
 let { utils: { report } } = stylelint
 
@@ -24,6 +25,9 @@ export function atRuleNameSpaceChecker (options: {
 }): void {
 	options.root.walkAtRules((atRule) => {
 		if (!options.syntax.isStandardAtRule(atRule)) return
+
+		// The one space of an encoding declaration is the specification's, not a style (#703)
+		if (declaresTheEncoding(atRule)) return
 
 		checkColon(
 			`@${atRule.name}${atRule.raws.afterName || ``}${atRule.params}`,

--- a/lib/utils/declaresTheEncoding/index.test.ts
+++ b/lib/utils/declaresTheEncoding/index.test.ts
@@ -1,0 +1,91 @@
+import { type AtRule, type Document, parse, type Root } from "postcss"
+import html from "postcss-html"
+import { parse as parseScss } from "postcss-scss"
+import { describe, expect, it } from "vitest"
+
+import { declaresTheEncoding } from "./index.ts"
+
+let parseHtml = (html as unknown as { parse: (code: string) => Document | Root }).parse
+
+describe(`declaresTheEncoding`, () => {
+	it(`the declaration the fallback-encoding step reads`, () => {
+		expect(answer(`@charset "UTF-8";`)).toBe(true)
+		expect(answer(`@charset "UTF-8";\na { color: pink; }`)).toBe(true)
+		expect(answer(`@charset "iso-8859-1";`)).toBe(true)
+		expect(answer(`@charset "";`)).toBe(true)
+	})
+
+	it(`a head the step does not match, which declares no encoding for a fix to lose`, () => {
+		expect(answer(`@charset  "UTF-8";`)).toBe(false)
+		expect(answer(`@charset\n"UTF-8";`)).toBe(false)
+		expect(answer(`@charset"UTF-8";`)).toBe(false)
+		expect(answer(`@charset 'UTF-8';`)).toBe(false)
+		expect(answer(`@charset "UTF-8" ;`)).toBe(false)
+		expect(answer(`@charset "UTF-8"`)).toBe(false)
+		expect(answer(`@CHARSET "UTF-8";`)).toBe(false)
+	})
+
+	it(`an at-rule of another name, whose head opens the file all the same`, () => {
+		expect(answer(`@media (min-width: 1px) { }`)).toBe(false)
+	})
+
+	it(`an at-rule standing behind something, which the step reads past nothing to find`, () => {
+		expect(answer(`\n@charset "UTF-8";`)).toBe(false)
+		expect(answer(`/* c */@charset "UTF-8";`, 1)).toBe(false)
+		expect(answer(`a { }\n@charset "UTF-8";`, 1)).toBe(false)
+	})
+
+	it(`a second one behind the declaration, which is the at-rule it looks like`, () => {
+		expect(answer(`@charset "UTF-8";\n@charset "UTF-8";`, 1)).toBe(false)
+	})
+
+	it(`an at-rule nested in a rule, which opens nothing`, () => {
+		expect(answer(`a { @charset "UTF-8"; }`, 0, 0)).toBe(false)
+	})
+
+	it(`the same head under another parser`, () => {
+		let root = parseScss(`@charset "UTF-8";\n// c\na { color: pink; }`)
+
+		expect(declaresTheEncoding(root.first as AtRule)).toBe(true)
+	})
+
+	it(`the head of a file opening with a byte-order mark, which PostCSS takes off the text and leaves the offsets alone`, () => {
+		expect(answer(`﻿@charset "UTF-8";\na { color: pink; }`)).toBe(true)
+	})
+
+	it(`the head of an embedded block, which no decoder reads`, () => {
+		expect(firstAtRuleOf(parseHtml(`<style>@charset "UTF-8";\na { color: pink; }</style>`))).toBe(false)
+		expect(firstAtRuleOf(parseHtml(`<style>\n@charset "UTF-8";\na { color: pink; }\n</style>\n`))).toBe(false)
+	})
+})
+
+/**
+ * Asks the util about the first at-rule of a parsed document.
+ * @param parsed - What a syntax's parser returned.
+ * @returns What the util answers, or false where the document holds no at-rule.
+ */
+function firstAtRuleOf (parsed: Document | Root): boolean {
+	let found: AtRule | undefined
+
+	parsed.walkAtRules((atRule) => {
+		found ??= atRule
+	})
+
+	return found !== undefined && declaresTheEncoding(found)
+}
+
+/**
+ * Asks the util about one at-rule of a stylesheet.
+ * @param code - The stylesheet.
+ * @param index - Which node of the root, the first by default.
+ * @param nested - Which node of that node, where the at-rule stands inside it.
+ * @returns What the util answers.
+ */
+function answer (code: string, index: number = 0, nested?: number): boolean {
+	let root = parse(code)
+	let node = root.nodes[index]
+
+	if (nested !== undefined) node = (node as unknown as { nodes: AtRule[] }).nodes[nested]
+
+	return declaresTheEncoding(node as AtRule)
+}

--- a/lib/utils/declaresTheEncoding/index.ts
+++ b/lib/utils/declaresTheEncoding/index.ts
@@ -1,0 +1,22 @@
+import type { AtRule } from "postcss"
+
+import { LEADING_ENCODING_DECLARATION } from "../../regexps.ts"
+
+/**
+ * Asks whether an at-rule is the encoding declaration a decoder reads, which the fallback-encoding step of css-syntax-3 matches in the byte stream before anything is parsed, so that no rule respells it into a file declaring nothing ([#703](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/703)).
+ *
+ * The text answers, not the raws: the step reads bytes, and what it reads is the head of the file. So the at-rule has to stand at offset zero, which is the file's start under every syntax, and the text of its root has to open with the declaration; under `postcss-html` and styled that text is the embedded block alone, and the offset is what keeps such a block from answering yes.
+ *
+ * A byte-order mark is answered yes over, PostCSS taking it off the text it hands back while the offsets stay where they were. The mark outranks the declaration there, so the at-rule declares nothing either way, and the answer only ever holds a rule back.
+ * @param atRule - The at-rule.
+ * @returns True where the at-rule is that declaration.
+ */
+export function declaresTheEncoding (atRule: AtRule): boolean {
+	if (atRule.name !== `charset` || atRule.source?.start?.offset !== 0) return false
+
+	let root = atRule.root()
+
+	if (root.first !== atRule) return false
+
+	return LEADING_ENCODING_DECLARATION.test(root.source?.input.css ?? ``)
+}


### PR DESCRIPTION
`@charset` is not a formatting choice. The fallback-encoding step of css-syntax-3 matches it in the byte stream before anything is parsed and reads exactly `@charset "`, a label, and a semicolon, so any other spelling declares nothing and the stylesheet falls back to the environment's encoding. Three rules of the plugin speak of that head, and one of them rewrites it:

```css
/* input */
@charset "UTF-8";
a { color: pink; }

/* --fix under `at-rule-name-case: "upper"`, before this branch */
@CHARSET "UTF-8";
a { color: pink; }

/* --fix under the same option, after it */
@charset "UTF-8";
a { color: pink; }
```

The second run over that output was silent, the rule having got what it asked for, so nothing said the encoding declaration was gone. `at-rule-name-newline-after` under `always` and `at-rule-semicolon-space-before` under `always` reported the same head and carry no fixer, so they only asked the user to do it by hand.

`declaresTheEncoding` reads the file's text rather than the node's raws, since that text is what a decoder reads: the at-rule is named `charset`, it stands at offset zero, it is its root's first node, and the root's text opens with `LEADING_ENCODING_DECLARATION`. Every other spelling is untouched by the reading, since it declares no encoding for a fix to lose. Whether those spellings are reported at all belongs to [stylelint/stylelint#7492](https://github.com/stylelint/stylelint/issues/7492), which asks Stylelint for an `at-charset-rule-no-invalid` rule of its own.

## What the review turned up

**The first reading was too wide.** It asked only whether the root's text opens with the declaration, and under `postcss-html` that text is the `<style>` block: `at-rule-name-case` under `upper` stopped recasing a `@charset` inside an embedded block, which no decoder reads anyway. The reading now asks the at-rule's offset as well, which is the file's start under every syntax — 8 and 7 under `postcss-html`, 13 under styled, 0 under plain CSS, SCSS, Less and over a file opening with a byte-order mark. Two cases pin it.

**A byte-order mark is answered yes over.** PostCSS takes the mark off the text it hands back and leaves the offsets where they were, so the reading says yes; the mark outranks the declaration there, so the at-rule declares nothing either way and the answer only holds a rule back.

**Nothing else rewrites that head.** Every rule of the registry under every primary `scripts/oracles/options.ts` names, over seven spellings of the declaration and three namespaces, and with every rule enabled at once: the declaration survives all of them. `unicode-bom` under `always` reports the same line for a reason of its own and carries no fixer.

**The six oracles report no row added, removed or changed** against `8ef2f6b`, and the README examples of the four rules of the family were run through the plugin — 45 examples, no mismatch with the prose above them. Two examples of `at-rule-name-newline-after` showed `@charset` as something the rule speaks of, and are now `@import` instead.

Closes #703.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
