### PR TITLE
Write the newline `at-rule-name-newline-after` asks for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The plugin now reads a line break the way PostCSS and Stylelint do: a line 
 - The [`max-line-length`](https://stylelint-stylistic.github.io/rules/max-line-length) rule now has an additional `tabSize` option (see [#10](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/10)), which measures a tab to the next tab stop of that width, so a file indented with tabs is as long as the editor's ruler shows.
 - The [`named-grid-areas-alignment`](https://stylelint-stylistic.github.io/rules/named-grid-areas-alignment) rule now has an additional `alignColumns` option (see [#45](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/45)), which lays the line names and the sizes of a `grid-template` or `grid` shorthand out as columns of a table.
 
+#### New autofixes
+
+- The [`at-rule-name-newline-after`](https://stylelint-stylistic.github.io/rules/at-rule-name-newline-after) rule is now autofixable (see [#696](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/696)). Expect `--fix` to write the newlines the rule used to only ask for. Where your configuration also lists `at-rule-name-space-after` under `always`, the two now ask for different things in the same place and the order they are listed in decides which one wins.
+
 #### New features
 
 - The package now exports the [`defineStylistic` and `defineStylisticOverride`](https://stylelint-stylistic.github.io/user-guide/typed-configuration) functions for a JavaScript configuration (see [#624](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/624)). You name the rules by their short names and the syntax once for the whole block: an editor completes the names and the options, and the compiler refuses a rule, an option, a key or a syntax the plugin does not take.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -119,7 +119,7 @@ Here are `stylelint-stylistic` rules, grouped by the _thing_ they apply to (j
 ## At-rule
 
 - [`at-rule-name-case`](../../lib/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names (Autofixable).
-- [`at-rule-name-newline-after`](../../lib/rules/at-rule-name-newline-after/README.md): Require a newline after at-rule names.
+- [`at-rule-name-newline-after`](../../lib/rules/at-rule-name-newline-after/README.md): Require a newline after at-rule names (Autofixable).
 - [`at-rule-name-space-after`](../../lib/rules/at-rule-name-space-after/README.md): Require a single space after at-rule names (Autofixable).
 - [`at-rule-semicolon-newline-after`](../../lib/rules/at-rule-semicolon-newline-after/README.md): Require a newline after the semicolon of at-rules (Autofixable).
 - [`at-rule-semicolon-space-before`](../../lib/rules/at-rule-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of at-rules.

--- a/lib/rules/at-rule-name-newline-after/README.md
+++ b/lib/rules/at-rule-name-newline-after/README.md
@@ -9,6 +9,8 @@ Require a newline after at-rule names.
  * The newline after this at-rule name */
 ```
 
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+
 The rule passes over an encoding declaration spelled as the specification reads it — `@charset "utf-8";` at the very start of the file, with one space and double quotes — since no other spelling of it declares an encoding at all.
 
 ## Options

--- a/lib/rules/at-rule-name-newline-after/index.test.ts
+++ b/lib/rules/at-rule-name-newline-after/index.test.ts
@@ -147,6 +147,7 @@ testRule({
 		{
 			description: `an at-rule spelled without a space in front of its options, which the parser gives the shape of a call to a Less detached ruleset`,
 			code: `@layer(l);`,
+			fixed: `@layer\n(l);`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@layer`),
@@ -154,6 +155,7 @@ testRule({
 		{
 			description: `nothing at all where the break belongs`,
 			code: `@charset"UTF-8";`,
+			fixed: `@charset\n"UTF-8";`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@charset`),
@@ -161,13 +163,72 @@ testRule({
 		{
 			description: `two spaces where the break belongs`,
 			code: `@charset  "UTF-8";`,
+			fixed: `@charset\n  "UTF-8";`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@charset`),
 		},
+		// See #696
+		{
+			description: `a block comment between the name and the params, in front of which the break goes`,
+			code: `@media /* c */ (a) { }`,
+			fixed: `@media\n /* c */ (a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `the same comment carrying a break of its own, which is no break behind the name`,
+			code: `@media /*\n*/ (a) { }`,
+			fixed: `@media\n /*\n*/ (a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `that comment abutting the name on both sides`,
+			code: `@media/*\n*/(a) { }`,
+			fixed: `@media\n/*\n*/(a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `a break standing behind two spaces, which is the break the rule asks for once they go`,
+			code: `@media  \n\t(a) { }`,
+			fixed: `@media\n\t(a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `the same break spelled with a carriage return, which is kept as it is written`,
+			code: `@media \r\n(a) { }`,
+			fixed: `@media\r\n(a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `a tab where the break belongs, which becomes the indentation of the new line`,
+			code: `@media\t(a) { }`,
+			fixed: `@media\n\t(a) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
+		{
+			description: `a space where the break belongs in a file ending its lines the Windows way`,
+			code: `@media (a) { }\r\nb { }`,
+			fixed: `@media\r\n (a) { }\r\nb { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
 		{
 			description: `a space in front of a range-syntax query`,
 			code: `@media (width <= 100px) { }`,
+			fixed: `@media\n (width <= 100px) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -175,6 +236,7 @@ testRule({
 		{
 			description: `a range-syntax query abutting the name`,
 			code: `@media(width <= 100px) { }`,
+			fixed: `@media\n(width <= 100px) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -182,6 +244,7 @@ testRule({
 		{
 			description: `two spaces in front of a range-syntax query`,
 			code: `@media  (width <= 100px) { }`,
+			fixed: `@media\n  (width <= 100px) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -189,6 +252,7 @@ testRule({
 		{
 			description: `a space in front of the string of an unknown at-rule`,
 			code: `@unknown "ident";`,
+			fixed: `@unknown\n "ident";`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@unknown`),
@@ -196,6 +260,7 @@ testRule({
 		{
 			description: `a string abutting the name of an unknown at-rule`,
 			code: `@unknown"ident";`,
+			fixed: `@unknown\n"ident";`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@unknown`),
@@ -203,6 +268,7 @@ testRule({
 		{
 			description: `a string abutting that name, with a block behind it`,
 			code: `@unknown"ident" { };`,
+			fixed: `@unknown\n"ident" { };`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@unknown`),
@@ -210,6 +276,7 @@ testRule({
 		{
 			description: `a space in front of the identifier of an unknown at-rule`,
 			code: `@unknown ident { };`,
+			fixed: `@unknown\n ident { };`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@unknown`),
@@ -217,6 +284,7 @@ testRule({
 		{
 			description: `two spaces in front of that identifier`,
 			code: `@unknown  ident { };`,
+			fixed: `@unknown\n  ident { };`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@unknown`),
@@ -224,6 +292,7 @@ testRule({
 		{
 			description: `a space behind a vendor-prefixed name`,
 			code: `@-webkit-keyframes identifier { }`,
+			fixed: `@-webkit-keyframes\n identifier { }`,
 			line: 1,
 			column: 18,
 			message: messages.expectedAfter(`@-webkit-keyframes`),
@@ -383,9 +452,19 @@ testRule({
 	],
 
 	reject: [
+		// See #696
+		{
+			description: `a block comment behind the name carrying the head's only break, the params themselves standing on one line`,
+			code: `@media /*\n*/ (a) and (b) { }`,
+			fixed: `@media\n /*\n*/ (a) and (b) { }`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
+		},
 		{
 			description: `params running over two lines with a space where the break belongs`,
 			code: `@import url("x.css")\nscreen and (orientation:landscape);`,
+			fixed: `@import\n url("x.css")\nscreen and (orientation:landscape);`,
 			line: 1,
 			column: 7,
 			message: messages.expectedAfter(`@import`),
@@ -393,6 +472,7 @@ testRule({
 		{
 			description: `the same params broken with a carriage return`,
 			code: `@import url("x.css")\r\nscreen and (orientation:landscape);`,
+			fixed: `@import\r\n url("x.css")\r\nscreen and (orientation:landscape);`,
 			line: 1,
 			column: 7,
 			message: messages.expectedAfter(`@import`),
@@ -400,6 +480,7 @@ testRule({
 		{
 			description: `a break opening the first feature, which makes the params multi-line`,
 			code: `@media (\nmin-width: 700px) and (orientation: landscape) { }`,
+			fixed: `@media\n (\nmin-width: 700px) and (orientation: landscape) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -407,6 +488,7 @@ testRule({
 		{
 			description: `the same break spelled with a carriage return`,
 			code: `@media (\r\nmin-width: 700px) and (orientation: landscape) { }`,
+			fixed: `@media\r\n (\r\nmin-width: 700px) and (orientation: landscape) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -414,6 +496,7 @@ testRule({
 		{
 			description: `a break in front of the closing parenthesis of the first feature`,
 			code: `@media (min-width: 700px\n) and (orientation: landscape) { }`,
+			fixed: `@media\n (min-width: 700px\n) and (orientation: landscape) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -421,6 +504,7 @@ testRule({
 		{
 			description: `a break in front of the colon of the first feature`,
 			code: `@media (min-width\n: 700px) and (orientation: landscape) { }`,
+			fixed: `@media\n (min-width\n: 700px) and (orientation: landscape) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),
@@ -428,6 +512,7 @@ testRule({
 		{
 			description: `a break behind that colon`,
 			code: `@media (min-width:\n700px) and (orientation: landscape) { }`,
+			fixed: `@media\n (min-width:\n700px) and (orientation: landscape) { }`,
 			line: 1,
 			column: 6,
 			message: messages.expectedAfter(`@media`),

--- a/lib/rules/at-rule-name-newline-after/index.ts
+++ b/lib/rules/at-rule-name-newline-after/index.ts
@@ -1,8 +1,10 @@
 import stylelint from "stylelint"
 
+import { LEADING_WHITESPACE, LINE_BREAK } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { atRuleNameSpaceChecker } from "../../utils/atRuleNameSpaceChecker/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
+import { getLineBreak } from "../../utils/getLineBreak/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
@@ -17,6 +19,7 @@ const MESSAGES = defineMessages({
 
 export let meta = {
 	url: getRuleDocUrl(shortName),
+	fixable: true,
 }
 
 /** `always` a newline after the at-rule's name, `always-multi-line` in an at-rule with multi-line params only. */
@@ -48,6 +51,18 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
+			fix: (atRule) => {
+				let { afterName } = atRule.raws
+
+				if (typeof afterName !== `string`) return
+
+				// The raw holds the comments between the name and the parameters too, so a break inside one is no break behind the name, and cutting the raw at it would open the comment
+				let [leading] = afterName.match(LEADING_WHITESPACE) as RegExpMatchArray
+				let index = leading.search(LINE_BREAK)
+
+				// Keep the break already standing, whatever runs in front of it; the rest of the raw is the new line's indentation, which `indentation` measures
+				atRule.raws.afterName = index >= 0 ? afterName.slice(index) : getLineBreak(syntax, atRule, result) + afterName
+			},
 		})
 	}
 }

--- a/lib/syntaxes/less/rules/at-rule-name-newline-after/index.test.ts
+++ b/lib/syntaxes/less/rules/at-rule-name-newline-after/index.test.ts
@@ -1,7 +1,7 @@
 import { createRule } from "../../../../rules/at-rule-name-newline-after/index.ts"
 import { less } from "../../index.ts"
 
-let { ruleName } = createRule(less)
+let { messages, ruleName } = createRule(less)
 
 let testRule = createTestRule({ ruleName })
 
@@ -42,6 +42,18 @@ testRule({
 		{
 			description: `a parent selector, which is no at-rule either`,
 			code: `.button { &-ok {} }`,
+		},
+	],
+
+	reject: [
+		// See #696
+		{
+			description: `a space where the break belongs, in a stylesheet whose variable the fixing run leaves alone`,
+			code: `@nice-blue: #5B83AD;\n@media (min-width: 1px) { a { color: @nice-blue } }`,
+			fixed: `@nice-blue: #5B83AD;\n@media\n (min-width: 1px) { a { color: @nice-blue } }`,
+			line: 2,
+			column: 6,
+			message: messages.expectedAfter(`@media`),
 		},
 	],
 })

--- a/lib/syntaxes/scss/rules/at-rule-name-newline-after/index.test.ts
+++ b/lib/syntaxes/scss/rules/at-rule-name-newline-after/index.test.ts
@@ -1,7 +1,7 @@
 import { createRule } from "../../../../rules/at-rule-name-newline-after/index.ts"
 import { scss } from "../../index.ts"
 
-let { ruleName } = createRule(scss)
+let { messages, ruleName } = createRule(scss)
 
 let testRule = createTestRule({ ruleName })
 
@@ -18,6 +18,27 @@ testRule({
 		{
 			description: `the same pair spelled with carriage returns`,
 			code: `@mixin\r\nmixin() { @content; }; .colors { @include\r\nmixin { color: $color; }}`,
+		},
+	],
+
+	reject: [
+		// See #696
+		{
+			description: `the same pair written with a space where each break belongs`,
+			code: `@mixin mixin() { @content; }; .colors { @include mixin { color: $color; }}`,
+			fixed: `@mixin\n mixin() { @content; }; .colors { @include\n mixin { color: $color; }}`,
+			warnings: [
+				{
+					line: 1,
+					column: 6,
+					message: messages.expectedAfter(`@mixin`),
+				},
+				{
+					line: 1,
+					column: 48,
+					message: messages.expectedAfter(`@include`),
+				},
+			],
 		},
 	],
 })


### PR DESCRIPTION
`at-rule-name-newline-after` reported and wrote nothing, so the break it asks for behind an at-rule's name was put in by hand, while its twin `at-rule-name-space-after` already wrote the very same raw:

```css
/* input */
@media (min-width: 100px) {}

/* --fix under `at-rule-name-newline-after: "always"`, before this branch */
@media (min-width: 100px) {}

/* --fix under the same option, after it */
@media
 (min-width: 100px) {}
```

The break goes in front of what the raw holds rather than over it, so whatever stood there becomes the indentation of the new line and stays `indentation`'s to measure, and a break already standing behind the name is kept rather than doubled. The raw carries the comments between the name and the parameters as well, so the search for that standing break is of the leading whitespace alone: cutting the raw at a break inside a comment would open the comment. `always-multi-line` needed nothing of its own, the rule already standing in `LINENESS_RULES` and `defersToRunEnd` already holding such a check back to the run's end.

Closes #696.