### PR TITLE
Read the run PostCSS prints in front of a node carrying no `raws.before` in `declaration-block-semicolon-newline-after`

### DIFF
--- a/lib/rules/declaration-block-semicolon-newline-after/declaration-without-a-run.test.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/declaration-without-a-run.test.ts
@@ -1,0 +1,122 @@
+import { parse as postcssParse, type ProcessOptions, type Root, stringify } from "postcss"
+import stylelint from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import { pick } from "../../../vitest.helpers.ts"
+import plugins from "../../index.ts"
+
+import { messages, ruleName } from "./index.ts"
+
+let testRule = createTestRule({ ruleName })
+
+/**
+ * Parses a stylesheet and takes the `raws.before` off every declaration of the rules selecting `a`, the way a rule of another plugin that fills an empty block leaves them; the declarations of any other rule keep the runs the file spells, for PostCSS to invent a run out of.
+ * @param source - The stylesheet.
+ * @param opts - The options of the parse.
+ * @returns The root.
+ */
+function parse (source: string, opts?: ProcessOptions): Root {
+	let root = postcssParse(source, opts)
+
+	root.walkRules(`a`, (statement) => {
+		statement.walkDecls((decl) => {
+			delete decl.raws.before
+		})
+	})
+
+	return root
+}
+
+// The library's declaration names a string alone, but it hands whatever it is given to Stylelint, which takes a syntax object as readily as a package name
+let declarationsWithoutARun = { parse, stringify } as unknown as string
+
+testRule({
+	ruleName,
+	config: [`always`],
+	customSyntax: declarationsWithoutARun,
+
+	accept: [
+		{
+			// See #693
+			description: `the break PostCSS prints in front of a declaration the file spells no run in front of`,
+			code: `
+				a {
+				color: pink;
+				top: 0; }
+			`,
+		},
+	],
+
+	reject: [],
+})
+
+testRule({
+	ruleName,
+	config: [`always-multi-line`],
+	customSyntax: declarationsWithoutARun,
+
+	accept: [
+		{
+			// See #693
+			description: `the break PostCSS prints in front of a declaration the file spells no run in front of`,
+			code: `
+				a {
+				color: pink;
+				top: 0; }
+			`,
+		},
+	],
+
+	reject: [],
+})
+
+describe(`the run PostCSS prints in front of a declaration the file spells none in front of`, () => {
+	/**
+	 * Fixes a stylesheet under the syntax that takes the raws off, then reads the file the fix left as a plain stylesheet, which is what the next run of the linter has in front of it.
+	 *
+	 * The testing library reads that file under the same syntax instead, which takes the raws off a second time; no run of the linter ever meets such a node twice, since only a rule building one puts it there, so these cases are written against the linter itself.
+	 * @param code - The stylesheet.
+	 * @param primary - The primary option.
+	 * @returns What the check said, the file the fix left, and how much the rule has to say about that file.
+	 */
+	async function fixAndRead (code: string, primary: string): Promise<{ warnings: string[], fixed: string, left: number }> {
+		let config = { plugins, rules: { [ruleName]: primary } }
+		let read = await stylelint.lint({ code, customSyntax: declarationsWithoutARun, config })
+		let run = await stylelint.lint({ code, customSyntax: declarationsWithoutARun, config, fix: true })
+		let fixed = run.code ?? code
+		let again = await stylelint.lint({ code: fixed, config })
+
+		return {
+			warnings: pick(read.results).warnings.map((warning) => `${warning.line}:${warning.column} ${warning.text}`),
+			fixed,
+			left: pick(again.results).warnings.length,
+		}
+	}
+
+	// See #693
+	it(`is the break never-multi-line refuses, and the fix takes it out`, async () => {
+		expect(await fixAndRead(`a {\ncolor: pink;\ntop: 0;\n}`, `never-multi-line`)).toEqual({
+			warnings: [`2:13 ${messages.rejectedAfterMultiLine()}`],
+			fixed: `a {\n    color: pink;top: 0;\n}`,
+			left: 0,
+		})
+	})
+
+	// See #693
+	it(`is short of the break always asks for where the run PostCSS prints is the space its neighbour carries, and the fix writes it`, async () => {
+		expect(await fixAndRead(`b { color: red;\n top: 0 }\na {color: pink;top: 0 }`, `always`)).toEqual({
+			warnings: [`3:16 ${messages.expectedAfter()}`],
+			fixed: `b { color: red;\n top: 0 }\na { color: pink;\n top: 0 }`,
+			left: 0,
+		})
+	})
+
+	// See #693
+	it(`is short of the break always-multi-line asks for in a multi-line block, and the fix writes it`, async () => {
+		expect(await fixAndRead(`b { color: red; top: 0 }\na {color: pink;top: 0\n}`, `always-multi-line`)).toEqual({
+			warnings: [`2:16 ${messages.expectedAfterMultiLine()}`],
+			fixed: `b { color: red; top: 0 }\na { color: pink;\n top: 0\n}`,
+			left: 0,
+		})
+	})
+})

--- a/lib/rules/declaration-block-semicolon-newline-after/index.ts
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.ts
@@ -11,8 +11,8 @@ import { isInlineStyleAttribute } from "../../utils/isInlineStyleAttribute/index
 import { isLastNodeWithoutSemicolon } from "../../utils/isLastNodeWithoutSemicolon/index.ts"
 import { nextNonCommentNode } from "../../utils/nextNonCommentNode/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
-import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
+import { runInFrontOf } from "../../utils/runInFrontOf/index.ts"
 import { isAtRule, isRule } from "../../utils/typeGuards/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
 
@@ -78,7 +78,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			let isFixable = primary.startsWith(`always`) || !syntax.writesIntoInlineComment(previousNode, result, previousNode === decl ? `;` : ``)
 
 			checker.afterOneOnly({
-				source: rawNodeString(nodeToCheck, result),
+				source: runInFrontOf(nodeToCheck) + nodeString(nodeToCheck, result),
 				index: -1,
 				lineCheckStr: blockString(parentRule, result),
 				err: (m) => {
@@ -92,10 +92,11 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						...(isFixable && {
 							fix: (): void => {
 								if (primary.startsWith(`always`)) {
-									// Trim up to the break already there, and add one only where none is
-									let index = nodeToCheck.raws.before.search(LINE_BREAK)
+									// Trim up to the break already there, and add one only where none is; a node carrying no raw is written the run PostCSS would have printed in front of it, trimmed or opened as the option asks (#693)
+									let standing = runInFrontOf(nodeToCheck)
+									let index = standing.search(LINE_BREAK)
 
-									nodeToCheck.raws.before = index >= 0 ? nodeToCheck.raws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheck.raws.before
+									nodeToCheck.raws.before = index >= 0 ? standing.slice(index) : getLineBreak(syntax, root, result) + standing
 
 									return
 								}


### PR DESCRIPTION
`declaration-block-semicolon-newline-after` read the run behind a semicolon out of the `raws.before` of the node standing there, through `rawNodeString`, which reads a raw that is not a string as the empty run, and its `always` and `always-multi-line` fix called `search` on that raw without asking what it held. PostCSS prints a run of its own in front of a node carrying none, so `never-multi-line` said nothing about a block that comes out broken across lines, and the other two ended the lint in a `TypeError`, leaving the rest of the configuration unchecked. No parser leaves such a node inside a block, only a rule of another plugin that builds one or takes its raw off, so what both sides answer about is a stylesheet beside a rule of another plugin:

```
a {⏎}⏎, beside a rule of another plugin, listed first, that fills the empty block with two declarations carrying no whitespace raw

945564a
	never-multi-line    nothing reported                                                  "a {\n    color: pink;\n    top: 0\n}\n"
	always              TypeError: Cannot read properties of undefined (reading 'search')
	always-multi-line   TypeError: Cannot read properties of undefined (reading 'search')

this branch
	never-multi-line    Unexpected newline after ";" in a multi-line declaration block    "a {\n    color: pink;top: 0\n}\n"
	always              nothing reported                                                  "a {\n    color: pink;\n    top: 0\n}\n"
	always-multi-line   nothing reported                                                  "a {\n    color: pink;\n    top: 0\n}\n"
```

The check and the `always` fix read the run through `runInFrontOf`, written for [#680](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/680): `raws.before` where the parser filed one, and otherwise the run PostCSS's own stringifier prints in front of the node. The fix writes the option's spelling of that run into the raw, as `block-opening-brace-newline-after` does. `never-multi-line` already wrote the empty run and is unchanged.

## What the review turned up

- **The registry probe of #680, rerun.** Every rule of the registry, every primary option of `scripts/oracles/options.ts` and four blocks a plugin fills with two declarations, 916 rows, each linted with the raws missing and over the text PostCSS prints from that tree: on `945564a` this rule threw on 8 rows and parted from the verdict and the fix on 4 more; on this branch neither, and the counts of every other rule are unchanged.
- **Nothing a corpus can spell.** The six oracles report no row added, removed or changed.
- **Five cases pin it, three of them against the linter itself**, since the testing library reads the fixer's output under the same syntax, which takes the raws off a second time. All five fail on `945564a`.
- **Left where it stands.** The other four rules that read such a node as the empty run — `declaration-block-semicolon-space-after`, `indentation`, `linebreaks` and `max-line-length` — are [#694](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/694).

Closes #693.
