### PR TITLE
Write no break behind the name of a `@charset` in `at-rule-name-newline-after`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The plugin now reads a line break the way PostCSS and Stylelint do: a line 
 
 #### New autofixes
 
-- The [`at-rule-name-newline-after`](https://stylelint-stylistic.github.io/rules/at-rule-name-newline-after) rule is now autofixable (see [#696](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/696)). Expect `--fix` to write the newlines the rule used to only ask for. Where your configuration also lists `at-rule-name-space-after` under `always`, the two now ask for different things in the same place and the order they are listed in decides which one wins.
+- The [`at-rule-name-newline-after`](https://stylelint-stylistic.github.io/rules/at-rule-name-newline-after) rule is now autofixable (see [#696](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/696)). Expect `--fix` to write the newlines the rule used to only ask for. Where your configuration also lists `at-rule-name-space-after` under `always`, the two now ask for different things in the same place and the order they are listed in decides which one wins. A `@charset` is reported but left as written, since breaking its head can leave the stylesheet declaring no encoding.
 - The [`at-rule-semicolon-space-before`](https://stylelint-stylistic.github.io/rules/at-rule-semicolon-space-before) rule is now autofixable (see [#697](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/697)). Expect `--fix` to write the whitespace the rule used to only ask for.
 
 #### New features

--- a/lib/rules/at-rule-name-newline-after/README.md
+++ b/lib/rules/at-rule-name-newline-after/README.md
@@ -9,7 +9,7 @@ Require a newline after at-rule names.
  * The newline after this at-rule name */
 ```
 
-The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix most of the problems reported by this rule. It writes no break behind the name of a `@charset`, whatever its head is spelled like: a rule respelling that head can make it the encoding declaration within the same run, and a break there is never the spelling the specification reads. The warning stands.
 
 The rule passes over an encoding declaration spelled as the specification reads it — `@charset "utf-8";` at the very start of the file, with one space and double quotes — since no other spelling of it declares an encoding at all.
 

--- a/lib/rules/at-rule-name-newline-after/index.test.ts
+++ b/lib/rules/at-rule-name-newline-after/index.test.ts
@@ -154,18 +154,68 @@ testRule({
 		},
 		{
 			description: `nothing at all where the break belongs`,
+			code: `@import"x.css";`,
+			fixed: `@import\n"x.css";`,
+			line: 1,
+			column: 7,
+			message: messages.expectedAfter(`@import`),
+		},
+		{
+			description: `two spaces where the break belongs`,
+			code: `@import  "x.css";`,
+			fixed: `@import\n  "x.css";`,
+			line: 1,
+			column: 7,
+			message: messages.expectedAfter(`@import`),
+		},
+		// See #708
+		{
+			description: `a charset rule with nothing where the break belongs, which at-rule-name-space-after turns into the declaration`,
 			code: `@charset"UTF-8";`,
-			fixed: `@charset\n"UTF-8";`,
+			fixed: `@charset"UTF-8";`,
 			line: 1,
 			column: 8,
 			message: messages.expectedAfter(`@charset`),
 		},
 		{
-			description: `two spaces where the break belongs`,
+			description: `a charset rule with two spaces where the break belongs, which at-rule-name-space-after turns into the declaration`,
 			code: `@charset  "UTF-8";`,
-			fixed: `@charset\n  "UTF-8";`,
+			fixed: `@charset  "UTF-8";`,
 			line: 1,
 			column: 8,
+			message: messages.expectedAfter(`@charset`),
+		},
+		{
+			description: `a charset rule whose name is spelled in upper case, which at-rule-name-case turns into the declaration`,
+			code: `@CHARSET "UTF-8";`,
+			fixed: `@CHARSET "UTF-8";`,
+			line: 1,
+			column: 8,
+			message: messages.expectedAfter(`@CHARSET`),
+		},
+		{
+			description: `a charset rule whose label is in single quotes, which string-quotes turns into the declaration`,
+			code: `@charset 'UTF-8';`,
+			fixed: `@charset 'UTF-8';`,
+			line: 1,
+			column: 8,
+			message: messages.expectedAfter(`@charset`),
+		},
+		{
+			autoStripIndent: false,
+			description: `a charset rule behind an empty first line, which no-empty-first-line turns into the declaration`,
+			code: `\n@charset "UTF-8";`,
+			fixed: `\n@charset "UTF-8";`,
+			line: 2,
+			column: 8,
+			message: messages.expectedAfter(`@charset`),
+		},
+		{
+			description: `a charset rule nested in a rule, which declares nothing and is left unwritten all the same`,
+			code: `a { @charset "UTF-8"; }`,
+			fixed: `a { @charset "UTF-8"; }`,
+			line: 1,
+			column: 12,
 			message: messages.expectedAfter(`@charset`),
 		},
 		// See #696
@@ -452,6 +502,15 @@ testRule({
 	],
 
 	reject: [
+		// See #708
+		{
+			description: `a charset rule whose params run over two lines, which this option writes no break into either`,
+			code: `@charset "UTF-8"\nscreen;`,
+			fixed: `@charset "UTF-8"\nscreen;`,
+			line: 1,
+			column: 8,
+			message: messages.expectedAfter(`@charset`),
+		},
 		// See #696
 		{
 			description: `a block comment behind the name carrying the head's only break, the params themselves standing on one line`,

--- a/lib/rules/at-rule-name-newline-after/index.ts
+++ b/lib/rules/at-rule-name-newline-after/index.ts
@@ -51,6 +51,8 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			syntax,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
+			// A neighbour respelling the head makes a `@charset` the encoding declaration within the same run, while the rule asks the text as parsed, which that repair does not change; a break behind the name is never the specification's spelling, so no `@charset` is written into, whatever its head is spelled like (#708)
+			isFixable: (atRule) => atRule.name.toLowerCase() !== `charset`,
 			fix: (atRule) => {
 				let { afterName } = atRule.raws
 

--- a/lib/utils/atRuleNameSpaceChecker/index.ts
+++ b/lib/utils/atRuleNameSpaceChecker/index.ts
@@ -8,7 +8,7 @@ let { utils: { report } } = stylelint
 
 /**
  * Checks whitespace around at-rule names.
- * @param options - The root, the checker, the result, the syntax, the rule name and its fix.
+ * @param options - The root, the checker, the result, the syntax, the rule name, its fix and which at-rules the fix may write.
  */
 export function atRuleNameSpaceChecker (options: {
 	root: Root,
@@ -22,6 +22,7 @@ export function atRuleNameSpaceChecker (options: {
 	syntax: Syntax,
 	checkedRuleName: string,
 	fix?: ((atRule: AtRule) => void) | null,
+	isFixable?: (atRule: AtRule) => boolean,
 }): void {
 	options.root.walkAtRules((atRule) => {
 		if (!options.syntax.isStandardAtRule(atRule)) return
@@ -43,7 +44,7 @@ export function atRuleNameSpaceChecker (options: {
 	 * @param node - The at-rule.
 	 */
 	function checkColon (source: string, index: number, node: AtRule): void {
-		let { fix } = options
+		let fix = options.isFixable?.(node) === false ? null : options.fix
 
 		options.locationChecker({
 			source,


### PR DESCRIPTION
`at-rule-name-newline-after` held off a `@charset` only where the file, as it was parsed, already opens with the encoding declaration. A head one spelling short of that declaration is repaired by a neighbour within the same `--fix` run, while the rule asks the text as parsed, which that repair does not change, and the break the rule then writes behind the name leaves the stylesheet declaring no encoding. The run after it is silent, since the at-rule is no declaration any more:

```
@CHARSET "UTF-8";⏎a { color: red }⏎, with at-rule-name-case: lower and at-rule-name-newline-after: always, in either order

bf2ec79       "@charset\n \"UTF-8\";\na { color: red }\n"
this branch   "@CHARSET \"UTF-8\";\na { color: red }\n" under the rule, "@charset \"UTF-8\";\na { color: red }\n" with its neighbour
```

The rule now reports a `@charset` of any spelling without a fix, as #697 did for `at-rule-semicolon-space-before`: a break behind the name is never the spelling the specification reads, and whether a neighbour makes the at-rule the declaration is not an answer the parsed text holds. `atRuleNameSpaceChecker` takes an optional `isFixable` for this; the twin `at-rule-name-space-after` passes none, since the one space it writes is the declaration's own.

## What the review turned up

- **A registry probe.** Every rule and every primary option of `scripts/oracles/options.ts` as the neighbour, both options of this rule, both configuration orders, six heads: a row is a run whose neighbour alone leaves the declaration and whose pair leaves none. 11 rows of 932 on `bf2ec79` — `at-rule-name-case`, `string-quotes`, `no-empty-first-line` and both options of `at-rule-name-space-after`, all under `always` — and none on this branch. Eighteen more heads (a leading space, a space in front of the semicolon, escaped names and others) under all three namespaces add `indentation` and `at-rule-semicolon-space-before: never` to the neighbours: 78 rows of 2904 on the base, none here, and no row among 7020 triples of the eleven rules that repair a head.
- **The price.** A `@charset` no neighbour ever turns into the declaration, such as one nested in a rule, is now reported and left as written. And the `--fix` run that repairs the head still reports the break, since the warning was raised over the text as parsed; the run after it is clean. Two existing cases carried a `@charset` the rule used to fix and now spell `@import`.
- **Nothing a corpus can spell.** The six oracles report no row added, removed or changed.
- **Seven cases pin it**, all failing on `bf2ec79`.

Closes #708.
