### PR TITLE
Read a neighbour under every namespace that reads the root in `neighbourSettings`

### DIFF
--- a/lib/rules/declaration-block-semicolon-space-before/integration.test.ts
+++ b/lib/rules/declaration-block-semicolon-space-before/integration.test.ts
@@ -166,3 +166,23 @@ testRule({
 		},
 	],
 })
+
+testRule({
+	ruleName,
+	config: [`never`],
+	extraRules: { "@stylistic/scss/declaration-colon-space-after": `always` },
+
+	reject: [
+		{
+			// See #710
+			description: `a value that is nothing but a space, with the neighbour listed under the namespace of another syntax, which reads the same plain CSS file and so is listed last all the same`,
+			code: `a { color: ; }`,
+			fixed: `a { color: ; }`,
+			line: 1,
+			column: 11,
+			endLine: 1,
+			endColumn: 12,
+			message: messages.rejectedBefore(),
+		},
+	],
+})

--- a/lib/syntaxes/scss/rules/declaration-block-semicolon-space-before/integration.test.ts
+++ b/lib/syntaxes/scss/rules/declaration-block-semicolon-space-before/integration.test.ts
@@ -1,0 +1,27 @@
+import { createRule } from "../../../../rules/declaration-block-semicolon-space-before/index.ts"
+import { messages as trailingSemicolonMessages } from "../../../../rules/declaration-block-trailing-semicolon/index.ts"
+import { scss } from "../../index.ts"
+
+let { ruleName } = createRule(scss)
+
+let testRule = createTestRule({ ruleName })
+
+testRule({
+	ruleName,
+	config: [`always`],
+	extraRules: { "@stylistic/declaration-block-trailing-semicolon": `always` },
+
+	reject: [
+		{
+			// See #710
+			description: `a plain CSS declaration closing its block without a semicolon, with the neighbour that adds one listed under the core's name, which reads the same file`,
+			code: `a { color: red }`,
+			fixed: `a { color: red ; }`,
+			line: 1,
+			column: 14,
+			endLine: 1,
+			endColumn: 15,
+			message: trailingSemicolonMessages.expected,
+		},
+	],
+})

--- a/lib/utils/neighbourSettings/index.test.ts
+++ b/lib/utils/neighbourSettings/index.test.ts
@@ -1,10 +1,15 @@
+import { parse } from "postcss"
+import postcssScss, { parse as parseScss } from "postcss-scss"
 import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
-import { css } from "../../syntaxes/css/index.ts"
-import type { Syntax } from "../../syntaxes/index.ts"
-
 import { neighbourSettings, speaksOf } from "./index.ts"
+
+/** A plain CSS root, which every namespace reads. */
+const NODE = parse(`a {}`)
+
+const SPACE = `@stylistic/declaration-block-semicolon-space-before`
+const NEWLINE = `@stylistic/declaration-block-semicolon-newline-before`
 
 const RULES = {
 	space: { name: `declaration-block-semicolon-space-before`, options: [`always`, `never`] },
@@ -18,13 +23,13 @@ describe(`neighbourSettings`, () => {
 	})
 
 	it(`each neighbour under the caller's key with its primary option, in the order the configuration lists them`, () => {
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": `always`, "@stylistic/declaration-block-semicolon-newline-before": `always` })).toEqual([[`space`, `always`, false], [`newline`, `always`, false]])
-		expect(read({ "@stylistic/declaration-block-semicolon-newline-before": `always`, "@stylistic/declaration-block-semicolon-space-before": `never` })).toEqual([[`newline`, `always`, false], [`space`, `never`, false]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": `always`, "@stylistic/declaration-block-semicolon-newline-before": `always` })).toEqual([[`space`, `always`, false, SPACE], [`newline`, `always`, false, NEWLINE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-newline-before": `always`, "@stylistic/declaration-block-semicolon-space-before": `never` })).toEqual([[`newline`, `always`, false, NEWLINE], [`space`, `never`, false, SPACE]])
 	})
 
 	it(`the option out of the array a configuration lists a rule's options in`, () => {
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`] })).toEqual([[`space`, `never`, false]])
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`always`, {}] })).toEqual([[`space`, `always`, false]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`] })).toEqual([[`space`, `never`, false, SPACE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`always`, {}] })).toEqual([[`space`, `always`, false, SPACE]])
 	})
 
 	it(`nothing for a rule listed with an option it refuses, or with no keyword at all`, () => {
@@ -34,27 +39,38 @@ describe(`neighbourSettings`, () => {
 	})
 
 	it(`whether the fix is turned off, read out of the secondary options the truthy way the report gate reads it`, () => {
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: true }] })).toEqual([[`space`, `never`, true]])
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: `yes` }] })).toEqual([[`space`, `never`, true]])
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: false }] })).toEqual([[`space`, `never`, false]])
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: 0 }] })).toEqual([[`space`, `never`, false]])
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { severity: `warning` }] })).toEqual([[`space`, `never`, false]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: true }] })).toEqual([[`space`, `never`, true, SPACE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: `yes` }] })).toEqual([[`space`, `never`, true, SPACE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: false }] })).toEqual([[`space`, `never`, false, SPACE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { disableFix: 0 }] })).toEqual([[`space`, `never`, false, SPACE]])
+		expect(read({ "@stylistic/declaration-block-semicolon-space-before": [`never`, { severity: `warning` }] })).toEqual([[`space`, `never`, false, SPACE]])
 	})
 
 	it(`a table with a key left empty, as a table shared by callers with unlike neighbours leaves some`, () => {
-		expect(neighbourSettings<`space` | `newline`>(css, result({ "@stylistic/declaration-block-semicolon-space-before": `always` }), { space: RULES.space })).toEqual([[`space`, `always`, false]])
+		expect(neighbourSettings<`space` | `newline`>(NODE, result({ "@stylistic/declaration-block-semicolon-space-before": `always` }), { space: RULES.space })).toEqual([[`space`, `always`, false, SPACE]])
 	})
 
-	it(`the names of the asking rule's own namespace, and not the core's`, () => {
-		let scss: Syntax = { ...css, namespace: `scss` }
+	// See #710
+	it(`a neighbour under every namespace reading the root, a rule listed under two of them twice`, () => {
+		expect(read({ "@stylistic/scss/declaration-block-semicolon-space-before": `always` })).toEqual([[`space`, `always`, false, `@stylistic/scss/declaration-block-semicolon-space-before`]])
+		expect(read({ "@stylistic/less/declaration-block-semicolon-space-before": `never`, "@stylistic/declaration-block-semicolon-space-before": `always` })).toEqual([[`space`, `never`, false, `@stylistic/less/declaration-block-semicolon-space-before`], [`space`, `always`, false, SPACE]])
+	})
 
-		expect(read({ "@stylistic/declaration-block-semicolon-space-before": `always` }, scss)).toEqual([])
-		expect(read({ "@stylistic/scss/declaration-block-semicolon-space-before": `always` }, scss)).toEqual([[`space`, `always`, false]])
-		expect(read({ "@stylistic/scss/declaration-block-semicolon-space-before": `always` })).toEqual([])
+	it(`no neighbour under a namespace refusing the root`, () => {
+		let scssResult = { opts: { syntax: postcssScss }, stylelint: { config: { customSyntax: `postcss-scss`, rules: { "@stylistic/less/declaration-block-semicolon-space-before": `always`, "@stylistic/scss/declaration-block-semicolon-space-before": `never` } } } } as unknown as PostcssResult
+
+		expect(neighbourSettings(parseScss(`a {}`), scssResult, RULES)).toEqual([[`space`, `never`, false, `@stylistic/scss/declaration-block-semicolon-space-before`]])
+	})
+
+	it(`two lineness-conditioned copies of one rule in the order their checks flush, the core's first`, () => {
+		let neighbours = { space: { name: `declaration-colon-space-after`, options: [`always-single-line`] } }
+		let expected = [[`space`, `always-single-line`, false, `@stylistic/declaration-colon-space-after`], [`space`, `always-single-line`, false, `@stylistic/scss/declaration-colon-space-after`]]
+
+		expect(neighbourSettings(NODE, result({ "@stylistic/scss/declaration-colon-space-after": `always-single-line`, "@stylistic/declaration-colon-space-after": `always-single-line` }), neighbours)).toEqual(expected)
 	})
 
 	it(`nothing where the result carries no configuration`, () => {
-		expect(neighbourSettings(css, {} as PostcssResult, RULES)).toEqual([])
+		expect(neighbourSettings(NODE, {} as PostcssResult, RULES)).toEqual([])
 	})
 
 	it(`the lineness-conditioned neighbours behind the rest, and among themselves in the plugin's own order rather than the configuration's`, () => {
@@ -64,15 +80,15 @@ describe(`neighbourSettings`, () => {
 			newline: { name: `declaration-block-semicolon-newline-before`, options: [`always-multi-line`] },
 			semicolonAfter: { name: `declaration-block-semicolon-space-after`, options: [`never-single-line`] },
 		}
-		let expected = [[`plain`, `always`, false], [`space`, `always-single-line`, false], [`newline`, `always-multi-line`, false], [`semicolonAfter`, `never-single-line`, false]]
+		let expected = [[`plain`, `always`, false, SPACE], [`space`, `always-single-line`, false, `@stylistic/declaration-colon-space-after`], [`newline`, `always-multi-line`, false, NEWLINE], [`semicolonAfter`, `never-single-line`, false, `@stylistic/declaration-block-semicolon-space-after`]]
 
-		expect(neighbourSettings(css, result({
+		expect(neighbourSettings(NODE, result({
 			"@stylistic/declaration-block-semicolon-space-after": `never-single-line`,
 			"@stylistic/declaration-block-semicolon-newline-before": `always-multi-line`,
 			"@stylistic/declaration-colon-space-after": `always-single-line`,
 			"@stylistic/declaration-block-semicolon-space-before": `always`,
 		}), neighbours)).toEqual(expected)
-		expect(neighbourSettings(css, result({
+		expect(neighbourSettings(NODE, result({
 			"@stylistic/declaration-colon-space-after": `always-single-line`,
 			"@stylistic/declaration-block-semicolon-space-before": `always`,
 			"@stylistic/declaration-block-semicolon-space-after": `never-single-line`,
@@ -111,11 +127,10 @@ describe(`speaksOf`, () => {
 /**
  * Reads the two neighbours' settings out of a configuration.
  * @param rules - The rules the configuration lists, in the order it lists them.
- * @param syntax - The syntax the asking rule is built over.
  * @returns What `neighbourSettings` answers.
  */
-function read (rules: Record<string, unknown>, syntax: Syntax = css): [string, string, boolean][] {
-	return neighbourSettings(syntax, result(rules), RULES)
+function read (rules: Record<string, unknown>): [string, string, boolean, string][] {
+	return neighbourSettings(NODE, result(rules), RULES)
 }
 
 /**

--- a/lib/utils/neighbourSettings/index.ts
+++ b/lib/utils/neighbourSettings/index.ts
@@ -1,6 +1,8 @@
+import type { Node } from "postcss"
 import type { PostcssResult } from "stylelint"
 
-import type { Syntax } from "../../syntaxes/index.ts"
+import { css } from "../../syntaxes/css/index.ts"
+import { namespaces, type Syntax } from "../../syntaxes/index.ts"
 import { addNamespace } from "../addNamespace/index.ts"
 import { compareRanks, defersToRunEnd, linenessRank } from "../defersToRunEnd/index.ts"
 
@@ -24,29 +26,30 @@ function primaryOf (setting: unknown): string | undefined {
 /**
  * Reads some neighbours' settings in run order: configuration order, then the lineness-conditioned rules, which wait for the run's writers ([#355](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/355)) in the plugin's order ([#502](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/502)).
  *
- * Stylelint runs rules in configuration order, so the key order of `result.stylelint.config` is the run's. A neighbour refusing its option is passed over; whether its fix is off travels with the option ([#485](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/485)).
- * @param syntax - The asking rule's syntax, whose namespace names the neighbours.
+ * Stylelint runs rules in configuration order, so the key order of `result.stylelint.config` is the run's. A neighbour is listed under any namespace that reads the node's root, since every namespace reads plain CSS and a copy under another one writes the same file ([#710](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/710)); so one key may come more than once, told apart by the name. A neighbour refusing its option is passed over; whether its fix is off travels with the option ([#485](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/485)).
+ * @param node - A node of the root the rules read.
  * @param result - The PostCSS result carrying the configuration.
  * @param rules - The neighbours by the caller's keys; a key may stand empty.
- * @returns Key, option and whether the fix is off, per neighbour, in run order.
+ * @returns Key, option, whether the fix is off and the configured name, per neighbour, in run order.
  */
-export function neighbourSettings<Key extends string> (syntax: Syntax, result: PostcssResult, rules: Partial<Record<Key, NeighbourRule>>): [Key, string, boolean][] {
+export function neighbourSettings<Key extends string> (node: Node, result: PostcssResult, rules: Partial<Record<Key, NeighbourRule>>): [Key, string, boolean, string][] {
 	let settings: Record<string, unknown> = result.stylelint?.config?.rules ?? {}
-	let neighbours = Object.entries(rules) as [Key, NeighbourRule][]
-	let found: { setting: [Key, string, boolean], rank: string }[] = []
+	let names = namesOf(rules)
+	let root = node.root()
+	let found: { setting: [Key, string, boolean, string], rank: string }[] = []
 
 	for (let name of Object.keys(settings)) {
-		let neighbour = neighbours.find(([, rule]) => name === addNamespace(rule.name, syntax.namespace))
+		let match = names.get(name)
 
-		if (!neighbour) continue
+		if (!match) continue
 
-		let [key, rule] = neighbour
+		let { key, rule, syntax } = match
 		let setting = settings[name]
 		let option = primaryOf(setting)
 
-		if (option === undefined || !rule.options.includes(option)) continue
+		if (option === undefined || !rule.options.includes(option) || !syntax.accepts(root, result)) continue
 
-		found.push({ setting: [key, option, fixDisabledBy(setting)], rank: linenessRank(rule.name, syntax.namespace, option) })
+		found.push({ setting: [key, option, fixDisabledBy(setting), name], rank: linenessRank(rule.name, syntax.namespace, option) })
 	}
 
 	// The deferred go behind every other (#355), in the plugin's order (#502)
@@ -54,6 +57,33 @@ export function neighbourSettings<Key extends string> (syntax: Syntax, result: P
 	let deferred = found.filter(({ setting: [, option] }) => defersToRunEnd(option)).toSorted((one, other) => compareRanks(one.rank, other.rank))
 
 	return [...undeferred, ...deferred].map(({ setting }) => setting)
+}
+
+/** A neighbour as a configured name registers it: the caller's key, the rule and the syntax of its namespace. */
+type NeighbourName<Key extends string> = { key: Key, rule: NeighbourRule, syntax: Syntax }
+
+/** The names each table of neighbours is configured under, built once per table. */
+let namesByTable: WeakMap<object, Map<string, NeighbourName<string>>> = new WeakMap()
+
+/**
+ * Maps every name a table's neighbours can be configured under, one per namespace, to what it registers.
+ * @param rules - The neighbours by the caller's keys.
+ * @returns The map.
+ */
+function namesOf<Key extends string> (rules: Partial<Record<Key, NeighbourRule>>): Map<string, NeighbourName<Key>> {
+	let names = namesByTable.get(rules) as Map<string, NeighbourName<Key>> | undefined
+
+	if (names) return names
+
+	let made: Map<string, NeighbourName<Key>> = new Map()
+
+	for (let syntax of [css, ...namespaces]) {
+		for (let [key, rule] of Object.entries(rules) as [Key, NeighbourRule][]) made.set(addNamespace(rule.name, syntax.namespace), { key, rule, syntax })
+	}
+
+	namesByTable.set(rules, made)
+
+	return made
 }
 
 /**

--- a/lib/utils/whitespaceAsked/index.ts
+++ b/lib/utils/whitespaceAsked/index.ts
@@ -11,9 +11,9 @@ export type Whitespace = `newline` | `space`
 /**
  * Returns the whitespace the rules about one run ask for, so that a fix spells the run as they would rather than leaving it to a rule already run ([#354](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/354)).
  *
- * The settings come through `neighbourSettings`, under the asking rule's namespace. Of two speaking rules the later-listed one with its fix on wins, its write being the file's last; a rule whose fix is off wins only where no live one speaks, and the caller still writes its whitespace ([#485](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/485)).
- * @param syntax - The asking rule's, whose namespace names the rules.
- * @param node - Written into, and read for the line break.
+ * The settings come through `neighbourSettings`, under every namespace reading the node's root. Of two speaking rules the later-listed one with its fix on wins, its write being the file's last; a rule whose fix is off wins only where no live one speaks, and the caller still writes its whitespace ([#485](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/485)).
+ * @param syntax - The asking rule's, which reads the line break.
+ * @param node - Written into; its root names the namespaces read, and it is read for the line break.
  * @param result - Holds the configuration.
  * @param rules - By the whitespace each writes.
  * @param isSingleLine - Whether the counted text is one line, asked only where an option needs it.
@@ -26,7 +26,7 @@ export function whitespaceAsked (syntax: Syntax, node: Node, result: PostcssResu
 	let askedByTurnedOff: Whitespace | undefined
 	let aFixSpeaks = false
 
-	for (let [kind, option, fixTurnedOff] of neighbourSettings(syntax, result, rules)) {
+	for (let [kind, option, fixTurnedOff] of neighbourSettings(node, result, rules)) {
 		if (!speaksOf(option, isSingleLine)) continue
 
 		spoke = true

--- a/lib/utils/whitespaceBeforeSemicolon/index.test.ts
+++ b/lib/utils/whitespaceBeforeSemicolon/index.test.ts
@@ -1,4 +1,5 @@
 import { type AtRule, type Declaration, parse, type Rule } from "postcss"
+import postcssScss, { parse as parseScss } from "postcss-scss"
 import type { PostcssResult } from "stylelint"
 import { describe, expect, it } from "vitest"
 
@@ -105,14 +106,23 @@ describe(`whitespaceBeforeSemicolon`, () => {
 		expect(askAtRule(`a { @foo bar }`, { [AT_RULE_SPACE_BEFORE]: `always` }, refusing)).toBe(``)
 	})
 
-	it(`the rules of the asking rule's own namespace, and not the core's, which refuse the file the namespace reads`, () => {
+	// See #710
+	it(`the rules of every namespace in a plain CSS file, which each of them reads`, () => {
 		let scss: Syntax = { ...css, namespace: `scss` }
 
-		expect(ask(SINGLE_LINE, { [SPACE_BEFORE]: `always` }, scss)).toBe(``)
+		expect(ask(SINGLE_LINE, { [SPACE_BEFORE]: `always` }, scss)).toBe(` `)
 		expect(ask(SINGLE_LINE, { "@stylistic/scss/declaration-block-semicolon-space-before": `always` }, scss)).toBe(` `)
-		expect(ask(SINGLE_LINE, { "@stylistic/scss/declaration-block-semicolon-newline-before": `always` })).toBe(``)
+		expect(ask(SINGLE_LINE, { "@stylistic/scss/declaration-block-semicolon-newline-before": `always` })).toBe(`\n`)
 		expect(askAtRule(`a { @foo bar }`, { "@stylistic/scss/at-rule-semicolon-space-before": `always` }, scss)).toBe(` `)
-		expect(askAtRule(`a { @foo bar }`, { [AT_RULE_SPACE_BEFORE]: `always` }, scss)).toBe(``)
+		expect(askAtRule(`a { @foo bar }`, { [AT_RULE_SPACE_BEFORE]: `always` }, scss)).toBe(` `)
+	})
+
+	it(`the rules of the asking rule's own namespace, and not the core's, which refuse the file the namespace reads`, () => {
+		let scss: Syntax = { ...css, namespace: `scss` }
+		let decl = (parseScss(SINGLE_LINE).first as Rule).last as Declaration
+
+		expect(whitespaceBeforeSemicolon(scss, decl, resultOfScss({ [SPACE_BEFORE]: `always` }))).toBe(``)
+		expect(whitespaceBeforeSemicolon(scss, decl, resultOfScss({ "@stylistic/scss/declaration-block-semicolon-space-before": `always` }))).toBe(` `)
 	})
 })
 
@@ -206,4 +216,13 @@ function lastAtRuleOf (code: string): AtRule {
  */
 function result (rules: Record<string, unknown>): PostcssResult {
 	return { stylelint: { config: { rules } } } as unknown as PostcssResult
+}
+
+/**
+ * Builds the least of a Stylelint result for a file parsed with `postcss-scss`.
+ * @param rules - The rules the configuration lists.
+ * @returns The result.
+ */
+function resultOfScss (rules: Record<string, unknown>): PostcssResult {
+	return { opts: { syntax: postcssScss }, stylelint: { config: { customSyntax: `postcss-scss`, rules } } } as unknown as PostcssResult
 }

--- a/lib/utils/whitespaceBeforeSemicolon/index.ts
+++ b/lib/utils/whitespaceBeforeSemicolon/index.ts
@@ -33,7 +33,7 @@ const RULES_OF_WHITESPACE: Record<`decl` | `atrule`, Partial<Record<Whitespace, 
  * The whitespace the rules about it ask for in front of a semicolon a fix adds behind a declaration or bodiless at-rule.
  *
  * Stylelint runs each rule once, so a bare semicolon written behind `declaration-block-semicolon-newline-before` or `-space-before` waits for the next `--fix` ([#354](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/354)), as does one written behind `at-rule-semicolon-space-before` ([#477](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/477)). `whitespaceAsked` picks the later-listed live rule; lineness is asked of the block at the write ([#355](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/355)).
- * @param syntax - The syntax, whose namespace names the rules.
+ * @param syntax - The asking rule's syntax.
  * @param node - The declaration or bodiless at-rule.
  * @param result - The Stylelint result.
  * @returns A break, a space, or nothing.

--- a/lib/utils/writesSharedRun/index.test.ts
+++ b/lib/utils/writesSharedRun/index.test.ts
@@ -245,12 +245,23 @@ describe(`writesSharedRun`, () => {
 		expect(ask(`a { b: !important ; }`, { [COLON_NEWLINE]: `always`, [COLON_SPACE]: [`always`, { disableFix: true }] }, COLON_NEWLINE)).toBe(true)
 	})
 
-	it(`the rules of the asking rule's own namespace, and not the core's`, () => {
+	it(`the rules of the asking rule's own namespace`, () => {
 		let scss: Syntax = { ...css, namespace: `scss` }
 
-		expect(ask(`a { b: ; }`, { [COLON_SPACE]: `always`, [SEMICOLON_SPACE]: `never` }, `@stylistic/scss/declaration-colon-space-after`, scss)).toBe(true)
 		expect(ask(`a { b: ; }`, { "@stylistic/scss/declaration-colon-space-after": `always`, "@stylistic/scss/declaration-block-semicolon-space-before": `never` }, `@stylistic/scss/declaration-colon-space-after`, scss)).toBe(false)
-		expect(ask(`a { b: ; }`, { "@stylistic/scss/declaration-colon-space-after": `always`, "@stylistic/scss/declaration-block-semicolon-space-before": `never` }, COLON_SPACE)).toBe(true)
+	})
+
+	// See #710
+	it(`a rule listed under another namespace that reads the same plain CSS root, the asking rule's own copy included`, () => {
+		let scss: Syntax = { ...css, namespace: `scss` }
+		let scssSemicolonSpace = `@stylistic/scss/declaration-block-semicolon-space-before`
+		let scssColonSpace = `@stylistic/scss/declaration-colon-space-after`
+
+		expect(ask(`a { b: ; }`, { [COLON_SPACE]: `always`, [scssSemicolonSpace]: `never` }, COLON_SPACE)).toBe(false)
+		expect(ask(`a { b: ; }`, { [COLON_SPACE]: `always`, [scssSemicolonSpace]: `never` }, scssSemicolonSpace, scss)).toBe(true)
+		expect(ask(`a { b: ; }`, { [COLON_SPACE]: `always`, [scssColonSpace]: `never` }, COLON_SPACE)).toBe(false)
+		expect(ask(`a { b: ; }`, { [COLON_SPACE]: `always`, [scssColonSpace]: `never` }, scssColonSpace, scss)).toBe(true)
+		expect(ask(`a { b:; }`, { [COLON_SPACE]: `always`, [scssColonSpace]: `always` }, COLON_SPACE)).toBe(true)
 	})
 })
 

--- a/lib/utils/writesSharedRun/index.ts
+++ b/lib/utils/writesSharedRun/index.ts
@@ -206,8 +206,8 @@ export function writesSharedRun (syntax: Syntax, decl: Declaration, result: Post
 
 	if (!readers.has(asking)) return true
 
-	let settings = neighbourSettings(syntax, result, PARTICIPANTS)
-	let position = settings.findIndex(([participant]) => participant === asking)
+	let settings = neighbourSettings(decl, result, PARTICIPANTS)
+	let position = settings.findIndex(([, , , name]) => name === ruleName)
 
 	if (position === -1) return true
 
@@ -259,7 +259,7 @@ export function writesSharedRun (syntax: Syntax, decl: Declaration, result: Post
 		})
 	}
 
-	let [participant, option] = settings[position] as [Participant, string, boolean]
+	let [participant, option] = settings[position] as [Participant, string, boolean, string]
 	let writes = writtenBy(participant, option)
 	let accepted = accepts(participant, option, decl, runIsTheText)
 	let asksFromTheSemicolon = FROM_THE_SEMICOLON.includes(participant)


### PR DESCRIPTION
Every namespace reads a plain CSS file, so a rule listed under the core's name and a neighbour listed under `scss/` both write the same run. `writesSharedRun` and `whitespaceAsked`, the two readers that ask what a neighbour is about to write, looked for that neighbour under the asking rule's own namespace only, so the copy under the other one wrote unseen and the pair took the run in turns. On `main` at `cd7834c`, with `declaration-colon-space-after: always` listed ahead of `scss/declaration-block-semicolon-space-before: never`:

```
a { color:; }     input
a { color: ; }    --fix, run 1 — no warning
a { color:; }     --fix, run 2 — no warning
a { color: ; }    --fix, run 3 — and so on, never a warning
```

`neighbourSettings` now takes a node and reads a neighbour under every namespace whose `accepts` answers yes for that node's root, ranking a deferred one by its own namespace, which is the order the deferred checks flush in. One rule can now come back more than once, so each entry carries its configured name, and `writesSharedRun` finds its own entry by that name. On this branch the configuration above rests on `a { color:; }` from the first run, with the warning of `declaration-colon-space-after` standing.

## What the review turned up

- **What moved.** A probe runs 8 920 configurations of two neighbouring rules to a fixed point — the shared run of a whitespace-only value, the whitespace in front of a semicolon, the solidus `aspect-ratio-notation` writes, the breaks of `declaration-block-single-line-max-declarations` and the run `block-opening-brace-newline-after` writes into a block of comments — once with both rules under the core's names and once split between the core and `scss/`. Split runs parting from the core's: 482 on the base, 82 on the branch; cycling split runs: 78 on the base, none on the branch. `make oracles` moved no row: every oracle lists its rules under one namespace.
- **The 82 left.** 52 are `writesBlockAfter` and 12 `closedBySemicolon`, both reading a neighbour through `neighbourSetting`, the single-rule reader beside `neighbourSettings`, which the branch leaves alone; a spin-off filed on merge covers them and carries a file growing by a space per run where `declaration-block-trailing-semicolon` is listed under both names with opposite options. The other 18 are a bodiless `@x` without parameters, which the `scss/` rules read as Sass `@content` and pass over — a difference between the two namespaces' grammars, not their reading of neighbours.
- **The issue's question** — what the wider reading costs a reader of a neighbour's option — has the answer the run gives: the copy under the second namespace writes over the same root, so `whitespaceAsked` picking it when it runs last picks the file's last write.
- **`writesRunBehindBrace`** of the unmerged branch of #698 calls `neighbourSettings` and finds its own entry by key; whichever of the two lands second adjusts the call.
- **`getLineBreak`** reads `linebreaks` under the asking rule's namespace alone, so a break written beside `scss/linebreaks: windows` comes out as `\r\n` one run late; a second spin-off filed on merge covers it.
- **The name lookup is built once per table of neighbours**: the review measured matching every configured name against every namespace on each call as a clear slowdown of a `--fix` over the whole registry.

Closes #710.
