### PR TITLE
Write the whitespace `block-closing-brace-space-after` asks for

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -71,7 +71,7 @@ Here are `stylelint-stylistic` rules, grouped by the _thing_ they apply to (j
 - [`block-closing-brace-empty-line-before`](../../lib/rules/block-closing-brace-empty-line-before/README.md): Require or disallow an empty line before the closing brace of blocks (Autofixable).
 - [`block-closing-brace-newline-after`](../../lib/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks (Autofixable).
 - [`block-closing-brace-newline-before`](../../lib/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks (Autofixable).
-- [`block-closing-brace-space-after`](../../lib/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.
+- [`block-closing-brace-space-after`](../../lib/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks (Autofixable).
 - [`block-closing-brace-space-before`](../../lib/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks (Autofixable).
 - [`block-opening-brace-newline-after`](../../lib/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks (Autofixable).
 - [`block-opening-brace-newline-before`](../../lib/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks (Autofixable).

--- a/lib/rules/block-closing-brace-newline-after/README.md
+++ b/lib/rules/block-closing-brace-newline-after/README.md
@@ -29,7 +29,7 @@ This rule allows a trailing semicolon after the closing brace of a block. F
 }
 ```
 
-The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix most of the problems reported by this rule. It writes nothing where `block-closing-brace-space-after` asks for something else of the same run and either writes it last or was already content with the run as it stands; the warning stands there instead.
 
 ## Options
 

--- a/lib/rules/block-closing-brace-newline-after/index.ts
+++ b/lib/rules/block-closing-brace-newline-after/index.ts
@@ -1,7 +1,7 @@
 import type { AtRule, Rule } from "postcss"
 import stylelint from "stylelint"
 
-import { LINE_BREAK, NON_SPACE } from "../../regexps.ts"
+import { LINE_BREAK } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import { blockString } from "../../utils/blockString/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
@@ -10,10 +10,12 @@ import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
+import { pastEndOfLineComment } from "../../utils/pastEndOfLineComment/index.ts"
 import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { isString } from "../../utils/validateTypes/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
+import { writesRunBehindBrace } from "../../utils/writesRunBehindBrace/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -98,9 +100,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 			if (!nextNode) return
 
 			// An end-of-line comment behind the brace is allowed
-			let nextNodeIsSingleLineComment = nextNode.type === `comment` && !NON_SPACE.test(nextNode.raws.before || ``) && !LINE_BREAK.test(nextNode.toString())
-
-			let nodeToCheck = nextNodeIsSingleLineComment ? nextNode.next() : nextNode
+			let nodeToCheck = pastEndOfLineComment(nextNode)
 
 			if (!nodeToCheck) return
 
@@ -112,6 +112,9 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 				source = source.slice(1)
 				reportIndex += 1
 			}
+
+			// The space twin writes this raw too, and where the two accept no spelling in common only the one that runs last may write it (#698)
+			let isFixable = writesRunBehindBrace(syntax, statement, result, ruleName)
 
 			// One character only; the rest is `indentation`'s
 			checker.afterOneOnly({
@@ -126,19 +129,21 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 						endIndex: reportIndex,
 						result,
 						ruleName,
-						fix () {
-							let nodeToCheckRaws = nodeToCheck.raws
+						...(isFixable && {
+							fix (): void {
+								let nodeToCheckRaws = nodeToCheck.raws
 
-							if (typeof nodeToCheckRaws.before !== `string`) return
+								if (typeof nodeToCheckRaws.before !== `string`) return
 
-							if (primary.startsWith(`always`)) {
-								// Keep an existing break, add one where none is
-								let index = nodeToCheckRaws.before.search(LINE_BREAK)
+								if (primary.startsWith(`always`)) {
+									// Keep an existing break, add one where none is
+									let index = nodeToCheckRaws.before.search(LINE_BREAK)
 
-								nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheckRaws.before
-							}
-							else if (primary.startsWith(`never`)) nodeToCheckRaws.before = ``
-						},
+									nodeToCheckRaws.before = index >= 0 ? nodeToCheckRaws.before.slice(index) : getLineBreak(syntax, root, result) + nodeToCheckRaws.before
+								}
+								else if (primary.startsWith(`never`)) nodeToCheckRaws.before = ``
+							},
+						}),
 					})
 				},
 			})

--- a/lib/rules/block-closing-brace-space-after/README.md
+++ b/lib/rules/block-closing-brace-space-after/README.md
@@ -20,6 +20,8 @@ This rule allows a trailing semicolon after the closing brace of a block. F
 }
 ```
 
+The [`fix` option](https://stylelint.io/user-guide/options#fix) can automatically fix most of the problems reported by this rule. It writes nothing where `block-closing-brace-newline-after` asks for something else of the same run and either writes it last or was already content with the run as it stands, nor where a stray semicolon stands inside the run itself rather than behind the brace. The warning stands in both.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/block-closing-brace-space-after/index.test.ts
+++ b/lib/rules/block-closing-brace-space-after/index.test.ts
@@ -49,6 +49,7 @@ testRule({
 		{
 			description: `a second block abutting the brace`,
 			code: `a { color: pink; }b { color: red; }`,
+			fixed: `a { color: pink; } b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.expectedAfter(),
@@ -56,6 +57,7 @@ testRule({
 		{
 			description: `two spaces where one belongs`,
 			code: `a { color: pink; }  b { color: red; }`,
+			fixed: `a { color: pink; } b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.expectedAfter(),
@@ -63,6 +65,7 @@ testRule({
 		{
 			description: `a break where the space belongs`,
 			code: `a { color: pink; }\nb { color: red; }`,
+			fixed: `a { color: pink; } b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.expectedAfter(),
@@ -70,6 +73,7 @@ testRule({
 		{
 			description: `the same break spelled with a carriage return`,
 			code: `a { color: pink; }\r\nb { color: red; }`,
+			fixed: `a { color: pink; } b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.expectedAfter(),
@@ -77,6 +81,7 @@ testRule({
 		{
 			description: `a tab where the space belongs`,
 			code: `a { color: pink; }\tb { color: red; }`,
+			fixed: `a { color: pink; } b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.expectedAfter(),
@@ -84,6 +89,7 @@ testRule({
 		{
 			description: `two nested blocks abutting one another`,
 			code: `@media print { a { color: pink; }b { color: red; }}`,
+			fixed: `@media print { a { color: pink; } b { color: red; }}`,
 			line: 1,
 			column: 34,
 			message: messages.expectedAfter(),
@@ -91,8 +97,50 @@ testRule({
 		{
 			description: `two at-rules abutting one another`,
 			code: `@media print { a { color: pink; }}@media screen { b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }} @media screen { b { color: red; }}`,
 			line: 1,
 			column: 35,
+			message: messages.expectedAfter(),
+		},
+		{
+			// See #698
+			description: `a stray semicolon behind the brace, behind which the space goes`,
+			code: `a {};b {}`,
+			fixed: `a {}; b {}`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(),
+		},
+		{
+			description: `the same semicolon with a space of its own in front of it, which is none of this rule's business`,
+			code: `a {} ;b {}`,
+			fixed: `a {} ; b {}`,
+			line: 1,
+			column: 7,
+			message: messages.expectedAfter(),
+		},
+		{
+			description: `two stray semicolons, the second of which the parser keeps in the next node's leading raw`,
+			code: `a{};;b{}`,
+			fixed: `a{};; b{}`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(),
+		},
+		{
+			description: `three of them, where the run the rule speaks of opens on a semicolon and the fix leaves it to the rule about those`,
+			code: `a{};;;b{}`,
+			fixed: `a{};;;b{}`,
+			line: 1,
+			column: 6,
+			message: messages.expectedAfter(),
+		},
+		{
+			description: `a comment standing where the next node would`,
+			code: `a {}/* c */b {}`,
+			fixed: `a {} /* c */b {}`,
+			line: 1,
+			column: 5,
 			message: messages.expectedAfter(),
 		},
 	],
@@ -129,6 +177,7 @@ testRule({
 		{
 			description: `a space between two blocks`,
 			code: `a { color: pink; } b { color: red; }`,
+			fixed: `a { color: pink; }b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.rejectedAfter(),
@@ -136,6 +185,7 @@ testRule({
 		{
 			description: `two spaces between two blocks`,
 			code: `a { color: pink; }  b { color: red; }`,
+			fixed: `a { color: pink; }b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.rejectedAfter(),
@@ -143,6 +193,7 @@ testRule({
 		{
 			description: `a break between two blocks`,
 			code: `a { color: pink; }\nb { color: red; }`,
+			fixed: `a { color: pink; }b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.rejectedAfter(),
@@ -150,6 +201,7 @@ testRule({
 		{
 			description: `the same break spelled with a carriage return`,
 			code: `a { color: pink; }\r\nb { color: red; }`,
+			fixed: `a { color: pink; }b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.rejectedAfter(),
@@ -157,6 +209,7 @@ testRule({
 		{
 			description: `a tab between two blocks`,
 			code: `a { color: pink; }\tb { color: red; }`,
+			fixed: `a { color: pink; }b { color: red; }`,
 			line: 1,
 			column: 19,
 			message: messages.rejectedAfter(),
@@ -164,6 +217,7 @@ testRule({
 		{
 			description: `a space between two nested blocks`,
 			code: `@media print { a { color: pink; } b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }b { color: red; }}`,
 			line: 1,
 			column: 34,
 			message: messages.rejectedAfter(),
@@ -171,8 +225,34 @@ testRule({
 		{
 			description: `a space between two at-rules`,
 			code: `@media print { a { color: pink; }} @media screen { b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }}@media screen { b { color: red; }}`,
 			line: 1,
 			column: 35,
+			message: messages.rejectedAfter(),
+		},
+		{
+			// See #698
+			description: `a space behind a stray semicolon, which the fix takes away and leaves the semicolon`,
+			code: `a {}; b {}`,
+			fixed: `a {};b {}`,
+			line: 1,
+			column: 6,
+			message: messages.rejectedAfter(),
+		},
+		{
+			description: `the same semicolon with a space of its own in front of it, which stays`,
+			code: `a {} ; b {}`,
+			fixed: `a {} ;b {}`,
+			line: 1,
+			column: 7,
+			message: messages.rejectedAfter(),
+		},
+		{
+			description: `a space in front of a comment standing where the next node would`,
+			code: `a {} /* c */ b {}`,
+			fixed: `a {}/* c */ b {}`,
+			line: 1,
+			column: 5,
 			message: messages.rejectedAfter(),
 		},
 	],
@@ -233,6 +313,7 @@ testRule({
 		{
 			description: `a single-line block abutting the block behind it`,
 			code: `a { color: pink; background: orange;}b { color: red; }`,
+			fixed: `a { color: pink; background: orange;} b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.expectedAfterSingleLine(),
@@ -240,6 +321,7 @@ testRule({
 		{
 			description: `two spaces behind a single-line block`,
 			code: `a { color: pink; background: orange;}  b { color: red; }`,
+			fixed: `a { color: pink; background: orange;} b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.expectedAfterSingleLine(),
@@ -247,6 +329,7 @@ testRule({
 		{
 			description: `a tab behind a single-line block`,
 			code: `a { color: pink; background: orange;}\tb { color: red; }`,
+			fixed: `a { color: pink; background: orange;} b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.expectedAfterSingleLine(),
@@ -254,6 +337,7 @@ testRule({
 		{
 			description: `two nested single-line blocks abutting one another`,
 			code: `@media print { a { color: pink; }b { color: red; }}`,
+			fixed: `@media print { a { color: pink; } b { color: red; }}`,
 			line: 1,
 			column: 34,
 			message: messages.expectedAfterSingleLine(),
@@ -261,6 +345,7 @@ testRule({
 		{
 			description: `two at-rules holding single-line blocks, abutting one another`,
 			code: `@media print { a { color: pink; }}@media screen { b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }} @media screen { b { color: red; }}`,
 			line: 1,
 			column: 35,
 			message: messages.expectedAfterSingleLine(),
@@ -323,6 +408,7 @@ testRule({
 		{
 			description: `a space behind a single-line block`,
 			code: `a { color: pink; background: orange;} b { color: red; }`,
+			fixed: `a { color: pink; background: orange;}b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.rejectedAfterSingleLine(),
@@ -330,6 +416,7 @@ testRule({
 		{
 			description: `two spaces behind a single-line block`,
 			code: `a { color: pink; background: orange;}  b { color: red; }`,
+			fixed: `a { color: pink; background: orange;}b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.rejectedAfterSingleLine(),
@@ -337,6 +424,7 @@ testRule({
 		{
 			description: `a tab behind a single-line block`,
 			code: `a { color: pink; background: orange;}\tb { color: red; }`,
+			fixed: `a { color: pink; background: orange;}b { color: red; }`,
 			line: 1,
 			column: 38,
 			message: messages.rejectedAfterSingleLine(),
@@ -344,6 +432,7 @@ testRule({
 		{
 			description: `a space between two nested single-line blocks`,
 			code: `@media print { a { color: pink; } b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }b { color: red; }}`,
 			line: 1,
 			column: 34,
 			message: messages.rejectedAfterSingleLine(),
@@ -351,6 +440,7 @@ testRule({
 		{
 			description: `a space between two at-rules holding single-line blocks`,
 			code: `@media print { a { color: pink; }} @media screen { b { color: red; }}`,
+			fixed: `@media print { a { color: pink; }}@media screen { b { color: red; }}`,
 			line: 1,
 			column: 35,
 			message: messages.rejectedAfterSingleLine(),
@@ -409,6 +499,7 @@ testRule({
 		{
 			description: `a multi-line block abutting the block behind it`,
 			code: `a { color: pink;\nbackground: orange;}b { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;} b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.expectedAfterMultiLine(),
@@ -416,6 +507,7 @@ testRule({
 		{
 			description: `two spaces behind a multi-line block`,
 			code: `a { color: pink;\nbackground: orange;}  b { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;} b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.expectedAfterMultiLine(),
@@ -427,6 +519,10 @@ testRule({
 				background: orange;}
 				b { color: red; }
 			`,
+			fixed: `
+				a { color: pink;
+				background: orange;} b { color: red; }
+			`,
 			line: 2,
 			column: 21,
 			message: messages.expectedAfterMultiLine(),
@@ -434,6 +530,7 @@ testRule({
 		{
 			description: `the same break spelled with a carriage return`,
 			code: `a { color: pink;\r\nbackground: orange;}\r\nb { color: red; }`,
+			fixed: `a { color: pink;\r\nbackground: orange;} b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.expectedAfterMultiLine(),
@@ -441,6 +538,7 @@ testRule({
 		{
 			description: `a tab behind a multi-line block`,
 			code: `a { color: pink;\nbackground: orange;}\tb { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;} b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.expectedAfterMultiLine(),
@@ -448,6 +546,7 @@ testRule({
 		{
 			description: `two nested blocks abutting one another, the first multi-line`,
 			code: `@media print { a {\ncolor: pink; }b { color: red; }}`,
+			fixed: `@media print { a {\ncolor: pink; } b { color: red; }}`,
 			line: 2,
 			column: 15,
 			message: messages.expectedAfterMultiLine(),
@@ -457,6 +556,11 @@ testRule({
 			code: `
 				@media print { a {
 				color: pink; }}@media screen { b {
+				color: red; }}
+			`,
+			fixed: `
+				@media print { a {
+				color: pink; }} @media screen { b {
 				color: red; }}
 			`,
 			line: 2,
@@ -517,6 +621,7 @@ testRule({
 		{
 			description: `a space behind a multi-line block`,
 			code: `a { color: pink;\nbackground: orange;} b { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;}b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.rejectedAfterMultiLine(),
@@ -524,6 +629,7 @@ testRule({
 		{
 			description: `two spaces behind a multi-line block`,
 			code: `a { color: pink;\nbackground: orange;}  b { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;}b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.rejectedAfterMultiLine(),
@@ -535,6 +641,10 @@ testRule({
 				background: orange;}
 				b { color: red; }
 			`,
+			fixed: `
+				a { color: pink;
+				background: orange;}b { color: red; }
+			`,
 			line: 2,
 			column: 21,
 			message: messages.rejectedAfterMultiLine(),
@@ -542,6 +652,7 @@ testRule({
 		{
 			description: `a tab behind a multi-line block`,
 			code: `a { color: pink;\nbackground: orange;}\tb { color: red; }`,
+			fixed: `a { color: pink;\nbackground: orange;}b { color: red; }`,
 			line: 2,
 			column: 21,
 			message: messages.rejectedAfterMultiLine(),
@@ -549,6 +660,7 @@ testRule({
 		{
 			description: `a space between two nested blocks, the first multi-line`,
 			code: `@media print { a {\ncolor: pink; } b { color: red; }}`,
+			fixed: `@media print { a {\ncolor: pink; }b { color: red; }}`,
 			line: 2,
 			column: 15,
 			message: messages.rejectedAfterMultiLine(),
@@ -560,6 +672,11 @@ testRule({
 				color: pink; }} @media screen { b {
 				color: red; }}
 			`,
+			fixed: `
+				@media print { a {
+				color: pink; }}@media screen { b {
+				color: red; }}
+			`,
 			line: 2,
 			column: 16,
 			message: messages.rejectedAfterMultiLine(),
@@ -567,6 +684,7 @@ testRule({
 		{
 			description: `the same pair spelled with carriage returns`,
 			code: `@media print { a {\r\ncolor: pink; }} @media screen { b {\r\ncolor: red; }}`,
+			fixed: `@media print { a {\r\ncolor: pink; }}@media screen { b {\r\ncolor: red; }}`,
 			line: 2,
 			column: 16,
 			message: messages.rejectedAfterMultiLine(),

--- a/lib/rules/block-closing-brace-space-after/index.ts
+++ b/lib/rules/block-closing-brace-space-after/index.ts
@@ -9,7 +9,9 @@ import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
 import { rawNodeString } from "../../utils/rawNodeString/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
+import { runBehindBrace } from "../../utils/runBehindBrace/index.ts"
 import { whitespaceChecker } from "../../utils/whitespaceChecker/index.ts"
+import { writesRunBehindBrace } from "../../utils/writesRunBehindBrace/index.ts"
 
 let { utils: { report, validateOptions } } = stylelint
 
@@ -26,6 +28,7 @@ const MESSAGES = defineMessages({
 
 export let meta = {
 	url: getRuleDocUrl(shortName),
+	fixable: true,
 }
 
 /** `always` a single space after the closing brace, `never` no whitespace; the `-single-line` and `-multi-line` forms in a block of that shape only. */
@@ -36,10 +39,11 @@ export type PrimaryOption = `always` | `never` | `always-single-line` | `never-s
  * @param scope - What the namespace hands the rule.
  * @param scope.ruleName - The configured name.
  * @param scope.messages - The messages, closing with that name.
+ * @param scope.syntax - The syntax the rule is built over.
  * @param primary - The primary option.
  * @returns The check.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: PrimaryOption): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: PrimaryOption): RuleCheck {
 	let checker = whitespaceChecker(`space`, primary, messages)
 
 	return (root, result) => {
@@ -81,6 +85,13 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: Prim
 				reportIndex += 1
 			}
 
+			// The run the check reads opens behind that one semicolon, so the fix writes behind it too, leaving it and whatever stands in front of it in the block's `raws.ownSemicolon`
+			let { semicolon, holdsASemicolon } = runBehindBrace(nextNode)
+			// A write crossing a further semicolon is `no-extra-semicolons`'s question rather than this rule's, and what may be written there is unsettled (#562, #584, #598, #687): the warning stands
+			let isFixable = typeof nextNode.raws.before === `string`
+				&& !holdsASemicolon
+				&& writesRunBehindBrace(syntax, statement, result, ruleName)
+
 			checker.after({
 				source,
 				index: -1,
@@ -93,6 +104,11 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: Prim
 						endIndex: reportIndex,
 						result,
 						ruleName,
+						...(isFixable && {
+							fix: (): void => {
+								nextNode.raws.before = semicolon + (primary.startsWith(`always`) ? ` ` : ``)
+							},
+						}),
 					})
 				},
 			})

--- a/lib/syntaxes/scss/rules/block-closing-brace-space-after/index.test.ts
+++ b/lib/syntaxes/scss/rules/block-closing-brace-space-after/index.test.ts
@@ -20,7 +20,7 @@ testRule({
 			`,
 			fixed: `
 				@media (min-width: 100px // c
-					) { a { color: red; } }b { color: red; }
+					) { a { color: red; } } b { color: red; }
 			`,
 			line: 2,
 			column: 25,

--- a/lib/utils/pastEndOfLineComment/index.test.ts
+++ b/lib/utils/pastEndOfLineComment/index.test.ts
@@ -1,0 +1,48 @@
+import { type ChildNode, parse } from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { pastEndOfLineComment } from "./index.ts"
+
+describe(`pastEndOfLineComment`, () => {
+	it(`a node that is no comment, which is the one read`, () => {
+		expect(behind(`a {}b {}`)).toBe(`b {}`)
+		expect(behind(`a {} b {}`)).toBe(`b {}`)
+		expect(behind(`a {}\nb {}`)).toBe(`b {}`)
+	})
+
+	it(`a comment ending the brace's line, which is read past`, () => {
+		expect(behind(`a {}/*c*/b {}`)).toBe(`b {}`)
+		expect(behind(`a {} /*c*/ b {}`)).toBe(`b {}`)
+		expect(behind(`a {}  /*c*/\nb {}`)).toBe(`b {}`)
+	})
+
+	it(`a gap of anything but spaces, which keeps the comment the node read`, () => {
+		expect(behind(`a {}\t/*c*/ b {}`)).toBe(`/*c*/`)
+		expect(behind(`a {}\n/*c*/ b {}`)).toBe(`/*c*/`)
+		expect(behind(`a {}\f/*c*/ b {}`)).toBe(`/*c*/`)
+	})
+
+	it(`a comment carrying a line break, which ends no line`, () => {
+		expect(behind(`a {} /*c\n*/ b {}`)).toBe(`/*c\n*/`)
+		expect(behind(`a {} /*c\r\n*/ b {}`)).toBe(`/*c\r\n*/`)
+	})
+
+	it(`a comment ending the block or the file, behind which nothing stands`, () => {
+		expect(behind(`a {} /*c*/`)).toBeUndefined()
+		expect(behind(`@media print { a {} /*c*/ }`, true)).toBeUndefined()
+	})
+})
+
+/**
+ * Prints what the util reads behind the first block of a stylesheet.
+ * @param code - The stylesheet.
+ * @param nested - Whether the block stands inside the first node.
+ * @returns The node's text, or nothing.
+ */
+function behind (code: string, nested: boolean = false): string | undefined {
+	let root = parse(code)
+	let statement = (nested ? (root.first as unknown as { first: ChildNode }).first : root.first) as ChildNode
+	let next = statement.next()
+
+	return next && pastEndOfLineComment(next)?.toString()
+}

--- a/lib/utils/pastEndOfLineComment/index.ts
+++ b/lib/utils/pastEndOfLineComment/index.ts
@@ -1,0 +1,16 @@
+import type { ChildNode } from "postcss"
+
+import { LINE_BREAK, NON_SPACE } from "../../regexps.ts"
+
+/**
+ * Steps over a comment standing at the end of the line a closing brace ends, which `block-closing-brace-newline-after` reads past and writes behind.
+ *
+ * One comment at most, and only where nothing but spaces stands between it and the brace — a tab or a break there makes the answer no — and the comment itself holds no line break.
+ * @param node - The node standing behind the brace.
+ * @returns That node, or the one behind the comment; nothing where the comment ends the block or the file.
+ */
+export function pastEndOfLineComment (node: ChildNode): ChildNode | undefined {
+	let endsTheLine = node.type === `comment` && !NON_SPACE.test(node.raws.before || ``) && !LINE_BREAK.test(node.toString())
+
+	return endsTheLine ? node.next() : node
+}

--- a/lib/utils/runBehindBrace/index.ts
+++ b/lib/utils/runBehindBrace/index.ts
@@ -1,0 +1,38 @@
+import type { ChildNode } from "postcss"
+
+import { LEADING_CSS_WHITESPACE, WHITESPACE_OR_NOTHING } from "../../regexps.ts"
+
+/** The leading raw of the node behind a closing brace, parted as both `block-closing-brace-*-after` rules read it. */
+export type BraceRun = {
+
+	/** The one semicolon both rules skip in front of the run, or nothing. */
+	semicolon: string,
+
+	/** The whitespace behind it, which is the run both rules judge: the break rule by its first character, the space rule by its first two. */
+	run: string,
+
+	/** Whether a further semicolon stands behind that run, which neither option can write over without crossing it; the run itself may be whitespace all the same. */
+	holdsASemicolon: boolean,
+}
+
+/**
+ * Parts the raw the two rules about the run behind a closing brace read.
+ *
+ * PostCSS keeps a stray semicolon and the whitespace in front of it in the block's own `raws.ownSemicolon`, so a semicolon reaching this raw is a second one; both rules skip one of them and judge what stands behind it ([#698](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/698)).
+ * @param node - The node the run stands in front of.
+ * @returns The parts; an empty run where the raw is no string, as a node another plugin inserted carries none.
+ */
+export function runBehindBrace (node: ChildNode): BraceRun {
+	let before = node.raws.before
+
+	if (typeof before !== `string`) return { semicolon: ``, run: ``, holdsASemicolon: false }
+
+	let semicolon = before.startsWith(`;`) ? `;` : ``
+	let rest = before.slice(semicolon.length)
+
+	return {
+		semicolon,
+		run: (rest.match(LEADING_CSS_WHITESPACE) as RegExpMatchArray)[0],
+		holdsASemicolon: !WHITESPACE_OR_NOTHING.test(rest),
+	}
+}

--- a/lib/utils/writesRunBehindBrace/index.test.ts
+++ b/lib/utils/writesRunBehindBrace/index.test.ts
@@ -1,0 +1,122 @@
+import { type AtRule, parse, type Rule } from "postcss"
+import type { PostcssResult } from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import { css } from "../../syntaxes/css/index.ts"
+
+import { writesRunBehindBrace } from "./index.ts"
+
+const SPACE = `@stylistic/block-closing-brace-space-after`
+const NEWLINE = `@stylistic/block-closing-brace-newline-after`
+
+const SINGLE_LINE = `a { color: pink; }b { color: red; }`
+const MULTI_LINE = `a {\n\tcolor: pink;\n}b { color: red; }`
+
+describe(`writesRunBehindBrace`, () => {
+	it(`a configuration listing the asking rule alone, or neither of the two`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always` }, SPACE)).toBe(true)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always` }, NEWLINE)).toBe(true)
+		expect(ask(SINGLE_LINE, { "@stylistic/color-hex-case": `lower` }, SPACE)).toBe(true)
+		expect(ask(SINGLE_LINE, {}, NEWLINE)).toBe(true)
+	})
+
+	it(`a rule that is neither of the two`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `always` }, `@stylistic/color-hex-case`)).toBe(true)
+	})
+
+	it(`two options that accept one spelling in common, where both write and write the same`, () => {
+		let rules = { [SPACE]: `never`, [NEWLINE]: `never-single-line` }
+
+		expect(ask(SINGLE_LINE, rules, SPACE)).toBe(true)
+		expect(ask(SINGLE_LINE, rules, NEWLINE)).toBe(true)
+	})
+
+	it(`two options that accept none, where the rule the configuration lists later is the one to write`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `always` }, SPACE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `always` }, NEWLINE)).toBe(true)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always`, [SPACE]: `always` }, SPACE)).toBe(true)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always`, [SPACE]: `always` }, NEWLINE)).toBe(false)
+	})
+
+	it(`a never option against an always one, which accept nothing in common either`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `never`, [NEWLINE]: `always` }, SPACE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always`, [SPACE]: `never` }, SPACE)).toBe(true)
+	})
+
+	it(`a neighbour whose option says nothing of this block's lineness, which gates nothing`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `always-multi-line` }, SPACE)).toBe(true)
+		expect(ask(MULTI_LINE, { [SPACE]: `always`, [NEWLINE]: `always-multi-line` }, SPACE)).toBe(false)
+		expect(ask(MULTI_LINE, { [SPACE]: `always`, [NEWLINE]: `always-single-line` }, SPACE)).toBe(true)
+	})
+
+	it(`a neighbour whose fix the configuration turned off, which rewrites nothing and so gates nothing`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: [`always`, { disableFix: true }] }, SPACE)).toBe(true)
+	})
+
+	it(`a neighbour deferred to the run's end, which writes behind an undeferred rule whatever the configuration's order`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `always-single-line` }, SPACE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always-single-line`, [SPACE]: `always` }, SPACE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always-single-line`, [SPACE]: `always` }, NEWLINE)).toBe(true)
+	})
+
+	it(`two deferred options, which the plugin orders rather than the configuration: the break rule ahead of the space rule`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always-single-line`, [NEWLINE]: `always-single-line` }, NEWLINE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [NEWLINE]: `always-single-line`, [SPACE]: `always-single-line` }, NEWLINE)).toBe(false)
+		expect(ask(SINGLE_LINE, { [SPACE]: `always-single-line`, [NEWLINE]: `always-single-line` }, SPACE)).toBe(true)
+	})
+
+	it(`a neighbour listed under an option it does not accept, which is no neighbour at all`, () => {
+		expect(ask(SINGLE_LINE, { [SPACE]: `always`, [NEWLINE]: `never` }, SPACE)).toBe(true)
+	})
+
+	it(`a comment ending the brace's line, which the break rule reads past, so the two write different raws and contend over nothing`, () => {
+		let rules = { [SPACE]: `never`, [NEWLINE]: `always` }
+
+		expect(ask(`a {} /* c */ b {}`, rules, SPACE)).toBe(true)
+		expect(ask(`a {} /* c */ b {}`, rules, NEWLINE)).toBe(true)
+		expect(ask(`a {} /* c */\nb {}`, rules, SPACE)).toBe(true)
+	})
+
+	it(`a comment on a line of its own, which the break rule reads no further than, so the two do write one raw`, () => {
+		expect(ask(`a {}\n/* c */ b {}`, { [SPACE]: `never`, [NEWLINE]: `always` }, SPACE)).toBe(false)
+	})
+
+	it(`a comment ending the file behind the brace, behind which the break rule writes no raw at all`, () => {
+		expect(ask(`a {} /* c */`, { [SPACE]: `never`, [NEWLINE]: `always` }, SPACE)).toBe(true)
+	})
+
+	it(`an at-rule the neighbour's secondary option passes over, which writes nothing there either`, () => {
+		expect(ask(`@media print { a { color: red; } }b {}`, { [SPACE]: `always`, [NEWLINE]: [`always`, { ignoreAtRules: [`media`] }] }, SPACE)).toBe(true)
+		expect(ask(`@media print { a { color: red; } }b {}`, { [SPACE]: `always`, [NEWLINE]: [`always`, { ignoreAtRules: [`supports`] }] }, SPACE)).toBe(false)
+	})
+
+	it(`a disable comment keeping the neighbour's fix off the line, which leaves it writing nothing`, () => {
+		let rules = { [SPACE]: `never`, [NEWLINE]: `always` }
+
+		expect(ask(SINGLE_LINE, rules, SPACE, { [NEWLINE]: [{ start: 1 }] })).toBe(true)
+		expect(ask(SINGLE_LINE, rules, SPACE, { all: [{ start: 1, end: 1 }] })).toBe(true)
+		expect(ask(SINGLE_LINE, rules, SPACE, { [NEWLINE]: [{ start: 2 }] })).toBe(false)
+	})
+})
+
+/**
+ * Asks the util about the first statement of a stylesheet.
+ * @param code - The stylesheet.
+ * @param rules - The rules the configuration lists.
+ * @param ruleName - The asking rule's registered name.
+ * @param disabledRanges - The ranges a disable comment opens, by rule name.
+ * @returns What the util answers.
+ */
+function ask (code: string, rules: Record<string, unknown>, ruleName: string, disabledRanges?: Record<string, { start: number, end?: number }[]>): boolean {
+	return writesRunBehindBrace(css, parse(code).first as AtRule | Rule, result(rules, disabledRanges), ruleName)
+}
+
+/**
+ * Builds the least of a Stylelint result that holds a configuration.
+ * @param rules - The rules the configuration lists.
+ * @param disabledRanges - The ranges a disable comment opens, by rule name.
+ * @returns The result.
+ */
+function result (rules: Record<string, unknown>, disabledRanges?: Record<string, { start: number, end?: number }[]>): PostcssResult {
+	return { stylelint: { config: { rules }, disabledRanges } } as unknown as PostcssResult
+}

--- a/lib/utils/writesRunBehindBrace/index.ts
+++ b/lib/utils/writesRunBehindBrace/index.ts
@@ -1,0 +1,161 @@
+import type { AtRule, ChildNode, Rule } from "postcss"
+import type { PostcssResult } from "stylelint"
+
+import { LEADING_LINE_BREAK } from "../../regexps.ts"
+import type { Syntax } from "../../syntaxes/index.ts"
+import { addNamespace } from "../addNamespace/index.ts"
+import { blockString } from "../blockString/index.ts"
+import { fixDisabledOnLine } from "../fixDisabledOnLine/index.ts"
+import { isSingleLineString } from "../isSingleLineString/index.ts"
+import { type NeighbourRule, neighbourSettings, speaksOf } from "../neighbourSettings/index.ts"
+import { optionsMatches } from "../optionsMatches/index.ts"
+import { pastEndOfLineComment } from "../pastEndOfLineComment/index.ts"
+import { runBehindBrace } from "../runBehindBrace/index.ts"
+import { isAtRule } from "../typeGuards/index.ts"
+
+/** The two rules that read the run behind a closing brace. */
+type Participant = `newline` | `space`
+
+/** A spelling of that run, as the rules judge it. */
+type Run = `newline` | `space` | `none` | `other`
+
+/** The two rules and the whitespace each writes where its option is an `always` one. */
+const PARTICIPANTS: Record<Participant, NeighbourRule & { writes: Run }> = {
+	newline: {
+		name: `block-closing-brace-newline-after`,
+		options: [`always`, `always-single-line`, `never-single-line`, `always-multi-line`, `never-multi-line`],
+		writes: `newline`,
+	},
+	space: {
+		name: `block-closing-brace-space-after`,
+		options: [`always`, `never`, `always-single-line`, `never-single-line`, `always-multi-line`, `never-multi-line`],
+		writes: `space`,
+	},
+}
+
+/**
+ * The spellings a rule's option accepts of the run: `always` what the rule writes, `never` no whitespace at all.
+ * @param participant - The rule.
+ * @param option - Its primary option, `always` or `never` with any line suffix.
+ * @returns The accepted spellings.
+ */
+function accepts (participant: Participant, option: string): Run[] {
+	return option.startsWith(`always`) ? [PARTICIPANTS[participant].writes] : [`none`]
+}
+
+/**
+ * Reads the spelling of the run as it stands, which each rule judges by its first character.
+ * @param run - The run, from {@link runBehindBrace}.
+ * @returns The spelling.
+ */
+function spellingOf (run: string): Run {
+	if (run === ``) return `none`
+	if (LEADING_LINE_BREAK.test(run)) return `newline`
+
+	return run === ` ` ? `space` : `other`
+}
+
+/**
+ * The node whose leading raw a rule writes behind this brace.
+ *
+ * The space rule writes the very next node's. The newline rule reads past a comment ending the brace's line and writes the raw of whatever stands behind it, so behind such a comment the two write different raws and contend over nothing; it also passes over an at-rule its `ignoreAtRules` names, and writes nothing where the comment ends the block or the file.
+ * @param participant - The rule.
+ * @param configuredName - The name the configuration lists that rule under, whose secondaries are read.
+ * @param result - The Stylelint result, which holds the configuration.
+ * @param statement - The rule or at-rule whose closing brace the run stands behind.
+ * @returns The node, or nothing where the rule writes no raw here.
+ */
+function writtenNodeOf (participant: Participant, configuredName: string, result: PostcssResult, statement: AtRule | Rule): ChildNode | undefined {
+	let next = statement.next()
+
+	if (!next || participant === `space`) return next
+
+	let setting: unknown = result.stylelint?.config?.rules?.[configuredName]
+	let secondary: unknown = Array.isArray(setting) ? setting[1] : undefined
+
+	if (isAtRule(statement) && optionsMatches(typeof secondary === `object` && secondary !== null ? secondary as Record<string, unknown> : {}, `ignoreAtRules`, statement.name)) return undefined
+
+	return pastEndOfLineComment(next)
+}
+
+/**
+ * Asks whether the asking rule is the one to write the run behind a closing brace, which both `block-closing-brace-*-after` rules write into a node's `raws.before` ([#698](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/698)).
+ *
+ * A rule writes only where every rule behind it in run order that would write the very same raw accepts a spelling it accepts too; otherwise that rule's write would be the file's last and this one's warning would be dropped as fixed over a run it does not accept ([#704](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/704)). Where the two accept a spelling in common both may write, since what either leaves the other accepts; the texts are not identical, the space rule keeping a stray semicolon the break rule takes away with the rest of the raw ([#687](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/687)).
+ *
+ * A neighbour that would write nothing gates nothing, so its `disableFix`, its disable ranges and its own guards — the at-rules it passes over, the raw it writes, the semicolon the space rule refuses to write over — are asked before it is counted in ([#536](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/536)).
+ *
+ * A rule ahead ran before the write and judged the run as it stood, so where it was content with that and refuses what the write leaves, the write would put the file in breach of a rule that reported nothing ([#355](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/355)). Both judge the lineness of the block whose brace it is, and a write behind a brace nested inside that block does move it, so the two answer about the block as each of them finds it.
+ * @param syntax - The asking rule's syntax, whose namespace names the neighbour.
+ * @param statement - The rule or at-rule whose closing brace the run stands behind.
+ * @param result - The Stylelint result, which holds the configuration.
+ * @param ruleName - The asking rule's registered name.
+ * @returns True where the asking rule writes the run.
+ */
+export function writesRunBehindBrace (syntax: Syntax, statement: AtRule | Rule, result: PostcssResult, ruleName: string): boolean {
+	let asking = (Object.keys(PARTICIPANTS) as Participant[]).find((participant) => addNamespace(PARTICIPANTS[participant].name, syntax.namespace) === ruleName)
+
+	if (!asking) return true
+
+	let settings = neighbourSettings(statement, result, PARTICIPANTS)
+	let position = settings.findIndex(([, , , name]) => name === ruleName)
+
+	if (position === -1) return true
+
+	let askingNode = writtenNodeOf(asking, ruleName, result, statement)
+
+	if (!askingNode) return true
+
+	let [, option] = settings[position] as [Participant, string, boolean, string]
+	let accepted = accepts(asking, option)
+	let singleLine: boolean | undefined
+
+	/**
+	 * Whether the block is on one line, printed once.
+	 * @returns True when it is.
+	 */
+	function isSingleLine (): boolean {
+		singleLine ??= isSingleLineString(blockString(statement, result))
+
+		return singleLine
+	}
+
+	let line = statement.source?.end?.line
+	let parted = runBehindBrace(askingNode)
+
+	/**
+	 * Asks whether a neighbour would write this very raw, so that its option gates the asking rule at all.
+	 * @param neighbour - The rule.
+	 * @param neighbourOption - Its primary option.
+	 * @param neighbourName - The name the configuration lists it under.
+	 * @returns True where it speaks of this block, writes this raw, and no disable comment keeps it off the line.
+	 */
+	function contends (neighbour: Participant, neighbourOption: string, neighbourName: string): boolean {
+		if (!speaksOf(neighbourOption, isSingleLine)) return false
+		if (writtenNodeOf(neighbour, neighbourName, result, statement) !== askingNode) return false
+		// The space rule writes nothing where a further semicolon stands inside the run, so it contends for nothing there
+		if (neighbour === `space` && parted.holdsASemicolon) return false
+
+		return line === undefined || !fixDisabledOnLine(result, neighbourName, line)
+	}
+
+	let restsBehind = settings.slice(position + 1).every(([behind, behindOption, behindFixTurnedOff, behindName]) => {
+		// A turned-off fix rewrites nothing, so it gates nothing (#485)
+		if (behindFixTurnedOff || !contends(behind, behindOption, behindName)) return true
+
+		return accepts(behind, behindOption).some((run) => accepted.includes(run))
+	})
+
+	let standing = spellingOf(parted.run)
+
+	// A rule ahead judged the run before the write, so where it was content with what stands and refuses what the write leaves, the write would put the file in breach of a rule that reported nothing (#355). A turned-off fix exempts nothing here: such a rule still reports, or still stays silent
+	let restsAhead = settings.slice(0, position).every(([ahead, aheadOption, , aheadName]) => {
+		if (!contends(ahead, aheadOption, aheadName)) return true
+
+		let aheadAccepts = accepts(ahead, aheadOption)
+
+		return !aheadAccepts.includes(standing) || aheadAccepts.some((run) => accepted.includes(run))
+	})
+
+	return restsBehind && restsAhead
+}


### PR DESCRIPTION
`block-closing-brace-space-after` reported and wrote nothing, while `block-closing-brace-newline-after`, which speaks of the same run, fixes:

```css
/* input */
a {}b {}

/* --fix under `block-closing-brace-space-after: "always"`, before this branch */
a {}b {}

/* --fix under the same option, after it */
a {} b {}
```

The run is the next node's `raws.before`, and the check reads it behind the one leading semicolon it skips, so the fix writes behind that semicolon too: a stray one, and any whitespace in front of it, stay where PostCSS keeps them, in the block's own `raws.ownSemicolon`. A write crossing a further semicolon is `no-extra-semicolons`'s question rather than this rule's, and four open issues still argue over the reading, so the warning stands there unfixed.

Both rules write that raw wherever they write the same one, and with no answer about which of them owns it the pair would take it in turns. `writesRunBehindBrace` answers it: the two write only where they accept a spelling in common; otherwise the one that runs last writes and the other reports, unless a rule ahead of it was content with the run as it stood, in which case neither writes. Both rules read it, and `block-closing-brace-newline-after` stops writing unconditionally.

Closes #698.
