### PR TITLE
Record the `block-closing-brace-space-after` fixer in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The plugin now reads a line break the way PostCSS and Stylelint do: a line 
 
 - The [`at-rule-name-newline-after`](https://stylelint-stylistic.github.io/rules/at-rule-name-newline-after) rule is now autofixable (see [#696](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/696)). Expect `--fix` to write the newlines the rule used to only ask for. Where your configuration also lists `at-rule-name-space-after` under `always`, the two now ask for different things in the same place and the order they are listed in decides which one wins. A `@charset` is reported but left as written, since breaking its head can leave the stylesheet declaring no encoding.
 - The [`at-rule-semicolon-space-before`](https://stylelint-stylistic.github.io/rules/at-rule-semicolon-space-before) rule is now autofixable (see [#697](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/697)). Expect `--fix` to write the whitespace the rule used to only ask for.
+- The [`block-closing-brace-space-after`](https://stylelint-stylistic.github.io/rules/block-closing-brace-space-after) rule is now autofixable (see [#698](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/698)). Expect `--fix` to write the whitespace the rule used to only ask for. Where your configuration also lists `block-closing-brace-newline-after` asking for something else of that same run, only one of the two now writes and the other reports.
+
 
 #### New features
 


### PR DESCRIPTION
The fixer of [#698](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/698) went out in `d4850fc` with no changelog entry. This is that entry, and nothing else.

It matters because the changelog drives the release rather than recording it: `@firefoxic/release-it` derives the bump from the first heading it finds in `Unreleased`, so a rule that gained a fixer and says nothing there ships without the minor version it earns, and a user meeting new autocorrections has nothing to read.

The entry sits third in `#### New autofixes`, behind the two the same umbrella has already shipped, and it names the one thing a user has to weigh: where `block-closing-brace-newline-after` asks for something else of the same run, only one of the two writes now and the other reports.

It could not come in as a `fixup!` of its own commit, which is what the working agreement asks for: that commit is already on `main`, and `rebase --autosquash` folds a fixup only into a commit of the range it rebases.
