### PR TITLE
Read a semicolon inside a `//` comment as the comment's text under Less

### DIFF
--- a/lib/rules/declaration-block-trailing-semicolon/index.ts
+++ b/lib/rules/declaration-block-trailing-semicolon/index.ts
@@ -1,7 +1,7 @@
 import type { AtRule, ChildNode, Container, Declaration, Node } from "postcss"
 import stylelint, { type PostcssResult } from "stylelint"
 
-import { TRAILING_CSS_WHITESPACE, WHITESPACE_OR_NOTHING } from "../../regexps.ts"
+import { LINE_BREAK, TRAILING_CSS_WHITESPACE, WHITESPACE_OR_NOTHING } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
 import type { Syntax } from "../../syntaxes/index.ts"
 import { betweenTailAfterColon } from "../../utils/betweenTailAfterColon/index.ts"
@@ -31,12 +31,13 @@ export let meta = {
 	fixable: true,
 }
 
-/** A raw behind the node closing a block: owner, key, file offset and text. */
+/** A raw behind the node closing a block: owner, key, file offset, text, and the index in the text its code opens at. */
 type HeldRaw = {
 	owner: Node,
 	key: string,
 	start: number,
 	text: string,
+	code: number,
 }
 
 /**
@@ -82,28 +83,74 @@ function blockEnd (container: Container): number {
 /**
  * Returns the raws between the node closing the block and the block's end, in file order, with their start offsets.
  *
- * Only comments follow that node, so a `;` here is code, not comment text. A comment's `raws.before` is anchored to the comment's own start, since `postcss-less` ends an inline comment one character short. A missing raw is skipped, since an empty string would override the PostCSS default.
+ * Only comments follow that node, so a `;` here is code, unless the flag's semicolon is the text of a `//` comment: that comment runs on to the first line break behind it, which a comment it meets may hold ([#359](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/359)). A comment's `raws.before` is anchored to the comment's own start, since `postcss-less` ends an inline comment one character short. A missing raw is skipped, since an empty string would override the PostCSS default.
  * @param node - The node closing the block.
+ * @param result - The Stylelint result.
+ * @param flagIsCommentText - Whether the flag's semicolon is the text of such a comment.
  * @returns The raws, each with its owner and key.
  */
-function rawsBehind (node: ChildNode): HeldRaw[] {
+function rawsBehind (node: ChildNode, result: PostcssResult, flagIsCommentText: boolean): HeldRaw[] {
 	let container = node.parent
 
 	if (!container?.nodes) throw new Error(`The node must stand in a block`)
 
 	let raws: HeldRaw[] = []
+	let inComment = flagIsCommentText
+
+	/**
+	 * Returns where a raw's code opens, closing the comment at its first break.
+	 * @param text - The raw.
+	 * @returns The index.
+	 */
+	function codeOf (text: string): number {
+		if (!inComment) return 0
+
+		let lineBreak = text.search(LINE_BREAK)
+
+		if (lineBreak === -1) return text.length
+
+		inComment = false
+
+		return lineBreak
+	}
 
 	for (let sibling of container.nodes.slice(container.index(node) + 1)) {
 		let text = sibling.raws.before
 
-		if (typeof text === `string`) raws.push({ owner: sibling, key: `before`, start: offsetsOf(sibling).start - text.length, text })
+		if (typeof text === `string`) raws.push({ owner: sibling, key: `before`, start: offsetsOf(sibling).start - text.length, text, code: codeOf(text) })
+
+		if (inComment && LINE_BREAK.test(nodeString(sibling, result))) inComment = false
 	}
 
 	let after = container.raws.after
 
-	if (typeof after === `string`) raws.push({ owner: container, key: `after`, start: blockEnd(container) - after.length, text: after })
+	if (typeof after === `string`) raws.push({ owner: container, key: `after`, start: blockEnd(container) - after.length, text: after, code: codeOf(after) })
 
 	return raws
+}
+
+/**
+ * Asks whether a raw spells a semicolon in its code.
+ * @param raw - The raw behind the node.
+ * @returns True where it does.
+ */
+function spellsSemicolon (raw: HeldRaw): boolean {
+	return raw.text.slice(raw.code).includes(`;`)
+}
+
+/**
+ * Asks whether a semicolon closes the node ending the block.
+ *
+ * A flag set by a comment's text leaves the node closed only by a semicolon of code behind that comment ([#359](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/359)).
+ * @param node - The node closing the block.
+ * @param raws - The raws behind the node.
+ * @param flagIsCommentText - Whether the flag's semicolon is the text of a `//` comment.
+ * @returns True where one does.
+ */
+function endsOnSemicolon (node: ChildNode, raws: HeldRaw[], flagIsCommentText: boolean): boolean {
+	if (flagIsCommentText) return raws.some((raw) => spellsSemicolon(raw))
+
+	return Boolean(node.parent?.raws.semicolon)
 }
 
 /**
@@ -112,53 +159,58 @@ function rawsBehind (node: ChildNode): HeldRaw[] {
  * `raws.semicolon` covers only the semicolon right behind the node; further ones sit in a following comment's `raws.before` or the block's `raws.after`. The index is counted in the file, as `report` reads it, so it may reach past the node's end; a raw another rule rewrote in the same `--fix` pass shifts it ([#356](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/356)).
  * @param node - The node closing the block.
  * @param result - The Stylelint result, which {@link offsetsOf} reads the syntax from.
+ * @param raws - The raws behind the node.
+ * @param flagIsCommentText - Whether the flag's semicolon is the text of a `//` comment.
  * @returns The index from the node's start, or undefined without a semicolon.
  */
-function trailingSemicolonIndex (node: ChildNode, result: PostcssResult): number | undefined {
+function trailingSemicolonIndex (node: ChildNode, result: PostcssResult, raws: HeldRaw[], flagIsCommentText: boolean): number | undefined {
 	let { start, end } = offsetsOf(node, result)
-	let holder = rawsBehind(node).findLast((raw) => raw.text.includes(`;`))
+	let holder = raws.findLast((raw) => spellsSemicolon(raw))
 
 	if (holder) return holder.start + holder.text.lastIndexOf(`;`) - start
 
 	// The flag's semicolon is the first behind the node, so it is asked last; the node's span ends on it
-	return node.parent?.raws.semicolon ? end - 1 - start : undefined
+	return node.parent?.raws.semicolon && !flagIsCommentText ? end - 1 - start : undefined
 }
 
 /**
  * Removes every semicolon behind the node, in the flag and in the raws, and the whitespace in front of the flag's own.
  *
- * Removing the flag's alone left one in a raw, which the next parse read as the flag's. The whitespace outlived the semicolon whenever a `declaration-block-semicolon-*-before` rule was listed first ([#479](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/479)); in front of a semicolon in a raw it is a comment's layout and stays. Behind an inline comment nothing is trimmed.
+ * Removing the flag's alone left one in a raw, which the next parse read as the flag's. The whitespace outlived the semicolon whenever a `declaration-block-semicolon-*-before` rule was listed first ([#479](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/479)); in front of a semicolon in a raw it is a comment's layout and stays. Behind an inline comment nothing is trimmed, and a semicolon in its text stays.
  * @param syntax - The syntax the rule is built over.
  * @param node - The node closing the block.
  * @param result - The Stylelint result.
+ * @param raws - The raws behind the node.
+ * @param flagIsCommentText - Whether the flag's semicolon is the text of a `//` comment.
  */
-function takeTheTrailingSemicolonsAway (syntax: Syntax, node: AtRule | Declaration, result: PostcssResult): void {
+function takeTheTrailingSemicolonsAway (syntax: Syntax, node: AtRule | Declaration, result: PostcssResult, raws: HeldRaw[], flagIsCommentText: boolean): void {
 	let { parent } = node
 
 	if (!parent) throw new Error(`The node must stand in a block`)
 
 	if (parent.raws.semicolon && !syntax.writesIntoInlineComment(node, result)) writeWhitespaceBeforeSemicolon(syntax, node, ``)
 
-	parent.raws.semicolon = false
+	if (!flagIsCommentText) parent.raws.semicolon = false
 
-	for (let raw of rawsBehind(node)) raw.owner.raws[raw.key] = raw.text.replaceAll(`;`, ``)
+	for (let raw of raws) raw.owner.raws[raw.key] = raw.text.slice(0, raw.code) + raw.text.slice(raw.code).replaceAll(`;`, ``)
 }
 
 /**
  * Asks whether the warning over a node can carry a fix.
  *
- * Under `always`, no for a node with a block (`postcss-scss` drops a Sass nested property's semicolon) and where an inline comment ending the node would swallow the semicolon. Under `never`, no for the semicolon PostCSS writes regardless of the flag and the ones the syntax requires, which under Less are the semicolon behind a bodiless at-rule and the one behind a declaration it reads no value in. The warning then stands over code the fix leaves alone.
+ * Under `always`, no for a node with a block (`postcss-scss` drops a Sass nested property's semicolon), where an inline comment ending the node would swallow the semicolon, and where the flag is that comment's text, which a break written in front of the semicolon would take out of it. Under `never`, no for the semicolon PostCSS writes regardless of the flag and the ones the syntax requires, which under Less are the semicolon behind a bodiless at-rule and the one behind a declaration it reads no value in. The warning then stands over code the fix leaves alone.
  * @param syntax - The syntax the rule is built over.
  * @param node - The node the semicolon stands behind.
  * @param primary - The primary option.
  * @param spelledBetween - The run between the node and an `always` write, where that write misses the node's trailing whitespace.
  * @param result - The Stylelint result.
+ * @param flagIsCommentText - Whether the flag's semicolon is the text of a `//` comment.
  * @returns True where the fix may be written.
  */
-function isFixable (syntax: Syntax, node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult): boolean {
+function isFixable (syntax: Syntax, node: ChildNode, primary: `always` | `never`, spelledBetween: string | undefined, result: PostcssResult, flagIsCommentText: boolean): boolean {
 	if (primary === `never`) return !semicolonOutlivesTheFlag(node) && !syntax.requiresTrailingSemicolon(node, result)
 
-	return !hasBlock(node) && !syntax.writesIntoInlineComment(node, result, spelledBetween)
+	return !hasBlock(node) && !syntax.writesIntoInlineComment(node, result, spelledBetween) && !flagIsCommentText
 }
 
 /** `always` a semicolon behind the last declaration, `never` none. */
@@ -222,9 +274,11 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 			if (!parent) throw new Error(`A parent node must be present`)
 
-			let hasSemicolon = parent.raws.semicolon
+			let flagIsCommentText = syntax.semicolonFlagIsCommentText(node, result)
+			let raws = rawsBehind(node, result, flagIsCommentText)
+			let hasSemicolon = endsOnSemicolon(node, raws, flagIsCommentText)
 			// `never` asks for the semicolon's place, since the block can end on one the flag does not cover
-			let trailingSemicolon = primary === `never` ? trailingSemicolonIndex(node, result) : undefined
+			let trailingSemicolon = primary === `never` ? trailingSemicolonIndex(node, result, raws, flagIsCommentText) : undefined
 			let ignoreSingleDeclaration = optionsMatches(
 				secondaryOptions,
 				`ignore`,
@@ -259,7 +313,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 					endIndex: problemIndex,
 					result,
 					ruleName,
-					...(isFixable(syntax, node, primary, spelledBetween, result) && {
+					...(isFixable(syntax, node, primary, spelledBetween, result, flagIsCommentText) && {
 						fix: (): void => {
 							if (primary === `always` && !hasSemicolon) {
 								parent.raws.semicolon = true
@@ -274,7 +328,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 								// A whitespace-only value shares its run with the colon, and a colon rule listed earlier may have written onto the tail of `raws.between` (#50); that tail and the value are read as one run, as the semicolon rules do (#536)
 								else if (isDeclaration(node) && whitespace && !(!node.important && WHITESPACE_OR_NOTHING.test(syntax.read(node)) && betweenTailAfterColon(syntax, node, result) + syntax.read(node) === whitespace)) writeWhitespaceBeforeSemicolon(syntax, node, whitespace)
 							}
-							else if (primary === `never`) takeTheTrailingSemicolonsAway(syntax, node, result)
+							else if (primary === `never`) takeTheTrailingSemicolonsAway(syntax, node, result, raws, flagIsCommentText)
 						},
 					}),
 				})

--- a/lib/syntaxes/css/index.ts
+++ b/lib/syntaxes/css/index.ts
@@ -75,6 +75,8 @@ export let css: Syntax = {
 		return findCommentSpans(text, spellsInlineComments)
 	},
 	requiresTrailingSemicolon: () => false,
+	// A parser leaving a `//` comment in a node's text is `postcss-less`, read by the less namespace
+	semicolonFlagIsCommentText: () => false,
 	// Both marks are `postcss-less`'s, read by the less namespace
 	readsRuleParams: () => false,
 	// No at-rule of plain CSS declares a variable, so none carries a value to walk

--- a/lib/syntaxes/index.ts
+++ b/lib/syntaxes/index.ts
@@ -205,6 +205,14 @@ export type Syntax = {
 	requiresTrailingSemicolon (node: Node, result: PostcssResult): boolean,
 
 	/**
+	 * Asks whether the semicolon the node's block is flagged as closing on is the text of a `//` comment behind the node, which the parser read as code.
+	 * @param node - The node closing the block.
+	 * @param result - The lint result naming the syntax the file was parsed with.
+	 * @returns True where it is.
+	 */
+	semicolonFlagIsCommentText (node: Node, result: PostcssResult): boolean,
+
+	/**
 	 * Asks whether the node's syntax has arithmetic of its own, where whitespace in front of a sign makes it an operator.
 	 *
 	 * The tree cannot tell `foo($a) -2px`, a Sass list, from `foo($a)-2px`, a subtraction, so whether `//` opens a comment is asked instead: Sass and Less have both, plain CSS neither, an unknown syntax is answered yes. Sass reads a plus as an operator whatever stands beside it, so a plus behind a call is left alone under both. The node is asked, not the file: a page may hold a plain `<style>` beside a `<style lang="scss">`.

--- a/lib/syntaxes/less/index.ts
+++ b/lib/syntaxes/less/index.ts
@@ -10,6 +10,7 @@ import type { Syntax } from "../index.ts"
 import { atRuleVariableValue } from "./atRuleVariableValue/index.ts"
 import { isStandardLessAtRule, isStandardLessDeclaration, isStandardLessProperty, isStandardLessRule, isStandardLessSelector, isStandardLessValue } from "./guards/index.ts"
 import { requiresTrailingSemicolon } from "./requiresTrailingSemicolon/index.ts"
+import { semicolonFlagIsCommentText } from "./semicolonFlagIsCommentText/index.ts"
 import { syncLessVariableValue } from "./syncLessVariableValue/index.ts"
 
 /** The syntax of the `less` namespace: Less parsed with `postcss-less`. A superset of the core, plain CSS included, so a project holding both configures these rules alone for the Less files. */
@@ -24,6 +25,7 @@ export let less: Syntax = {
 	isStandardValue: isStandardLessValue,
 	isStandardComment: isStandardPreprocessorComment,
 	requiresTrailingSemicolon,
+	semicolonFlagIsCommentText,
 	readsRuleParams: (rule: PostcssRule) => `params` in rule && Boolean(rule.params),
 	atRuleVariableValue,
 	// Under its default `math` mode Less divides only inside parentheses (`@a/2` prints `4/2`), a nameless call the rules pass over, so a solidus outside is the separator it is to the core

--- a/lib/syntaxes/less/regexps.ts
+++ b/lib/syntaxes/less/regexps.ts
@@ -6,6 +6,9 @@ export const LESS_EXTEND = /:extend(?:\(.*?\))?/u
 /** A Less `:extend(…)` with a selector list, in any case. */
 export const LESS_EXTEND_CALL = /:extend\(.+\)/iu
 
+/** A name Less calls a detached ruleset by: its `variableCall` reads ASCII word characters and hyphens, and an at-rule of the same shape spelling any other is read as an at-rule. */
+export const LESS_DETACHED_RULESET_NAME = /^[\w-]+$/u
+
 /** The `when` of a Less guard, lower case only, as Less reads its keywords. */
 export const LESS_GUARD = /\swhen\s*(?:not\s*)?\(/u
 

--- a/lib/syntaxes/less/rules/declaration-block-trailing-semicolon/index.test.ts
+++ b/lib/syntaxes/less/rules/declaration-block-trailing-semicolon/index.test.ts
@@ -16,9 +16,71 @@ testRule({
 			description: `a Less variable standing on the root of the file, which this syntax reads as an at-rule and the walk over at-rules has always let stand`,
 			code: `@var: pink`,
 		},
+		{
+			// See #359
+			description: `a semicolon in the text of an inline comment behind the value, with a semicolon of code on the line under it, which closes the declaration`,
+			code: `
+				a {
+					color: pink // ;
+					;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `the same comment behind the parameters of an extend at-rule, which Less reads to the semicolon with a reader that knows no double slash, so the semicolon is code`,
+			code: `
+				a {
+					@extend .b // c;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `the same comment behind a custom property carrying an important flag, which Less reads the same way`,
+			code: `
+				a {
+					--x: pink !important // ;
+				}
+			`,
+		},
 	],
 
 	reject: [
+		{
+			// See #359
+			description: `a semicolon in the text of an inline comment behind the value, which this syntax reads as the semicolon closing the declaration and Less as the text of the comment: no semicolon closes it, and the comment is left alone`,
+			code: `
+				a {
+					color: pink // ;
+				}
+			`,
+			fixed: `
+				a {
+					color: pink // ;
+				}
+			`,
+			line: 2,
+			column: 15,
+			message: messages.expected,
+		},
+		{
+			// See #359
+			description: `the same comment behind a mixin call, which Less reads with the same reader`,
+			code: `
+				a {
+					.m() // ;
+				}
+			`,
+			fixed: `
+				a {
+					.m() // ;
+				}
+			`,
+			line: 2,
+			column: 8,
+			message: messages.expected,
+		},
 		{
 			// See #232
 			description: `an inline comment behind the value, which this syntax keeps inside it: the semicolon cannot leave the comment's line, so the code is left alone and the warning stands`,
@@ -216,6 +278,60 @@ testRule({
 			description: `the same name with no colon behind it, which the parser reads as an at-rule of that name`,
 			code: `a { @v }`,
 		},
+		{
+			// See #359
+			description: `a semicolon in the text of an inline comment behind the value, which this syntax reads as the semicolon closing the declaration and Less as the text of the comment`,
+			code: `
+				a {
+					color: pink // ;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `the same comment behind an important flag`,
+			code: `
+				a {
+					color: pink !important // ;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `the same comment behind a mixin call`,
+			code: `
+				a {
+					.m() // ;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `the same comment behind a call to a detached ruleset`,
+			code: `
+				a {
+					@dr() // ;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `a second semicolon in the same comment, which this syntax files in the raw ending the block`,
+			code: `
+				a {
+					color: pink // ;;
+				}
+			`,
+		},
+		{
+			// See #359
+			description: `a block comment and a semicolon behind it in the same comment, which run on to the line break as its text`,
+			code: `
+				a {
+					color: pink // ; /* c */ ;
+				}
+			`,
+		},
 	],
 
 	reject: [
@@ -243,6 +359,15 @@ testRule({
 			`,
 			line: 2,
 			column: 13,
+			message: messages.rejected,
+		},
+		{
+			// Spelled with escapes for the line holding a tab alone, as above. See #359
+			description: `a semicolon of code on the line under an inline comment whose text holds two, which alone is taken away`,
+			code: `a {\n\tcolor: pink // ;;\n\t;\n}\n`,
+			fixed: `a {\n\tcolor: pink // ;;\n\t\n}\n`,
+			line: 3,
+			column: 2,
 			message: messages.rejected,
 		},
 		{

--- a/lib/syntaxes/less/rules/declaration-block-trailing-semicolon/integration.test.ts
+++ b/lib/syntaxes/less/rules/declaration-block-trailing-semicolon/integration.test.ts
@@ -1,3 +1,7 @@
+import stylelint from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import plugins from "../../../../index.ts"
 import { createRule as createAtRuleSpaceBefore } from "../../../../rules/at-rule-semicolon-space-before/index.ts"
 import { createRule as createNewlineBefore } from "../../../../rules/declaration-block-semicolon-newline-before/index.ts"
 import { createRule as createSpaceBefore } from "../../../../rules/declaration-block-semicolon-space-before/index.ts"
@@ -46,6 +50,18 @@ testRule({
 			message: messages.expected,
 		},
 	],
+})
+
+// The neighbour's fix is off, so the break it asks for could only be this rule's write, and the file and this rule's warning are asserted directly: the neighbour reads the comment's semicolon as well. See #359
+describe(`a semicolon in the text of an inline comment ending the value`, () => {
+	it(`is left in the comment where the namespace's rule asks for a break in front of the semicolon, which would take it out`, async () => {
+		let code = `a {\n\tb: c // ;\n}\n`
+		let rules = { [ruleName]: `always`, [newlineBeforeRuleName]: [`always`, { disableFix: true }] }
+		let result = await stylelint.lint({ code, config: { plugins, rules }, customSyntax: `postcss-less`, fix: true })
+
+		expect(result.code).toBe(code)
+		expect(result.results[0]?.warnings.filter((warning) => warning.rule === ruleName).map((warning) => ({ line: warning.line, column: warning.column, text: warning.text }))).toEqual([{ line: 2, column: 8, text: messages.expected }])
+	})
 })
 
 testRule({

--- a/lib/syntaxes/less/semicolonFlagIsCommentText/index.test.ts
+++ b/lib/syntaxes/less/semicolonFlagIsCommentText/index.test.ts
@@ -1,0 +1,50 @@
+import type { Container, Parser } from "postcss"
+import less from "postcss-less"
+import scss from "postcss-scss"
+import type { PostcssResult } from "stylelint"
+import { describe, expect, it } from "vitest"
+
+import { semicolonFlagIsCommentText } from "./index.ts"
+
+/**
+ * Asks about the last node of the one block of a stylesheet.
+ * @param code - The node closing the block, spelled inside it.
+ * @param syntax - The syntax the stylesheet is parsed with.
+ * @returns What the util makes of that node.
+ */
+function closing (code: string, syntax: { parse: Parser } = less): boolean {
+	let block = syntax.parse(`a {\n\t${code}\n}`, { from: undefined }).first as Container
+	let node = block.last
+
+	if (!node) throw new Error(`The block holds no node`)
+
+	return semicolonFlagIsCommentText(node, { opts: { syntax } } as unknown as PostcssResult)
+}
+
+describe(`semicolonFlagIsCommentText`, () => {
+	it(`a declaration of an ordinary property, a mixin call and a detached ruleset call, the semicolon in the text of the comment behind each`, () => {
+		expect(closing(`color: pink // ;`)).toBe(true)
+		expect(closing(`color: pink !important // ;`)).toBe(true)
+		expect(closing(`.m() // ;`)).toBe(true)
+		expect(closing(`@dr() // ;`)).toBe(true)
+	})
+
+	it(`a custom property, a variable and an at-rule, which Less may read to the semicolon with a reader that knows no double slash`, () => {
+		expect(closing(`--x: pink // ;`)).toBe(false)
+		expect(closing(`@v: pink // ;`)).toBe(false)
+		expect(closing(`@extend .b // ;`)).toBe(false)
+		expect(closing(`@dr$() // ;`)).toBe(false)
+	})
+
+	it(`a semicolon of code, behind the line break closing the comment, behind a double slash of an address or with no comment at all, and a comment with no semicolon behind it`, () => {
+		expect(closing(`color: pink // c\n;`)).toBe(false)
+		expect(closing(`background: url(//a) ;`)).toBe(false)
+		expect(closing(`color: pink;`)).toBe(false)
+		expect(closing(`color: pink // c`)).toBe(false)
+	})
+
+	it(`the same comment read by a parser that cuts it out of the node itself`, () => {
+		expect(closing(`color: pink // ;`, scss)).toBe(false)
+		expect(closing(`color: pink // c\f;`, scss)).toBe(false)
+	})
+})

--- a/lib/syntaxes/less/semicolonFlagIsCommentText/index.ts
+++ b/lib/syntaxes/less/semicolonFlagIsCommentText/index.ts
@@ -1,0 +1,37 @@
+import type { Node } from "postcss"
+import type { AtRule } from "postcss-less"
+import type { PostcssResult } from "stylelint"
+
+import { inlineCommentReading } from "../../../preprocessor/readsInlineComments/index.ts"
+import { writesIntoInlineComment } from "../../../preprocessor/writesIntoInlineComment/index.ts"
+import { isCustomProperty } from "../../../utils/isCustomProperty/index.ts"
+import { isAtRule, isDeclaration } from "../../../utils/typeGuards/index.ts"
+import { isLessDetachedRulesetCall } from "../isLessDetachedRulesetCall/index.ts"
+import { LESS_DETACHED_RULESET_NAME } from "../regexps.ts"
+
+/**
+ * Asks whether Less reads a `//` comment behind the node as a comment whatever the node spells.
+ *
+ * A declaration of an ordinary property and a call to a mixin or a detached ruleset are read with the reader that skips such a comment, the call's name spelled as Less reads one, so a semicolon in its text closes nothing or the file is refused. A custom property, a variable and any other at-rule fall back to a reader that knows no `//`, and which of the two Less takes turns on its expression grammar, so their flag is believed.
+ * @param node - The node closing the block.
+ * @returns True where the comment is one.
+ */
+function readsTheComment (node: Node): boolean {
+	if (isDeclaration(node)) return !isCustomProperty(node.prop)
+
+	return isAtRule(node) && (Boolean((node as AtRule).mixin) || (isLessDetachedRulesetCall(node) && LESS_DETACHED_RULESET_NAME.test(node.name)))
+}
+
+/**
+ * Asks whether the semicolon a block's `raws.semicolon` stands for is the text of a `//` comment behind the node.
+ *
+ * `postcss-less` closes a node at the first semicolon behind it, one inside such a comment included ([#359](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/359)). The stringifier prints the flag's semicolon right behind the node's text, which is where an empty spelled run puts the guard's written character. A parser keeping no such comment in that text cut it out itself, so its flag is code.
+ * @param node - The node closing the block.
+ * @param result - The Stylelint result, whose syntax says what opens a comment.
+ * @returns True where the flag is set by comment text.
+ */
+export function semicolonFlagIsCommentText (node: Node, result: PostcssResult): boolean {
+	if (!node.parent?.raws.semicolon || !readsTheComment(node)) return false
+
+	return inlineCommentReading(node, result).keeps && writesIntoInlineComment(node, result, ``)
+}

--- a/lib/utils/closedBySemicolon/index.ts
+++ b/lib/utils/closedBySemicolon/index.ts
@@ -94,7 +94,7 @@ function reaches (syntax: Syntax, decl: Declaration, result: PostcssResult, sett
 /**
  * Asks what `declaration-block-trailing-semicolon` leaves behind a declaration: a semicolon under a live `always`, none under a live `never`, nothing where its fix cannot write.
  *
- * `always` writes behind no node with a block and none an inline comment closes; `never` takes no semicolon PostCSS writes regardless or the language requires. The disable line is the declaration's last, where `always` reports.
+ * `always` writes behind no node with a block and none an inline comment closes; `never` takes no semicolon PostCSS writes regardless or the language requires; neither acts on a flag a comment's text set. The disable line is the declaration's last, where `always` reports.
  * @param syntax - The asking rule's syntax.
  * @param decl - The declaration.
  * @param result - The Stylelint result, which holds the configuration.
@@ -104,6 +104,8 @@ export function trailingSemicolonAsked (syntax: Syntax, decl: Declaration, resul
 	let setting = neighbourSetting(syntax, result, TRAILING_SEMICOLON_RULE)
 
 	if (!setting || !reaches(syntax, decl, result, setting)) return undefined
+
+	if (syntax.semicolonFlagIsCommentText(decl, result)) return undefined
 
 	if (setting.option === `always`) return !hasBlock(decl) && !syntax.writesIntoInlineComment(decl, result, whitespaceBeforeSemicolon(syntax, decl, result)) ? true : undefined
 

--- a/scripts/sweeps/semicolon-in-comment.ts
+++ b/scripts/sweeps/semicolon-in-comment.ts
@@ -1,0 +1,46 @@
+/**
+ * A semicolon in the text of a `//` comment behind the last node of a block, which `postcss-less` reads as the semicolon closing that node. `postcss-scss` reads it as comment text; Less does behind an ordinary declaration and a call, and behind a custom property, a variable or an at-rule reads it either way by the value.
+ *
+ * Written for [#359](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/359). The comment's text holds one semicolon, two, two apart, one either side of a block comment, and one with a semicolon of code on the line under it; a bare carriage return and a form feed in front of the semicolon are the two breaks the readers part on. The controls hold no semicolon in the comment, or one of code under it; the node also stands in the middle of the block. Every rule under every primary option.
+ */
+
+import { multiply } from "../harness/matrix.ts"
+import { RULE_OPTIONS } from "../oracles/options.ts"
+
+import type { Sweep } from "./run.ts"
+
+const name: Sweep[`name`] = `semicolon-in-comment`
+
+const corpus: Sweep[`corpus`] = multiply({
+	node: {
+		declaration: `color: pink`,
+		flag: `color: pink !important`,
+		custom: `--x: pink`,
+		customFlag: `--x: pink !important`,
+		variable: `@v: pink`,
+		detached: `@dr()`,
+		atRule: `@include x`,
+		mixin: `.m()`,
+		extend: `@extend .b`,
+	},
+	tail: {
+		semicolon: ` ;`,
+		twoSemicolons: ` ;;`,
+		twoApart: ` ; ;`,
+		aroundBlockComment: ` ; /* c */ ;`,
+		codeBelow: ` ;\n\t;`,
+		bareReturn: ` c\r;`,
+		formFeed: ` c\f;`,
+		none: ` c`,
+		codeBelowNone: ` c\n\t;`,
+	},
+	place: {
+		last: `last`,
+		middle: `middle`,
+	},
+}, ({ node, tail, place }) => (place === `last` ? `a {\n\t${node} //${tail}\n}\n` : `a {\n\t${node} //${tail}\n\ttop: 0;\n}\n`))
+
+// An array primary is a whole setting: primary, then secondary options
+const configs: Sweep[`configs`] = Object.entries(RULE_OPTIONS).flatMap(([rule, primaries]) => primaries.map((primary) => (Array.isArray(primary) ? { rule, primary: primary[0] as unknown, secondary: primary[1] as object } : { rule, primary })))
+
+export { configs, corpus, name }


### PR DESCRIPTION
`postcss-less` closes the last node of a block at the first semicolon behind it, a semicolon inside an end-of-line comment included, and sets the block's `raws.semicolon` for it. `declaration-block-trailing-semicolon` believed that flag, so `never` took the character out of the comment's text, and `always` said nothing over a block no semicolon of code closes:

```less
a {
	color: pink // ;
}
/* never, one --fix run on the base:   color: pink //      (the comment's semicolon gone)
   never, on the branch:               nothing reported, nothing written
   always, on the base:                nothing reported
   always, on the branch:              2:15 Expected a trailing semicolon, nothing written */
```

The less namespace now answers whether such a flag is the comment's text, and the rule reads it as unset where it is: the comment is read on over the raws behind the node to its line break, so `// ;;` and `// ; /* c */ ;` keep their second semicolon too, while a semicolon of code on the next line still closes the node for `always` and is still taken away by `never`. The answer is yes behind a declaration of an ordinary property, a mixin call and a detached ruleset call whose name Less reads as one, word characters and hyphens alone. Less reads those with the reader that skips a `//` comment: over 58 value spellings of a declaration, 58 argument spellings of a mixin call and 46 further spellings of properties, flags and calls, it never read the semicolon as code, and the file either compiled without it or was refused either way. Behind a custom property, a Less variable and any other at-rule, Less falls back to a reader that knows no `//` for some values, `--x: pink !important // ;` and `@extend .b // c;` among them, so the flag is believed there as before. `always` writes nothing over the block it now reports, since a break asked for in front of the semicolon by `declaration-block-semicolon-newline-before` would take the comment's semicolon out of it.

## What the review turned up

- **A sweep of every rule under every primary option** over the committed `semicolon-in-comment` corpus — nine kinds of node, nine comment tails, the node last in its block or in the middle, under css, scss and less — is 111 294 rows, of which 52 move, every one this rule's under less and behind the four nodes the reading covers. None stops reparsing. The fix writes over four of them, where a semicolon of code stands on the line under the comment, and takes that semicolon alone; Less compiles each output to the same CSS as its input.
- **What it costs:** Less ends a `//` comment at a bare carriage return, while the inline-comment guard ends it only at a line feed. Over `color: pink // c\r;` the branch reads the semicolon as comment text, so `never` no longer takes it (4 rows) and `always` reports a warning it cannot fix (4 rows). The same holds of a semicolon behind a bare carriage return in the raws behind the node. Filed as #721.
- **Left as it was:** `never` still takes a semicolon out of the comment behind a custom property whose value Less reads with the reader that skips it, `--x: pink // ;`. Filed as #722. And `always` still writes into a comment where a whole node stands in the comment of the one in front of it, `color: pink // ; top: 0`, on the base as on the branch. Filed as #723. And `never` still takes the semicolon Less asks for behind an at-rule spelled like a detached ruleset call with a name Less does not call one by, `@dr$() // c⏎;`. Filed as #724.
- **The neighbour mirror** `trailingSemicolonAsked` now answers nothing for such a flag, as the rule leaves it under either option. A mutant without that change, over this rule paired with every other rule under every primary option, in both orders and under both of its options, over the corpus's forms that close their block under less, moves none of 73 548 runs.
- **Other rules read the same semicolon as code.** Over the same corpus under less, behind the four nodes the reading covers and bare carriage returns left out, 138 runs of other rules change what stands between `//` and the line break, and every one does it on the base as well; among them `block-closing-brace-space-before` leaves a file Less refuses, and `declaration-block-semicolon-space-after` comments out the next declaration. With `declaration-block-semicolon-newline-before: always` listed behind this rule's `never`, `b: c // ;` now takes two `--fix` runs to settle rather than one, since this rule no longer takes the semicolon away before the neighbour writes its break into the comment. Filed as #720.
- **The six oracles do not move.**

Closes #359.

