### PR TITLE
Count the text `max-empty-lines` reads as the syntax prints it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The rules below used to pass some code over in silence. They now warn on it
 - The `declaration-colon-space-after` rule now looks for the whitespace after the colon where a custom property whose value holds a comment actually keeps it (see [#109](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/109)) ([@VChet](https://github.com/VChet)).
 - The `indentation` rule now reports every mis-indented line of an at-rule's parameters holding comments, at the line and column the file spells (see [#65](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/65)).
 - The `indentation` rule now corrects every mis-indented line of an at-rule, and not only one of them (see [#64](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/64)).
+- The `max-empty-lines` rule now counts the empty lines inside a Sass nested property written with a value, and puts every warning behind such a property, an end-of-line comment or a Less mixin call's `!important` on the line and column the file spells (see [#583](https://github.com/stylelint-stylistic/stylelint-stylistic/issues/583)).
 
 And also a huge number of false negatives found by tools and agents, which may likewise require you to fix the code.
 

--- a/lib/rules/max-empty-lines/index.ts
+++ b/lib/rules/max-empty-lines/index.ts
@@ -4,10 +4,12 @@ import stylelint, { type PostcssResult } from "stylelint"
 
 import { CRLF, CRLF_RUN, EVERY_CRLF_RUN, EVERY_LF_RUN, LEADING_LINE_BREAK_RUN, TRAILING_SPACES_AND_TABS } from "../../regexps.ts"
 import { css } from "../../syntaxes/css/index.ts"
+import { blankComments } from "../../utils/blankComments/index.ts"
 import { defineMessages, defineRule, type RuleScope } from "../../utils/defineRule/index.ts"
 import { getBlockAfter } from "../../utils/getBlockAfter/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
+import { nodeString } from "../../utils/nodeString/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setBlockAfter } from "../../utils/setBlockAfter/index.ts"
@@ -41,11 +43,12 @@ export type SecondaryOptions = {
  * @param scope - What the namespace hands the rule.
  * @param scope.ruleName - The configured name.
  * @param scope.messages - The messages, closing with that name.
+ * @param scope.syntax - The syntax, which says where a `//` comment runs.
  * @param primary - The primary option.
  * @param secondaryOptions - The secondary options.
  * @returns The check.
  */
-function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: PrimaryOption, secondaryOptions: SecondaryOptions): RuleCheck {
+function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, primary: PrimaryOption, secondaryOptions: SecondaryOptions): RuleCheck {
 	return (root, result) => {
 		let validOptions = validateOptions(
 			result,
@@ -107,7 +110,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: Prim
 
 		let emptyLines = 0
 		let lastIndex = -1
-		let rootString = root.toString()
+		// Printed by the syntax, since PostCSS's stringifier drops a Sass nested property's block and a Less mixin call's `!important`, and widens a `//` comment (#583); a styled template's root hangs in its document, whose stringifier prints the host code around it
+		let rootString = root.parent ? root.toString() : nodeString(root, result)
 
 		// A file ending on a break counts one empty line more, and spaces and tabs behind the last break are `no-eol-whitespace`'s line, so the end is measured in front of them
 		let endOfFile = rootString.replace(TRAILING_SPACES_AND_TABS, ``).length
@@ -115,7 +119,8 @@ function rule ({ ruleName, messages }: RuleScope<typeof MESSAGES>, primary: Prim
 
 		styleSearch(
 			{
-				source: rootString,
+				// `style-search` skips the break closing a `//` comment, so the inline comment spans the syntax finds are blanked
+				source: ignoreComments ? blankComments(rootString, syntax.commentSpans(rootString, root, result).filter(({ isInline }) => isInline)) : rootString,
 				target: CRLF.test(rootString) ? `\r\n` : `\n`,
 				comments: ignoreComments ? `skip` : `check`,
 			},

--- a/lib/syntaxes/less/rules/max-empty-lines/index.test.ts
+++ b/lib/syntaxes/less/rules/max-empty-lines/index.test.ts
@@ -27,5 +27,41 @@ testRule({
 			column: 1,
 			message: messages.expected(1),
 		},
+		// See #583
+		{
+			description: `two blank lines between two end-of-line comments, which the stringifier of PostCSS prints as block ones two characters wider`,
+			code: `// one\n\n\n// two\n`,
+			fixed: `// one\n\n// two\n`,
+			line: 3,
+			column: 1,
+			message: messages.expected(1),
+		},
+		// See #583
+		{
+			description: `two blank lines behind a mixin call carrying a flag, which the stringifier of PostCSS leaves out`,
+			code: `a {\n\t.m() !important;\n\n\n\tcolor: pink;\n}\n`,
+			fixed: `a {\n\t.m() !important;\n\n\tcolor: pink;\n}\n`,
+			line: 4,
+			column: 1,
+			message: messages.expected(1),
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [1, { ignore: [`comments`] }],
+	customSyntax: `postcss-less`,
+
+	reject: [
+		// See #583
+		{
+			description: `two blank lines between two end-of-line comments, whose closing break counts`,
+			code: `// one\n\n\n// two\n`,
+			fixed: `// one\n\n// two\n`,
+			line: 3,
+			column: 1,
+			message: messages.expected(1),
+		},
 	],
 })

--- a/lib/syntaxes/scss/rules/max-empty-lines/index.test.ts
+++ b/lib/syntaxes/scss/rules/max-empty-lines/index.test.ts
@@ -39,15 +39,15 @@ testRule({
 			code: `// one\n\n\n`,
 			fixed: `// one\n\n`,
 			line: 4,
-			column: 3,
+			column: 1,
 			message: messages.expected(2),
 		},
 		{
 			description: `three blank lines between two end-of-line comments`,
 			code: `// one\n\n\n\n// two\n`,
 			fixed: `// one\n\n\n// two\n`,
-			line: 5,
-			column: 2,
+			line: 4,
+			column: 1,
 			message: messages.expected(2),
 		},
 		// See #481
@@ -66,6 +66,42 @@ testRule({
 			line: 6,
 			column: 1,
 			message: messages.expected(2),
+		},
+		// See #583
+		{
+			description: `three blank lines in front of the closing brace of a nested property written with a value, whose block the stringifier of PostCSS leaves out`,
+			code: `a {\n\tfont: 12px {\n\t\tfamily: x;\n\n\n\n\t}\n}\n`,
+			fixed: `a {\n\tfont: 12px {\n\t\tfamily: x;\n\n\n\t}\n}\n`,
+			line: 6,
+			column: 1,
+			message: messages.expected(2),
+		},
+		// See #583
+		{
+			description: `three blank lines behind a nested property written with a value`,
+			code: `a {\n\tfont: 12px {\n\t\tfamily: x;\n\t}\n}\n\n\n\nb {}\n`,
+			fixed: `a {\n\tfont: 12px {\n\t\tfamily: x;\n\t}\n}\n\n\nb {}\n`,
+			line: 8,
+			column: 1,
+			message: messages.expected(2),
+		},
+	],
+})
+
+testRule({
+	ruleName,
+	config: [1, { ignore: [`comments`] }],
+	customSyntax: `postcss-scss`,
+
+	reject: [
+		// See #583
+		{
+			description: `two blank lines between two end-of-line comments, whose closing break counts`,
+			code: `// one\n\n\n// two\n`,
+			fixed: `// one\n\n// two\n`,
+			line: 3,
+			column: 1,
+			message: messages.expected(1),
 		},
 	],
 })

--- a/lib/syntaxes/styled/rules/max-empty-lines/index.test.ts
+++ b/lib/syntaxes/styled/rules/max-empty-lines/index.test.ts
@@ -1,0 +1,24 @@
+import { createRule } from "../../../../rules/max-empty-lines/index.ts"
+import { styled } from "../../index.ts"
+
+let { ruleName, messages } = createRule(styled)
+
+let testRule = createTestRule({ ruleName, autoStripIndent: false })
+
+testRule({
+	ruleName,
+	config: [1],
+	customSyntax: `postcss-styled-syntax`,
+
+	reject: [
+		// See #583
+		{
+			description: `two blank lines inside a template, whose surrounding code the stringifier of the syntax prints in front of the stylesheet`,
+			code: `const A = styled.div\`\n\tcolor: pink;\n\n\n\ttop: 0;\n\`\n`,
+			fixed: `const A = styled.div\`\n\tcolor: pink;\n\n\ttop: 0;\n\`\n`,
+			line: 4,
+			column: 1,
+			message: messages.expected(1),
+		},
+	],
+})


### PR DESCRIPTION
`max-empty-lines` counted the breaks of `root.toString()`, which PostCSS prints with its own stringifier, while Stylelint places every warning in the file's text. Under `postcss-scss` that stringifier drops the block of a Sass nested property written with a value, so nothing inside such a property was measured and every warning behind it landed lines too early; under `postcss-less` it drops a mixin call's `!important`, and under both it prints a `//` comment as a block comment two characters wider, so every warning behind either landed past its mark:

```scss
a {
	font: 12px {
		family: x;



	}
}
/* scss/max-empty-lines: 1, on the base:   nothing reported, --fix writes nothing
   on the branch:                           5:1 and 6:1, --fix leaves one empty line */
```

```less
// one


// two
/* less/max-empty-lines: 1, on the base:   4:2, inside the second comment
   on the branch:                           3:1 */
```

The rule now counts the root as its syntax prints it. A styled template's root is the exception and is printed as before: it has no syntax of its own, and the document's stringifier prints the JavaScript around the template in front of it. Under `ignore: comments`, `style-search` skips the break that closes a `//` comment, which the block comment PostCSS printed used to hide, so the search copy blanks the inline comment spans the syntax finds; plain CSS reads none, and its text is unchanged.

## What the review turned up

- **A probe over 36 shapes** — nested properties, `//` comments at the root, in a block, behind a declaration and in a selector, parameters and a value, Less mixin calls, detached rulesets, guards and imports, Sass maps and control directives — with LF and CRLF breaks, under css, scss and less and under `0`, `1`, `2` and `1` with `ignore: comments`, is 864 runs. 150 move, 100 under scss and 50 under less: 50 gain warnings the base missed and 100 keep their count at other positions; none loses a warning, no `--fix` output of the probe moves, and plain CSS moves nowhere. Outside it, `--fix` now writes a file whose only long runs stand inside a nested property written with a value, which the base neither reported nor fixed. Against the same files with every `// c` replaced by a block comment of the same width, the branch agrees under scss and less on all 144 runs.
- **`postcss-html` and styled** are reached by no oracle, so both were probed by hand: a `<style>` element, a `style` attribute, a `<style lang="scss">` element and two styled templates give the same warnings and the same `--fix` output as on the base. Under `ignore: comments` they move where they should: a `<style lang="scss">` or `lang="less"` block now counts the break behind a `//` comment, which its root printed raw on the base too, and a styled template counts the break behind a `//` in a custom property's value, as it already did without the option. A new styled case pins the template's root, which a first draft printed with the JavaScript in front of it.
- **Left as it was:** `style-search` reads a `//` as a comment in any text, so under `ignore: comments` the break at the end of a line holding `url(http://x.y/z)` goes uncounted in plain CSS, and so does the break behind `/* a *//* b */`, whose join it reads as a `//`, on the base as on the branch. Filed as #725.
- **The six oracles and the six sweeps naming the rule do not move**; none of their fixtures holds a run of empty lines beside a `//` comment or inside a nested property, and the sweeps keep no positions.

Closes #583.
