### PR TITLE
Count the text `max-empty-lines` reads without the byte-order mark

### DIFF
--- a/lib/rules/max-empty-lines/index.test.ts
+++ b/lib/rules/max-empty-lines/index.test.ts
@@ -92,6 +92,24 @@ testRule({
 			column: 1,
 			message: messages.expected(0),
 		},
+		// See #601
+		{
+			description: `two blank lines opening a stylesheet behind a byte-order mark, which is no character of the text the positions are counted in`,
+			code: `\uFEFF\n\na {}`,
+			fixed: `\uFEFFa {}`,
+			warnings: [
+				{
+					line: 1,
+					column: 1,
+					message: messages.expected(0),
+				},
+				{
+					line: 2,
+					column: 1,
+					message: messages.expected(0),
+				},
+			],
+		},
 	],
 })
 
@@ -362,6 +380,32 @@ testRule({
 			column: 1,
 			message: messages.expected(1),
 		},
+		// See #601
+		{
+			description: `two blank lines opening a stylesheet behind a byte-order mark, which is no character of the text the positions are counted in`,
+			code: `\uFEFF\n\na {}`,
+			fixed: `\uFEFF\na {}`,
+			line: 2,
+			column: 1,
+			message: messages.expected(1),
+		},
+		{
+			description: `two blank lines closing a stylesheet behind a byte-order mark`,
+			code: `\uFEFFa {}\n\n\n`,
+			fixed: `\uFEFFa {}\n`,
+			warnings: [
+				{
+					line: 3,
+					column: 1,
+					message: messages.expected(1),
+				},
+				{
+					line: 4,
+					column: 1,
+					message: messages.expected(1),
+				},
+			],
+		},
 	],
 })
 
@@ -490,6 +534,15 @@ a {}
 			code: `<style>\na {\n\tb: c;\n\n\n}\n</style>\n`,
 			fixed: `<style>\na {\n\tb: c;\n\n}\n</style>\n`,
 			line: 5,
+			column: 1,
+			message: messages.expected(1),
+		},
+		// See #601
+		{
+			description: `two blank lines between two rules of an embedded stylesheet opening with a byte-order mark, which is a character of the document the lines are placed in`,
+			code: `<style>\uFEFFa {}\n\n\nb {}</style>`,
+			fixed: `<style>\uFEFFa {}\n\nb {}</style>`,
+			line: 3,
 			column: 1,
 			message: messages.expected(1),
 		},

--- a/lib/rules/max-empty-lines/index.ts
+++ b/lib/rules/max-empty-lines/index.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Container, Document, Root } from "postcss"
+import { type ChildNode, type Container, type Document, type Root, stringify } from "postcss"
 import styleSearch from "style-search"
 import stylelint, { type PostcssResult } from "stylelint"
 
@@ -10,6 +10,7 @@ import { getBlockAfter } from "../../utils/getBlockAfter/index.ts"
 import { getRuleDocUrl } from "../../utils/getRuleDocUrl/index.ts"
 import { hasBlock } from "../../utils/hasBlock/index.ts"
 import { nodeString } from "../../utils/nodeString/index.ts"
+import { nodeSyntax } from "../../utils/nodeSyntax/index.ts"
 import { optionsMatches } from "../../utils/optionsMatches/index.ts"
 import type { RuleCheck } from "../../utils/ruleCheck/index.ts"
 import { setBlockAfter } from "../../utils/setBlockAfter/index.ts"
@@ -110,8 +111,7 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
 
 		let emptyLines = 0
 		let lastIndex = -1
-		// Printed by the syntax, since PostCSS's stringifier drops a Sass nested property's block and a Less mixin call's `!important`, and widens a `//` comment (#583); a styled template's root hangs in its document, whose stringifier prints the host code around it
-		let rootString = root.parent ? root.toString() : nodeString(root, result)
+		let rootString = countedText(root, result)
 
 		// A file ending on a break counts one empty line more, and spaces and tabs behind the last break are `no-eol-whitespace`'s line, so the end is measured in front of them
 		let endOfFile = rootString.replace(TRAILING_SPACES_AND_TABS, ``).length
@@ -191,6 +191,26 @@ function rule ({ ruleName, messages, syntax }: RuleScope<typeof MESSAGES>, prima
  */
 function carriesABlock (node: ChildNode): node is ChildNode & Container {
 	return hasBlock(node)
+}
+
+/**
+ * Prints the text the breaks are counted in, as the file the warnings are placed in holds it.
+ * @param root - The root checked.
+ * @param result - The Stylelint result, which holds the file's syntax and tells a standalone root from a block of a document.
+ * @returns The root's text.
+ */
+function countedText (root: Root, result: PostcssResult): string {
+	// A block embedded in a document is placed in the document's text, which keeps a byte-order mark; a styled template's root hangs in its document, whose stringifier prints the host code around it
+	if (result.root !== root) return root.parent ? root.toString() : nodeString(root, result)
+
+	let text = ``
+
+	// Printed by the syntax, since PostCSS's stringifier drops a Sass nested property's block and a Less mixin call's `!important`, and widens a `//` comment (#583); without the root's opening piece, which is the byte-order mark PostCSS's stringifier prints and `input.css`, which the indices are resolved in, leaves out, while `sugarss` prints none (#601)
+	;(nodeSyntax(root, result)?.stringify ?? stringify)(root, (piece, node, type) => {
+		if (node !== root || type !== `start`) text += piece
+	})
+
+	return text
 }
 
 /**


### PR DESCRIPTION
`max-empty-lines` counted the breaks of the root as its syntax prints it, and PostCSS prints the byte-order mark a file opened with in front of the root while `input.css`, which every index of a standalone stylesheet is resolved in, leaves it out. So behind a mark the rule read a text one character longer than the file Stylelint places the warnings in: the first break stood at index 1, the check for the start of the file missed it, and the run the file opens with counted one line short, while every warning stood a character past its mark:

```css
/* a U+FEFF, then two line breaks, then `a {}` */
/* max-empty-lines: 1, on the base:   nothing reported
   on the branch:                      2:1, --fix leaves one empty line */

/* a U+FEFF, then `a {}` and three line breaks */
/* max-empty-lines: 1, on the base:   4:1 and 4:2
   on the branch:                      3:1 and 4:1 */
```

The rule now prints a standalone stylesheet without the piece its stringifier opens the root with, which is the mark wherever a stringifier prints one. A block embedded in a document keeps it: under `postcss-html` and styled the indices are placed in the document's text, where the mark is a character of the block's first line, and the positions there were right on the base.

## What the review turned up

- **Every standalone form of the issue, and more** — a leading run under `0` and `1`, a trailing run, a run between rules, a run inside a comment, a stylesheet of breaks alone, CRLF under css, a leading run under `postcss-scss` and `postcss-less`, and a run beside a `//` comment under `postcss-scss` — now gives the same warnings, positions and `--fix` output as its twin without the mark, the mark kept in front of the fixed text.
- **`postcss-html` and styled** give the same warnings and `--fix` output as on the base, for a mark opening the whole file and for one opening the block. A first draft took the mark off every root whose input had one and moved the embedded positions a line early; a new `postcss-html` case pins that.
- **`sugarss` prints no mark** while its input still flags one, so a second draft that cut the first character of the printed text cut a real one there: a mark and three breaks under a maximum of one drew `2:1` alone, where its twin draws `2:1` and `3:1`. Skipping the root's opening piece leaves such a printer's text whole, and `sugarss` and `postcss-sass` now agree with their twins; neither package is a dependency, so no case pins it.
- **No oracle or sweep can see the change**: the only corpus holding a mark does not name the rule, and without a mark the counted text is the same as on the base.
- **Left as it was:** `postcss-styled-syntax` 0.7.2 drops a U+FEFF that opens a template whenever it prints the document, so any `--fix` there deletes it; Stylelint's own `length-zero-no-unit` does the same without the plugin, so it is the syntax's.

Closes #601.
